### PR TITLE
fix: preserve line breaks and show description in all calendar views

### DIFF
--- a/frontend/src/views/CalendarPublic.vue
+++ b/frontend/src/views/CalendarPublic.vue
@@ -42,7 +42,7 @@
           <h1 class="font-display text-3xl font-bold text-gray-900 dark:text-white">
             {{ calendar.name }}
           </h1>
-          <p v-if="calendar.description" class="mt-2 text-gray-600 dark:text-gray-400">
+          <p v-if="calendar.description" class="mt-2 text-gray-600 dark:text-gray-400 whitespace-pre-wrap">
             {{ calendar.description }}
           </p>
           <div class="mt-4 flex items-center gap-4 text-sm text-gray-500 dark:text-gray-400">

--- a/frontend/src/views/Dashboard.vue
+++ b/frontend/src/views/Dashboard.vue
@@ -144,7 +144,7 @@
               >
                 {{ calendar.name }}
               </h3>
-              <p v-if="calendar.description" class="text-sm text-gray-600 dark:text-gray-400">
+              <p v-if="calendar.description" class="text-sm text-gray-600 dark:text-gray-400 whitespace-pre-wrap">
                 {{ calendar.description }}
               </p>
             </div>

--- a/frontend/src/views/ParticipantView.vue
+++ b/frontend/src/views/ParticipantView.vue
@@ -46,6 +46,9 @@
             <p class="mt-2 text-base md:text-lg text-gray-600 dark:text-gray-400">
               {{ participant.name }}
             </p>
+            <p v-if="calendar.description" class="mt-2 text-sm text-gray-600 dark:text-gray-400 whitespace-pre-wrap">
+              {{ calendar.description }}
+            </p>
           </div>
           <button
             v-if="!calendar?.lock_participants"


### PR DESCRIPTION
## Summary
- Add `whitespace-pre-wrap` to description in **Dashboard** and **CalendarPublic** to preserve line breaks
- Add missing description display in **ParticipantView**

## Test plan
- [x] Create a calendar with a multi-line description
- [x] Verify line breaks are preserved on the Dashboard
- [x] Verify line breaks are preserved on the public calendar page
- [x] Verify the description is displayed in the participant view