### PR TITLE
feat: allow threshold to exceed participant count when anonymous registration is enabled

### DIFF
--- a/frontend/src/views/CalendarSettings.vue
+++ b/frontend/src/views/CalendarSettings.vue
@@ -437,14 +437,14 @@
                 v-model.number="form.threshold"
                 type="number"
                 min="1"
-                :max="calendar.participants?.length || undefined"
+                :max="form.allow_anonymous_participants ? undefined : (calendar.participants?.length || undefined)"
                 class="input"
                 :class="{ 'border-danger-500': errors.threshold }"
                 required
               />
               <p class="mt-1 text-sm text-gray-500 dark:text-gray-400">
                 {{ t('calendar.thresholdHelp') }}
-                <span v-if="calendar.participants && calendar.participants.length > 0">
+                <span v-if="!form.allow_anonymous_participants && calendar.participants && calendar.participants.length > 0">
                   ({{ t('common.max') }}: {{ calendar.participants.length }})
                 </span>
               </p>
@@ -1145,7 +1145,7 @@ function validateForm(): boolean {
     isValid = false;
   }
 
-  if (calendar.value?.participants && form.threshold > calendar.value.participants.length) {
+  if (!form.allow_anonymous_participants && calendar.value?.participants && form.threshold > calendar.value.participants.length) {
     errors.threshold = t('calendar.thresholdMaxError');
     isValid = false;
   }

--- a/internal/calendar/handlers/calendar_handler.go
+++ b/internal/calendar/handlers/calendar_handler.go
@@ -96,16 +96,18 @@ func (h *CalendarHandler) CreateCalendar(w http.ResponseWriter, r *http.Request)
 			participantNames[name] = true
 		}
 
-		// Check that threshold doesn't exceed participant count
-		nonEmptyCount := 0
-		for _, name := range req.Participants {
-			if name != "" {
-				nonEmptyCount++
+		// Check that threshold doesn't exceed participant count (unless anonymous registration is enabled)
+		if !req.AllowAnonymousParticipants {
+			nonEmptyCount := 0
+			for _, name := range req.Participants {
+				if name != "" {
+					nonEmptyCount++
+				}
 			}
-		}
-		if req.Threshold > 0 && req.Threshold > nonEmptyCount {
-			httputil.Error(w, http.StatusBadRequest, httputil.ErrCodeValidation, "Threshold cannot exceed the number of participants")
-			return
+			if req.Threshold > 0 && req.Threshold > nonEmptyCount {
+				httputil.Error(w, http.StatusBadRequest, httputil.ErrCodeValidation, "Threshold cannot exceed the number of participants")
+				return
+			}
 		}
 	}
 


### PR DESCRIPTION
## Summary

- Remove the max threshold limit when anonymous participant registration is enabled
- Calendar managers can now set a threshold higher than the current participant count, since anonymous users can self-register and increase that count
- Applies to both backend validation and frontend form validation

## Changes

- `internal/calendar/handlers/calendar_handler.go`: skip threshold > participant count check when `AllowAnonymousParticipants` is true
- `frontend/src/views/CalendarSettings.vue`: remove `:max` attribute and JS validation for threshold when anonymous registration is enabled