### PR TITLE
fix: security audit remediations

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -39,6 +39,13 @@ LOG_LEVEL=debug
 # Rate Limiting
 RATE_LIMIT_ENABLED=true
 
+# Security
+# Comma-separated list of allowed CORS origins (default: APP_URL)
+CORS_ORIGINS=http://localhost:8080
+# Comma-separated list of trusted reverse proxy IPs (leave empty if no proxy)
+# Only these IPs are allowed to set X-Forwarded-For / X-Real-IP headers
+TRUSTED_PROXIES=
+
 # SMTP Configuration (for email notifications)
 SMTP_HOST=smtp.example.com
 SMTP_PORT=587

--- a/.env.example
+++ b/.env.example
@@ -42,8 +42,9 @@ RATE_LIMIT_ENABLED=true
 # Security
 # Comma-separated list of allowed CORS origins (default: APP_URL)
 CORS_ORIGINS=http://localhost:8080
-# Comma-separated list of trusted reverse proxy IPs (leave empty if no proxy)
+# Comma-separated list of trusted reverse proxy IPs or CIDR ranges (leave empty if no proxy)
 # Only these IPs are allowed to set X-Forwarded-For / X-Real-IP headers
+# Examples: 10.0.0.1, 172.17.0.0/16, 2001:db8::/32
 TRUSTED_PROXIES=
 
 # SMTP Configuration (for email notifications)

--- a/.github/workflows/release-selfhosted.yml
+++ b/.github/workflows/release-selfhosted.yml
@@ -320,6 +320,13 @@ jobs:
       - name: Create release body
         id: release_body
         run: |
+          # Prepend tag message if available
+          if [ "${{ steps.tag_message.outputs.has_message }}" = "true" ]; then
+            cat tag_message.txt > release_body.md
+            echo "" >> release_body.md
+            echo "---" >> release_body.md
+            echo "" >> release_body.md
+          fi
           # Append installation instructions
           cat >> release_body.md << 'EOF'
           ## Installation

--- a/README.md
+++ b/README.md
@@ -236,6 +236,8 @@ RATE_LIMIT_ENABLED=true
 
 # Security
 BCRYPT_COST=12
+CORS_ORIGINS=https://your-domain.com  # Comma-separated allowed CORS origins (default: APP_URL)
+TRUSTED_PROXIES=                       # Comma-separated trusted reverse proxy IPs (e.g., 127.0.0.1,10.0.0.1)
 ```
 
 ---

--- a/build/selfhosted/.env.example
+++ b/build/selfhosted/.env.example
@@ -28,5 +28,6 @@ RATE_LIMIT_ENABLED=true
 BCRYPT_COST=12
 # Comma-separated list of allowed CORS origins (default: APP_URL)
 CORS_ORIGINS=http://localhost:8080
-# Comma-separated list of trusted reverse proxy IPs (leave empty if no proxy)
+# Comma-separated list of trusted reverse proxy IPs or CIDR ranges (leave empty if no proxy)
+# Examples: 10.0.0.1, 172.17.0.0/16, 2001:db8::/32
 TRUSTED_PROXIES=

--- a/build/selfhosted/.env.example
+++ b/build/selfhosted/.env.example
@@ -18,7 +18,6 @@ JWT_REFRESH_EXPIRY=168h
 
 # Application
 APP_URL=http://localhost:8080
-ALLOWED_ORIGINS=http://localhost:8080
 ALLOWED_REGISTER=true
 ALLOWED_EMAILS=
 
@@ -27,3 +26,7 @@ RATE_LIMIT_ENABLED=true
 
 # Security
 BCRYPT_COST=12
+# Comma-separated list of allowed CORS origins (default: APP_URL)
+CORS_ORIGINS=http://localhost:8080
+# Comma-separated list of trusted reverse proxy IPs (leave empty if no proxy)
+TRUSTED_PROXIES=

--- a/build/selfhosted/docker-compose.yml
+++ b/build/selfhosted/docker-compose.yml
@@ -31,7 +31,6 @@ services:
 
       # Application
       - APP_URL=${APP_URL:-http://localhost:8080}
-      - ALLOWED_ORIGINS=${ALLOWED_ORIGINS:-http://localhost:8080}
       - ALLOWED_REGISTER=${ALLOWED_REGISTER:-true}
       - ALLOWED_EMAILS=${ALLOWED_EMAILS:-}
 
@@ -40,6 +39,8 @@ services:
 
       # Security
       - BCRYPT_COST=12
+      - CORS_ORIGINS=${CORS_ORIGINS:-${APP_URL:-http://localhost:8080}}
+      - TRUSTED_PROXIES=${TRUSTED_PROXIES:-}
     volumes:
       - whento_keys:/app/keys
     depends_on:

--- a/cmd/init_cloud.go
+++ b/cmd/init_cloud.go
@@ -69,6 +69,7 @@ func InitServices(ctx context.Context, cfg *config.Config, pool *pgxpool.Pool) (
 		StripeSecretKey:  cfg.Stripe.SecretKey,
 		StripePricePro:   cfg.Stripe.PricePro,
 		StripePricePower: cfg.Stripe.PricePower,
+		AppURL:           cfg.AppURL,
 	}, log)
 
 	log.Info("Subscription service initialized (Cloud mode)")
@@ -125,6 +126,7 @@ func RegisterBillingRoutes(r chi.Router, services *Services, cfg *config.Config,
 		StripeSecretKey:  cfg.Stripe.SecretKey,
 		StripePricePro:   cfg.Stripe.PricePro,
 		StripePricePower: cfg.Stripe.PricePower,
+		AppURL:           cfg.AppURL,
 	}, log)
 
 	// Initialize subscription handlers

--- a/cmd/init_cloud.go
+++ b/cmd/init_cloud.go
@@ -14,6 +14,7 @@ import (
 	"github.com/go-chi/chi/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
 
+	"github.com/whento/pkg/cache"
 	"github.com/whento/pkg/jwt"
 	"github.com/whento/pkg/logger"
 	"github.com/whento/pkg/middleware"
@@ -115,7 +116,7 @@ func InitServices(ctx context.Context, cfg *config.Config, pool *pgxpool.Pool) (
 }
 
 // RegisterBillingRoutes registers cloud-specific billing routes (Stripe)
-func RegisterBillingRoutes(r chi.Router, services *Services, cfg *config.Config, pool *pgxpool.Pool, jwtManager interface{}) {
+func RegisterBillingRoutes(r chi.Router, services *Services, cfg *config.Config, pool *pgxpool.Pool, jwtManager interface{}, cacheInstance cache.Cache) {
 	log := logger.Default()
 
 	// Re-initialize subscription service for handlers
@@ -141,7 +142,7 @@ func RegisterBillingRoutes(r chi.Router, services *Services, cfg *config.Config,
 
 		// Authenticated routes
 		r.Group(func(r chi.Router) {
-			r.Use(middleware.Auth(jwtManager.(*jwt.Manager)))
+			r.Use(middleware.Auth(jwtManager.(*jwt.Manager), cacheInstance))
 
 			r.Post("/checkout", subHandler.HandleCreateCheckout)
 			r.Post("/portal", subHandler.HandleCreatePortal)
@@ -150,7 +151,7 @@ func RegisterBillingRoutes(r chi.Router, services *Services, cfg *config.Config,
 
 		// Admin-only routes
 		r.Group(func(r chi.Router) {
-			r.Use(middleware.Auth(jwtManager.(*jwt.Manager)))
+			r.Use(middleware.Auth(jwtManager.(*jwt.Manager), cacheInstance))
 			r.Use(middleware.RequireRole("admin"))
 
 			r.Get("/accounting", subHandler.HandleGetAccounting)
@@ -159,7 +160,7 @@ func RegisterBillingRoutes(r chi.Router, services *Services, cfg *config.Config,
 
 	// Quota routes (authenticated)
 	r.Route("/api/v1/quota", func(r chi.Router) {
-		r.Use(middleware.Auth(jwtManager.(*jwt.Manager)))
+		r.Use(middleware.Auth(jwtManager.(*jwt.Manager), cacheInstance))
 		r.Get("/limits", quotaHandler.HandleGetLimits)
 	})
 
@@ -169,7 +170,7 @@ func RegisterBillingRoutes(r chi.Router, services *Services, cfg *config.Config,
 	ecommHandler := ecommerceHandlers.New(ecommService, log)
 
 	r.Route("/api/v1/admin/ecommerce", func(r chi.Router) {
-		r.Use(middleware.Auth(jwtManager.(*jwt.Manager)))
+		r.Use(middleware.Auth(jwtManager.(*jwt.Manager), cacheInstance))
 		r.Use(middleware.RequireRole("admin"))
 
 		// License search by support key
@@ -195,7 +196,7 @@ func RegisterBillingRoutes(r chi.Router, services *Services, cfg *config.Config,
 
 	// VAT admin routes (admin only)
 	r.Route("/api/v1/admin/vat", func(r chi.Router) {
-		r.Use(middleware.Auth(jwtManager.(*jwt.Manager)))
+		r.Use(middleware.Auth(jwtManager.(*jwt.Manager), cacheInstance))
 		r.Use(middleware.RequireRole("admin"))
 
 		r.Get("/rates", vatHandler.HandleGetRates)

--- a/cmd/init_selfhosted.go
+++ b/cmd/init_selfhosted.go
@@ -12,6 +12,7 @@ import (
 	"github.com/go-chi/chi/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
 
+	"github.com/whento/pkg/cache"
 	"github.com/whento/pkg/jwt"
 	"github.com/whento/pkg/logger"
 	"github.com/whento/pkg/middleware"
@@ -86,7 +87,7 @@ func InitServices(ctx context.Context, cfg *config.Config, pool *pgxpool.Pool) (
 }
 
 // RegisterBillingRoutes registers self-hosted specific licensing routes
-func RegisterBillingRoutes(r chi.Router, services *Services, cfg *config.Config, pool *pgxpool.Pool, jwtManager interface{}) {
+func RegisterBillingRoutes(r chi.Router, services *Services, cfg *config.Config, pool *pgxpool.Pool, jwtManager interface{}, cacheInstance cache.Cache) {
 	log := logger.Default()
 
 	// Reuse the licensing service from InitServices (already has license loaded in RAM)
@@ -108,7 +109,7 @@ func RegisterBillingRoutes(r chi.Router, services *Services, cfg *config.Config,
 	r.Route("/api/v1/license", func(r chi.Router) {
 		// Authenticated routes
 		r.Group(func(r chi.Router) {
-			r.Use(middleware.Auth(jwtManager.(*jwt.Manager)))
+			r.Use(middleware.Auth(jwtManager.(*jwt.Manager), cacheInstance))
 
 			// Public info (any authenticated user can view)
 			r.Get("/info", licHandler.HandleGetLicenseInfo)
@@ -126,7 +127,7 @@ func RegisterBillingRoutes(r chi.Router, services *Services, cfg *config.Config,
 
 	// Quota routes (authenticated users)
 	r.Route("/api/v1/quota", func(r chi.Router) {
-		r.Use(middleware.Auth(jwtManager.(*jwt.Manager)))
+		r.Use(middleware.Auth(jwtManager.(*jwt.Manager), cacheInstance))
 		r.Get("/limits", quotaHandler.HandleGetLimits)
 	})
 

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -59,6 +59,7 @@ import (
 	"github.com/whento/pkg/jwt"
 	"github.com/whento/pkg/logger"
 	"github.com/whento/pkg/middleware"
+	"github.com/whento/pkg/participanttoken"
 	"github.com/whento/whento/internal/config"
 
 	// Auth module
@@ -160,6 +161,14 @@ func main() {
 	}
 	log.Info("JWT manager initialized")
 
+	// Initialize participant token signing (uses JWT private key as HMAC seed)
+	ptKeyBytes, err := os.ReadFile(cfg.JWTPrivateKeyPath)
+	if err != nil {
+		log.Warn("Failed to read JWT private key for participant tokens, using fallback", "error", err)
+		ptKeyBytes = []byte("whento-participant-token-fallback-secret")
+	}
+	participanttoken.Init(ptKeyBytes)
+
 	// Initialize cache (uses Redis if available, NoOp otherwise)
 	cacheInstance := cache.NewRedisCache(redisClient)
 	if cacheInstance.IsEnabled() {
@@ -201,8 +210,8 @@ func main() {
 	tokenRepo := authRepo.NewTokenRepository(pool)
 	mfaRepository := mfaRepo.NewMFARepository(pool)
 
-	// Initialize auth service (with MFA repository for 2FA checking)
-	authSvc := authService.NewAuthService(userRepo, tokenRepo, mfaRepository, jwtManager, cfg.BcryptCost, cfg.AllowedRegister, cfg.AllowedEmails)
+	// Initialize auth service (with MFA repository for 2FA checking and cache for temp token replay prevention)
+	authSvc := authService.NewAuthService(userRepo, tokenRepo, mfaRepository, jwtManager, cacheInstance, cfg.BcryptCost, cfg.AllowedRegister, cfg.AllowedEmails)
 
 	// Initialize password reset service
 	passwordResetSvc := authService.NewPasswordResetService(userRepo, tokenRepo, emailService, jwtManager, cfg, log, cfg.BcryptCost)

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -369,34 +369,47 @@ func main() {
 		// Public routes with rate limiting
 		r.Group(func(r chi.Router) {
 			if cfg.RateLimitEnabled {
-				// Login: 5 requests/minute/IP
+				// Login: 5 requests/minute/IP (fail-closed: block if Redis is down)
 				r.With(rateLimiter.Limit(middleware.RateLimitConfig{
-					Requests: 5,
-					Window:   time.Minute,
-					KeyFunc:  middleware.CombinedKeyFunc,
+					Requests:   5,
+					Window:     time.Minute,
+					KeyFunc:    middleware.CombinedKeyFunc,
+					FailClosed: true,
 				})).Post("/login", authHandler.Login)
 
-				// Register: 3 requests/minute/IP
+				// Register: 3 requests/minute/IP (fail-closed)
 				r.With(rateLimiter.Limit(middleware.RateLimitConfig{
-					Requests: 3,
-					Window:   time.Minute,
-					KeyFunc:  middleware.CombinedKeyFunc,
+					Requests:   3,
+					Window:     time.Minute,
+					KeyFunc:    middleware.CombinedKeyFunc,
+					FailClosed: true,
 				})).Post("/register", authHandler.Register)
 			} else {
 				r.Post("/login", authHandler.Login)
 				r.Post("/register", authHandler.Register)
 			}
 
-			r.Post("/refresh", authHandler.Refresh)
+			if cfg.RateLimitEnabled {
+				// Refresh: 5 requests/minute/IP (fail-closed)
+				r.With(rateLimiter.Limit(middleware.RateLimitConfig{
+					Requests:   5,
+					Window:     time.Minute,
+					KeyFunc:    middleware.CombinedKeyFunc,
+					FailClosed: true,
+				})).Post("/refresh", authHandler.Refresh)
+			} else {
+				r.Post("/refresh", authHandler.Refresh)
+			}
 			r.Post("/logout", authHandler.Logout)
 
 			// Password reset (public - no auth required)
 			if cfg.RateLimitEnabled {
-				// Forgot password: 3 requests/15 minutes/IP
+				// Forgot password: 3 requests/15 minutes/IP (fail-closed)
 				r.With(rateLimiter.Limit(middleware.RateLimitConfig{
-					Requests: 3,
-					Window:   15 * time.Minute,
-					KeyFunc:  middleware.IPKeyFunc,
+					Requests:   3,
+					Window:     15 * time.Minute,
+					KeyFunc:    middleware.IPKeyFunc,
+					FailClosed: true,
 				})).Post("/forgot-password", passwordResetHandler.ForgotPassword)
 			} else {
 				r.Post("/forgot-password", passwordResetHandler.ForgotPassword)
@@ -584,7 +597,16 @@ func main() {
 
 			// Public participant email management (requires calendar token validation)
 			r.Post("/{token}/participants/{pid}/email", participantEmailHandler.AddEmail)
-			r.Post("/{token}/participants/{pid}/resend-verification", participantEmailHandler.ResendVerification)
+			if cfg.RateLimitEnabled {
+				// Resend verification: 3 requests/15 minutes/IP
+				r.With(rateLimiter.Limit(middleware.RateLimitConfig{
+					Requests: 3,
+					Window:   15 * time.Minute,
+					KeyFunc:  middleware.IPKeyFunc,
+				})).Post("/{token}/participants/{pid}/resend-verification", participantEmailHandler.ResendVerification)
+			} else {
+				r.Post("/{token}/participants/{pid}/resend-verification", participantEmailHandler.ResendVerification)
+			}
 		})
 
 		// Authenticated routes

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -262,7 +262,7 @@ func main() {
 	calendarSvc := calendarService.NewCalendarService(calendarRepository, participantRepository, userRepo, cacheInstance)
 
 	// Initialize calendar handlers (with quota service for limit checking)
-	calendarHandler := calendarHandlers.NewCalendarHandler(calendarSvc, services.QuotaService, userRepo, cfg)
+	calendarHandler := calendarHandlers.NewCalendarHandler(calendarSvc, services.QuotaService, userRepo, cfg, pool)
 	participantHandler := calendarHandlers.NewParticipantHandler(calendarSvc)
 
 	// ========== AVAILABILITY MODULE ==========

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -248,7 +248,7 @@ func main() {
 	log.Info("MFA service initialized")
 
 	// Initialize MFA handler (with auth service for completing login)
-	mfaHandler := mfaHandlers.NewMFAHandler(mfaSvc, authSvc, jwtManager, log)
+	mfaHandler := mfaHandlers.NewMFAHandler(mfaSvc, authSvc, jwtManager, cacheInstance, log)
 
 	// Initialize admin MFA handler for admin operations (disable 2FA)
 	adminMFAHandler := authHandlers.NewAdminMFAHandler(mfaSvc, log)

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -346,7 +346,10 @@ func main() {
 	r.Use(middleware.Recoverer)
 	r.Use(middleware.SecurityHeaders)
 	r.Use(middleware.LimitRequestSize(1 * 1024 * 1024)) // 1MB max payload
-	r.Use(middleware.CORS([]string{"*"}))               // Configure for production
+	r.Use(middleware.CORS(cfg.CORSOrigins))
+
+	// Configure trusted proxies for X-Forwarded-For validation
+	middleware.SetTrustedProxies(cfg.TrustedProxies)
 
 	// Health routes (use auth health handler as primary)
 	r.Get("/api/health", authHealthHandler.Health)
@@ -389,7 +392,16 @@ func main() {
 			} else {
 				r.Post("/forgot-password", passwordResetHandler.ForgotPassword)
 			}
-			r.Post("/reset-password", passwordResetHandler.ResetPassword)
+			if cfg.RateLimitEnabled {
+				// Reset password: 5 requests/15 minutes/IP
+				r.With(rateLimiter.Limit(middleware.RateLimitConfig{
+					Requests: 5,
+					Window:   15 * time.Minute,
+					KeyFunc:  middleware.CombinedKeyFunc,
+				})).Post("/reset-password", passwordResetHandler.ResetPassword)
+			} else {
+				r.Post("/reset-password", passwordResetHandler.ResetPassword)
+			}
 
 			// Magic link authentication (public)
 			if cfg.RateLimitEnabled {
@@ -401,7 +413,16 @@ func main() {
 			} else {
 				r.Post("/magic-link/request", magicLinkHandler.RequestMagicLink)
 			}
-			r.Get("/magic-link/verify/{token}", magicLinkHandler.VerifyMagicLink)
+			if cfg.RateLimitEnabled {
+				// Magic link verify: 5 requests/15 minutes/IP
+				r.With(rateLimiter.Limit(middleware.RateLimitConfig{
+					Requests: 5,
+					Window:   15 * time.Minute,
+					KeyFunc:  middleware.CombinedKeyFunc,
+				})).Get("/magic-link/verify/{token}", magicLinkHandler.VerifyMagicLink)
+			} else {
+				r.Get("/magic-link/verify/{token}", magicLinkHandler.VerifyMagicLink)
+			}
 			r.Get("/magic-link/available", magicLinkHandler.CheckAvailable)
 
 			// Email verification (public - no auth required)

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -164,8 +164,8 @@ func main() {
 	// Initialize participant token signing (uses JWT private key as HMAC seed)
 	ptKeyBytes, err := os.ReadFile(cfg.JWTPrivateKeyPath)
 	if err != nil {
-		log.Warn("Failed to read JWT private key for participant tokens, using fallback", "error", err)
-		ptKeyBytes = []byte("whento-participant-token-fallback-secret")
+		log.Error("Failed to read JWT private key for participant tokens", "error", err)
+		os.Exit(1)
 	}
 	participanttoken.Init(ptKeyBytes)
 
@@ -417,9 +417,10 @@ func main() {
 			if cfg.RateLimitEnabled {
 				// Reset password: 5 requests/15 minutes/IP
 				r.With(rateLimiter.Limit(middleware.RateLimitConfig{
-					Requests: 5,
-					Window:   15 * time.Minute,
-					KeyFunc:  middleware.CombinedKeyFunc,
+					Requests:   5,
+					Window:     15 * time.Minute,
+					KeyFunc:    middleware.CombinedKeyFunc,
+					FailClosed: true,
 				})).Post("/reset-password", passwordResetHandler.ResetPassword)
 			} else {
 				r.Post("/reset-password", passwordResetHandler.ResetPassword)
@@ -428,9 +429,10 @@ func main() {
 			// Magic link authentication (public)
 			if cfg.RateLimitEnabled {
 				r.With(rateLimiter.Limit(middleware.RateLimitConfig{
-					Requests: 3,
-					Window:   15 * time.Minute,
-					KeyFunc:  middleware.IPKeyFunc,
+					Requests:   3,
+					Window:     15 * time.Minute,
+					KeyFunc:    middleware.IPKeyFunc,
+					FailClosed: true,
 				})).Post("/magic-link/request", magicLinkHandler.RequestMagicLink)
 			} else {
 				r.Post("/magic-link/request", magicLinkHandler.RequestMagicLink)
@@ -438,9 +440,10 @@ func main() {
 			if cfg.RateLimitEnabled {
 				// Magic link verify: 5 requests/15 minutes/IP
 				r.With(rateLimiter.Limit(middleware.RateLimitConfig{
-					Requests: 5,
-					Window:   15 * time.Minute,
-					KeyFunc:  middleware.CombinedKeyFunc,
+					Requests:   5,
+					Window:     15 * time.Minute,
+					KeyFunc:    middleware.CombinedKeyFunc,
+					FailClosed: true,
 				})).Get("/magic-link/verify/{token}", magicLinkHandler.VerifyMagicLink)
 			} else {
 				r.Get("/magic-link/verify/{token}", magicLinkHandler.VerifyMagicLink)
@@ -453,7 +456,7 @@ func main() {
 
 		// Authenticated routes
 		r.Group(func(r chi.Router) {
-			r.Use(middleware.Auth(jwtManager))
+			r.Use(middleware.Auth(jwtManager, cacheInstance))
 
 			r.Get("/me", authHandler.GetMe)
 			r.Patch("/me", authHandler.UpdateMe)
@@ -478,15 +481,17 @@ func main() {
 			if cfg.RateLimitEnabled {
 				// Passkey login (usernameless/passwordless): 5 requests/minute/IP
 				r.With(rateLimiter.Limit(middleware.RateLimitConfig{
-					Requests: 5,
-					Window:   time.Minute,
-					KeyFunc:  middleware.CombinedKeyFunc,
+					Requests:   5,
+					Window:     time.Minute,
+					KeyFunc:    middleware.CombinedKeyFunc,
+					FailClosed: true,
 				})).Post("/passkey/login/begin", passkeyHandler.BeginDiscoverableAuthentication)
 
 				r.With(rateLimiter.Limit(middleware.RateLimitConfig{
-					Requests: 5,
-					Window:   time.Minute,
-					KeyFunc:  middleware.CombinedKeyFunc,
+					Requests:   5,
+					Window:     time.Minute,
+					KeyFunc:    middleware.CombinedKeyFunc,
+					FailClosed: true,
 				})).Post("/passkey/login/finish", passkeyHandler.FinishAuthentication)
 			} else {
 				r.Post("/passkey/login/begin", passkeyHandler.BeginDiscoverableAuthentication)
@@ -499,9 +504,10 @@ func main() {
 			if cfg.RateLimitEnabled {
 				// MFA verification: 5 requests/5 minutes/IP
 				r.With(rateLimiter.Limit(middleware.RateLimitConfig{
-					Requests: 5,
-					Window:   5 * time.Minute,
-					KeyFunc:  middleware.CombinedKeyFunc,
+					Requests:   5,
+					Window:     5 * time.Minute,
+					KeyFunc:    middleware.CombinedKeyFunc,
+					FailClosed: true,
 				})).Post("/mfa/verify", mfaHandler.VerifyLogin)
 			} else {
 				r.Post("/mfa/verify", mfaHandler.VerifyLogin)
@@ -511,7 +517,7 @@ func main() {
 
 	// ========== PASSKEY ROUTES (Authenticated) ==========
 	r.Route("/api/v1/passkey", func(r chi.Router) {
-		r.Use(middleware.Auth(jwtManager))
+		r.Use(middleware.Auth(jwtManager, cacheInstance))
 
 		if cfg.RateLimitEnabled {
 			// Passkey operations: 5 requests/minute/user
@@ -538,7 +544,7 @@ func main() {
 
 	// ========== MFA ROUTES (Authenticated) ==========
 	r.Route("/api/v1/mfa", func(r chi.Router) {
-		r.Use(middleware.Auth(jwtManager))
+		r.Use(middleware.Auth(jwtManager, cacheInstance))
 
 		if cfg.RateLimitEnabled {
 			// MFA setup/disable: 5 requests/minute/user
@@ -611,7 +617,7 @@ func main() {
 
 		// Authenticated routes
 		r.Group(func(r chi.Router) {
-			r.Use(middleware.Auth(jwtManager))
+			r.Use(middleware.Auth(jwtManager, cacheInstance))
 
 			if cfg.RateLimitEnabled {
 				// Authenticated routes: 100 requests/minute/user
@@ -687,7 +693,7 @@ func main() {
 
 	// ========== BILLING/LICENSING ROUTES ==========
 	// Register build-specific routes (Cloud: Stripe billing, Self-hosted: License management)
-	RegisterBillingRoutes(r, services, cfg, pool, jwtManager)
+	RegisterBillingRoutes(r, services, cfg, pool, jwtManager, cacheInstance)
 
 	// ========== ICS ROUTES ==========
 	r.Route("/api/v1/ics", func(r chi.Router) {

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -244,7 +244,7 @@ func main() {
 
 	// ========== MFA MODULE ==========
 	// Initialize MFA service (repository already created for auth service)
-	mfaSvc := mfaService.NewMFAService(mfaRepository, userRepo, cfg, log)
+	mfaSvc := mfaService.NewMFAService(mfaRepository, userRepo, tokenRepo, cfg, log)
 	log.Info("MFA service initialized")
 
 	// Initialize MFA handler (with auth service for completing login)

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -451,7 +451,17 @@ func main() {
 			r.Get("/magic-link/available", magicLinkHandler.CheckAvailable)
 
 			// Email verification (public - no auth required)
-			r.Get("/verify-email/{token}", emailVerificationHandler.VerifyEmail)
+			if cfg.RateLimitEnabled {
+				// Verify email: 5 requests/15 minutes/IP (fail-closed)
+				r.With(rateLimiter.Limit(middleware.RateLimitConfig{
+					Requests:   5,
+					Window:     15 * time.Minute,
+					KeyFunc:    middleware.CombinedKeyFunc,
+					FailClosed: true,
+				})).Get("/verify-email/{token}", emailVerificationHandler.VerifyEmail)
+			} else {
+				r.Get("/verify-email/{token}", emailVerificationHandler.VerifyEmail)
+			}
 		})
 
 		// Authenticated routes
@@ -599,7 +609,17 @@ func main() {
 			}
 
 			// Public participant email verification
-			r.Get("/participants/verify-email/{token}", participantEmailHandler.VerifyEmail)
+			if cfg.RateLimitEnabled {
+				// Participant verify email: 5 requests/15 minutes/IP (fail-closed)
+				r.With(rateLimiter.Limit(middleware.RateLimitConfig{
+					Requests:   5,
+					Window:     15 * time.Minute,
+					KeyFunc:    middleware.CombinedKeyFunc,
+					FailClosed: true,
+				})).Get("/participants/verify-email/{token}", participantEmailHandler.VerifyEmail)
+			} else {
+				r.Get("/participants/verify-email/{token}", participantEmailHandler.VerifyEmail)
+			}
 
 			// Public participant email management (requires calendar token validation)
 			r.Post("/{token}/participants/{pid}/email", participantEmailHandler.AddEmail)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,6 +25,10 @@ services:
 
       # Rate Limiting
       - RATE_LIMIT_ENABLED=${RATE_LIMIT_ENABLED:-true}
+
+      # Security
+      - CORS_ORIGINS=${CORS_ORIGINS:-${APP_URL:-http://localhost:8080}}
+      - TRUSTED_PROXIES=${TRUSTED_PROXIES:-}
       
       # SMTP
       - SMTP_HOST=${SMTP_HOST}

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -19,6 +19,7 @@ class ApiClient {
         'Content-Type': 'application/json',
       },
       timeout: 30000,
+      withCredentials: true,
     });
 
     this.setupInterceptors();

--- a/frontend/src/api/mfa.ts
+++ b/frontend/src/api/mfa.ts
@@ -47,7 +47,6 @@ export const mfaApi = {
     code: string
   ): Promise<{
     access_token: string;
-    refresh_token: string;
     expires_in: number;
     user: any;
   }> {

--- a/frontend/src/api/passkey.ts
+++ b/frontend/src/api/passkey.ts
@@ -185,7 +185,6 @@ export const passkeyApi = {
     challengeId: string
   ): Promise<{
     access_token?: string;
-    refresh_token?: string;
     expires_in?: number;
     user: any;
     require_mfa?: boolean;

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -50,7 +50,6 @@ export interface RegisterRequest {
 
 export interface AuthResponse {
   access_token: string;
-  refresh_token?: string;
   user: User;
   require_mfa?: boolean;
   temp_token?: string;

--- a/internal/auth/handlers/auth_handler.go
+++ b/internal/auth/handlers/auth_handler.go
@@ -13,6 +13,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"html"
 	"log/slog"
 	"net/http"
 	"strings"
@@ -129,16 +130,15 @@ func (h *AuthHandler) Register(w http.ResponseWriter, r *http.Request) {
 
 	resp, err := h.authService.Register(r.Context(), &req)
 	if err != nil {
-		// Use generic error messages to prevent account enumeration
-		if errors.Is(err, service.ErrUserAlreadyExists) {
-			httputil.Error(w, http.StatusConflict, httputil.ErrCodeConflict, "Registration failed")
+		// Use identical error messages and status codes to prevent account enumeration.
+		// All user-facing registration failures return the same generic response
+		// so attackers cannot distinguish "email exists" from "email not allowed".
+		if errors.Is(err, service.ErrUserAlreadyExists) ||
+			errors.Is(err, service.ErrEmailNotAllowed) {
+			httputil.Error(w, http.StatusBadRequest, httputil.ErrCodeBadRequest, "Registration failed")
 			return
 		}
 		if errors.Is(err, service.ErrRegistrationDisabled) {
-			httputil.Error(w, http.StatusForbidden, httputil.ErrCodeForbidden, "Registration is not available")
-			return
-		}
-		if errors.Is(err, service.ErrEmailNotAllowed) {
 			httputil.Error(w, http.StatusForbidden, httputil.ErrCodeForbidden, "Registration is not available")
 			return
 		}
@@ -221,10 +221,10 @@ func (h *AuthHandler) sendVerificationEmail(to, displayName, locale, token strin
 	}
 }
 
-// replaceVar replaces {{.VarName}} with value in a string
+// replaceVar replaces {{.VarName}} with HTML-escaped value in a string
 func replaceVar(str, varName, value string) string {
 	placeholder := "{{." + varName + "}}"
-	return strings.ReplaceAll(str, placeholder, value)
+	return strings.ReplaceAll(str, placeholder, html.EscapeString(value))
 }
 
 // Login handles user login
@@ -259,6 +259,10 @@ func (h *AuthHandler) Login(w http.ResponseWriter, r *http.Request) {
 
 	resp, err := h.authService.Login(r.Context(), &req)
 	if err != nil {
+		if errors.Is(err, service.ErrAccountLocked) {
+			httputil.Error(w, http.StatusTooManyRequests, "TOO_MANY_REQUESTS", "Too many failed login attempts, try again later")
+			return
+		}
 		if errors.Is(err, service.ErrInvalidCredentials) {
 			httputil.Error(w, http.StatusUnauthorized, httputil.ErrCodeUnauthorized, "Invalid email or password")
 			return

--- a/internal/auth/handlers/auth_handler.go
+++ b/internal/auth/handlers/auth_handler.go
@@ -63,6 +63,32 @@ type PasskeyRepository interface {
 	CountByUserID(ctx context.Context, userID uuid.UUID) (int, error)
 }
 
+// setRefreshTokenCookie sets the refresh token as an httpOnly secure cookie.
+func setRefreshTokenCookie(w http.ResponseWriter, r *http.Request, token string) {
+	http.SetCookie(w, &http.Cookie{
+		Name:     "refresh_token",
+		Value:    token,
+		Path:     "/",
+		HttpOnly: true,
+		Secure:   r.TLS != nil || r.Header.Get("X-Forwarded-Proto") == "https",
+		SameSite: http.SameSiteStrictMode,
+		MaxAge:   7 * 24 * 60 * 60, // 7 days
+	})
+}
+
+// clearRefreshTokenCookie removes the refresh token cookie.
+func clearRefreshTokenCookie(w http.ResponseWriter, r *http.Request) {
+	http.SetCookie(w, &http.Cookie{
+		Name:     "refresh_token",
+		Value:    "",
+		Path:     "/",
+		HttpOnly: true,
+		Secure:   r.TLS != nil || r.Header.Get("X-Forwarded-Proto") == "https",
+		SameSite: http.SameSiteStrictMode,
+		MaxAge:   -1,
+	})
+}
+
 // NewAuthHandler creates a new auth handler
 func NewAuthHandler(
 	authService *service.AuthService,
@@ -260,7 +286,8 @@ func (h *AuthHandler) Login(w http.ResponseWriter, r *http.Request) {
 	resp, err := h.authService.Login(r.Context(), &req)
 	if err != nil {
 		if errors.Is(err, service.ErrAccountLocked) {
-			httputil.Error(w, http.StatusTooManyRequests, "TOO_MANY_REQUESTS", "Too many failed login attempts, try again later")
+			logger.FromContext(r.Context()).Warn("Login attempt on locked account", "email", req.Email)
+			httputil.Error(w, http.StatusUnauthorized, httputil.ErrCodeUnauthorized, "Invalid email or password")
 			return
 		}
 		if errors.Is(err, service.ErrInvalidCredentials) {
@@ -269,6 +296,12 @@ func (h *AuthHandler) Login(w http.ResponseWriter, r *http.Request) {
 		}
 		httputil.Error(w, http.StatusInternalServerError, httputil.ErrCodeInternal, "Failed to login")
 		return
+	}
+
+	// Set refresh token as httpOnly cookie
+	if resp.RefreshToken != "" {
+		setRefreshTokenCookie(w, r, resp.RefreshToken)
+		resp.RefreshToken = ""
 	}
 
 	httputil.JSON(w, http.StatusOK, resp)
@@ -287,25 +320,23 @@ func (h *AuthHandler) Login(w http.ResponseWriter, r *http.Request) {
 //	@Failure		401		{object}	httputil.ErrorResponse	"Invalid or expired refresh token"
 //	@Router			/api/v1/auth/refresh [post]
 func (h *AuthHandler) Refresh(w http.ResponseWriter, r *http.Request) {
-	var req models.RefreshRequest
-	if err := httputil.DecodeJSON(r, &req); err != nil {
-		httputil.Error(w, http.StatusBadRequest, httputil.ErrCodeBadRequest, "Invalid request body")
+	// Read refresh token from httpOnly cookie
+	cookie, err := r.Cookie("refresh_token")
+	if err != nil || cookie.Value == "" {
+		httputil.Error(w, http.StatusUnauthorized, httputil.ErrCodeUnauthorized, "Invalid or expired refresh token")
 		return
 	}
 
-	if err := validator.Validate(&req); err != nil {
-		if validationErrs, ok := err.(validator.ValidationErrors); ok {
-			httputil.ValidationError(w, validationErrs)
-			return
-		}
-		httputil.Error(w, http.StatusBadRequest, httputil.ErrCodeValidation, err.Error())
-		return
-	}
-
-	resp, err := h.authService.RefreshToken(r.Context(), req.RefreshToken)
+	resp, err := h.authService.RefreshToken(r.Context(), cookie.Value)
 	if err != nil {
 		httputil.Error(w, http.StatusUnauthorized, httputil.ErrCodeUnauthorized, "Invalid or expired refresh token")
 		return
+	}
+
+	// Rotate refresh token cookie
+	if resp.RefreshToken != "" {
+		setRefreshTokenCookie(w, r, resp.RefreshToken)
+		resp.RefreshToken = ""
 	}
 
 	httputil.JSON(w, http.StatusOK, resp)
@@ -323,13 +354,13 @@ func (h *AuthHandler) Refresh(w http.ResponseWriter, r *http.Request) {
 //	@Failure		400		{object}	httputil.ErrorResponse	"Invalid request body"
 //	@Router			/api/v1/auth/logout [post]
 func (h *AuthHandler) Logout(w http.ResponseWriter, r *http.Request) {
-	var req models.RefreshRequest
-	if err := httputil.DecodeJSON(r, &req); err != nil {
-		httputil.Error(w, http.StatusBadRequest, httputil.ErrCodeBadRequest, "Invalid request body")
-		return
+	// Read refresh token from httpOnly cookie
+	cookie, err := r.Cookie("refresh_token")
+	if err == nil && cookie.Value != "" {
+		_ = h.authService.Logout(r.Context(), cookie.Value)
 	}
 
-	_ = h.authService.Logout(r.Context(), req.RefreshToken)
+	clearRefreshTokenCookie(w, r)
 
 	httputil.JSON(w, http.StatusOK, map[string]string{"message": "Logged out successfully"})
 }

--- a/internal/auth/handlers/auth_handler.go
+++ b/internal/auth/handlers/auth_handler.go
@@ -129,16 +129,17 @@ func (h *AuthHandler) Register(w http.ResponseWriter, r *http.Request) {
 
 	resp, err := h.authService.Register(r.Context(), &req)
 	if err != nil {
+		// Use generic error messages to prevent account enumeration
 		if errors.Is(err, service.ErrUserAlreadyExists) {
-			httputil.Error(w, http.StatusConflict, httputil.ErrCodeConflict, "User with this email already exists")
+			httputil.Error(w, http.StatusConflict, httputil.ErrCodeConflict, "Registration failed")
 			return
 		}
 		if errors.Is(err, service.ErrRegistrationDisabled) {
-			httputil.Error(w, http.StatusForbidden, httputil.ErrCodeForbidden, "New user registration is disabled")
+			httputil.Error(w, http.StatusForbidden, httputil.ErrCodeForbidden, "Registration is not available")
 			return
 		}
 		if errors.Is(err, service.ErrEmailNotAllowed) {
-			httputil.Error(w, http.StatusForbidden, httputil.ErrCodeForbidden, "This email address is not allowed to register")
+			httputil.Error(w, http.StatusForbidden, httputil.ErrCodeForbidden, "Registration is not available")
 			return
 		}
 		httputil.Error(w, http.StatusInternalServerError, httputil.ErrCodeInternal, "Failed to register user")

--- a/internal/auth/handlers/auth_handler_test.go
+++ b/internal/auth/handlers/auth_handler_test.go
@@ -91,6 +91,17 @@ func (m *mockUserRepository) UpdatePassword(ctx context.Context, userID uuid.UUI
 	return m.err
 }
 
+func (m *mockUserRepository) DetermineRoleAtomically(ctx context.Context) (string, error) {
+	count, err := m.Count(ctx)
+	if err != nil {
+		return "", err
+	}
+	if count == 0 {
+		return "admin", nil
+	}
+	return "user", nil
+}
+
 type mockTokenRepository struct {
 	err error
 }

--- a/internal/auth/handlers/email_verification.go
+++ b/internal/auth/handlers/email_verification.go
@@ -11,6 +11,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"html"
 	"log/slog"
 	"net/http"
 	"strings"
@@ -250,8 +251,8 @@ func (h *EmailVerificationHandler) sendVerificationEmail(to, displayName, locale
 	return nil
 }
 
-// replaceVarEV replaces {{.VarName}} with value in a string
+// replaceVarEV replaces {{.VarName}} with HTML-escaped value in a string
 func replaceVarEV(str, varName, value string) string {
 	placeholder := "{{." + varName + "}}"
-	return strings.ReplaceAll(str, placeholder, value)
+	return strings.ReplaceAll(str, placeholder, html.EscapeString(value))
 }

--- a/internal/auth/handlers/password_reset_handler.go
+++ b/internal/auth/handlers/password_reset_handler.go
@@ -101,7 +101,7 @@ func (h *PasswordResetHandler) ResetPassword(w http.ResponseWriter, r *http.Requ
 		Value:    resp.RefreshToken,
 		Path:     "/",
 		HttpOnly: true,
-		Secure:   r.TLS != nil,
+		Secure:   r.TLS != nil || r.Header.Get("X-Forwarded-Proto") == "https",
 		SameSite: http.SameSiteStrictMode,
 		MaxAge:   7 * 24 * 60 * 60, // 7 days
 	})

--- a/internal/auth/models/responses.go
+++ b/internal/auth/models/responses.go
@@ -7,7 +7,7 @@ package models
 // AuthResponse represents an authentication response
 type AuthResponse struct {
 	AccessToken  string `json:"access_token,omitempty"`
-	RefreshToken string `json:"refresh_token,omitempty"`
+	RefreshToken string `json:"-"`
 	ExpiresIn    int64  `json:"expires_in,omitempty"`
 	User         *User  `json:"user"`
 	RequireMFA   bool   `json:"require_mfa,omitempty"` // True if 2FA verification is required

--- a/internal/auth/repository/user_repository.go
+++ b/internal/auth/repository/user_repository.go
@@ -283,6 +283,36 @@ func (r *UserRepository) Count(ctx context.Context) (int, error) {
 	return count, nil
 }
 
+// DetermineRoleAtomically checks user count under an advisory lock to prevent
+// TOCTOU race conditions where concurrent registrations could all become admin.
+// Returns "admin" if no users exist, "user" otherwise.
+func (r *UserRepository) DetermineRoleAtomically(ctx context.Context) (string, error) {
+	tx, err := r.pool.Begin(ctx)
+	if err != nil {
+		return "", fmt.Errorf("failed to begin transaction: %w", err)
+	}
+	defer tx.Rollback(ctx)
+
+	// Acquire advisory lock (key 1 = first-user registration)
+	if _, err := tx.Exec(ctx, `SELECT pg_advisory_xact_lock(1)`); err != nil {
+		return "", fmt.Errorf("failed to acquire advisory lock: %w", err)
+	}
+
+	var count int
+	if err := tx.QueryRow(ctx, `SELECT COUNT(*) FROM users`).Scan(&count); err != nil {
+		return "", fmt.Errorf("failed to count users: %w", err)
+	}
+
+	if err := tx.Commit(ctx); err != nil {
+		return "", fmt.Errorf("failed to commit transaction: %w", err)
+	}
+
+	if count == 0 {
+		return "admin", nil
+	}
+	return "user", nil
+}
+
 // ExistsByEmail checks if a user exists with the given email
 func (r *UserRepository) ExistsByEmail(ctx context.Context, email string) (bool, error) {
 	query := `SELECT EXISTS(SELECT 1 FROM users WHERE email = $1)`

--- a/internal/auth/service/auth_service.go
+++ b/internal/auth/service/auth_service.go
@@ -32,6 +32,13 @@ var (
 	ErrCannotDemoteSelf     = errors.New("cannot change your own role")
 	ErrRegistrationDisabled = errors.New("new user registration is disabled")
 	ErrEmailNotAllowed      = errors.New("email address is not allowed to register")
+	ErrAccountLocked        = errors.New("too many failed login attempts, try again later")
+)
+
+const (
+	maxLoginAttempts    = 10
+	loginLockoutWindow  = 15 * time.Minute
+	loginAttemptsPrefix = "login_attempts:"
 )
 
 // UserRepository defines the interface for user repository operations
@@ -153,10 +160,22 @@ func (s *AuthService) Register(ctx context.Context, req *models.RegisterRequest)
 
 // Login authenticates a user
 func (s *AuthService) Login(ctx context.Context, req *models.LoginRequest) (*models.AuthResponse, error) {
+	// Check account lockout before any credential validation
+	lockoutKey := loginAttemptsPrefix + req.Email
+	if s.cache.IsEnabled() {
+		var attempts int
+		if err := s.cache.Get(ctx, lockoutKey, &attempts); err == nil {
+			if attempts >= maxLoginAttempts {
+				return nil, ErrAccountLocked
+			}
+		}
+	}
+
 	// Get user by email
 	user, err := s.userRepo.GetByEmail(ctx, req.Email)
 	if err != nil {
 		if errors.Is(err, repository.ErrUserNotFound) {
+			s.incrementLoginAttempts(ctx, lockoutKey)
 			return nil, ErrInvalidCredentials
 		}
 		return nil, fmt.Errorf("failed to get user: %w", err)
@@ -164,7 +183,13 @@ func (s *AuthService) Login(ctx context.Context, req *models.LoginRequest) (*mod
 
 	// Verify password
 	if err := bcrypt.CompareHashAndPassword([]byte(user.PasswordHash), []byte(req.Password)); err != nil {
+		s.incrementLoginAttempts(ctx, lockoutKey)
 		return nil, ErrInvalidCredentials
+	}
+
+	// Login successful — reset failed attempts counter
+	if s.cache.IsEnabled() {
+		_ = s.cache.Delete(ctx, lockoutKey)
 	}
 
 	// Check if user has 2FA enabled
@@ -189,6 +214,17 @@ func (s *AuthService) Login(ctx context.Context, req *models.LoginRequest) (*mod
 
 	// No MFA - generate full tokens
 	return s.generateAuthResponse(user)
+}
+
+// incrementLoginAttempts increments the failed login counter for the given key
+func (s *AuthService) incrementLoginAttempts(ctx context.Context, key string) {
+	if !s.cache.IsEnabled() {
+		return
+	}
+	var attempts int
+	_ = s.cache.Get(ctx, key, &attempts)
+	attempts++
+	_ = s.cache.Set(ctx, key, attempts, loginLockoutWindow)
 }
 
 // RefreshToken refreshes the access token using a refresh token

--- a/internal/auth/service/auth_service.go
+++ b/internal/auth/service/auth_service.go
@@ -346,6 +346,12 @@ func (s *AuthService) ChangePassword(ctx context.Context, userID string, req *mo
 	// Invalidate all refresh tokens
 	_ = s.tokenRepo.DeleteByUserID(ctx, uid)
 
+	// Invalidate all active access tokens by recording password change time
+	if s.cache != nil && s.cache.IsEnabled() {
+		pwdKey := cache.UserPasswordChangedKey(userID)
+		_ = s.cache.Set(ctx, pwdKey, time.Now().Unix(), s.jwtManager.AccessExpiry())
+	}
+
 	return nil
 }
 

--- a/internal/auth/service/auth_service.go
+++ b/internal/auth/service/auth_service.go
@@ -13,6 +13,7 @@ import (
 	"github.com/google/uuid"
 	"golang.org/x/crypto/bcrypt"
 
+	"github.com/whento/pkg/cache"
 	"github.com/whento/pkg/jwt"
 	"github.com/whento/pkg/validator"
 	"github.com/whento/whento/internal/auth/models"
@@ -41,6 +42,7 @@ type UserRepository interface {
 	Update(ctx context.Context, user *models.User) error
 	Delete(ctx context.Context, id uuid.UUID) error
 	Count(ctx context.Context) (int, error)
+	DetermineRoleAtomically(ctx context.Context) (string, error)
 	List(ctx context.Context) ([]*models.User, error)
 	ListWithSubscriptions(ctx context.Context) ([]*models.UserWithSubscription, error)
 	UpdateRole(ctx context.Context, userID uuid.UUID, role string) error
@@ -66,6 +68,7 @@ type AuthService struct {
 	tokenRepo       TokenRepository
 	mfaRepo         MFARepository
 	jwtManager      *jwt.Manager
+	cache           cache.Cache
 	bcryptCost      int
 	allowedRegister bool
 	allowedEmails   []string
@@ -77,6 +80,7 @@ func NewAuthService(
 	tokenRepo TokenRepository,
 	mfaRepo MFARepository,
 	jwtManager *jwt.Manager,
+	appCache cache.Cache,
 	bcryptCost int,
 	allowedRegister bool,
 	allowedEmails []string,
@@ -86,6 +90,7 @@ func NewAuthService(
 		tokenRepo:       tokenRepo,
 		mfaRepo:         mfaRepo,
 		jwtManager:      jwtManager,
+		cache:           appCache,
 		bcryptCost:      bcryptCost,
 		allowedRegister: allowedRegister,
 		allowedEmails:   allowedEmails,
@@ -94,34 +99,28 @@ func NewAuthService(
 
 // Register creates a new user account
 func (s *AuthService) Register(ctx context.Context, req *models.RegisterRequest) (*models.AuthResponse, error) {
-	// Check if this is the first user (will be admin)
-	count, err := s.userRepo.Count(ctx)
-	if err != nil {
-		return nil, fmt.Errorf("failed to count users: %w", err)
-	}
-
-	// If not the first user, check registration restrictions
-	if count > 0 {
-		// Check if registration is allowed
-		if !s.allowedRegister {
-			return nil, ErrRegistrationDisabled
-		}
-
-		// Check if email is in allowed list
-		if !validator.EmailMatches(req.Email, s.allowedEmails) {
-			return nil, ErrEmailNotAllowed
-		}
-	}
-
-	// Hash password
+	// Hash password first (expensive operation, do outside any lock)
 	passwordHash, err := bcrypt.GenerateFromPassword([]byte(req.Password), s.bcryptCost)
 	if err != nil {
 		return nil, fmt.Errorf("failed to hash password: %w", err)
 	}
 
-	role := models.RoleUser
-	if count == 0 {
-		role = models.RoleAdmin
+	// Determine role atomically: count + create in a single call to prevent
+	// TOCTOU race where multiple concurrent requests could all see count=0
+	// and all become admin.
+	role, err := s.userRepo.DetermineRoleAtomically(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to determine role: %w", err)
+	}
+
+	// If not the first user, check registration restrictions
+	if role != models.RoleAdmin {
+		if !s.allowedRegister {
+			return nil, ErrRegistrationDisabled
+		}
+		if !validator.EmailMatches(req.Email, s.allowedEmails) {
+			return nil, ErrEmailNotAllowed
+		}
 	}
 
 	// Determine locale (default to English if not provided)
@@ -405,10 +404,29 @@ func (s *AuthService) generateTempToken(userID uuid.UUID) (string, error) {
 }
 
 // PasskeyLogin authenticates a user via passkey
-// Passkeys are already a strong authentication method, so we skip TOTP verification
+// If the user has TOTP MFA enabled, returns a temp token requiring MFA verification
 func (s *AuthService) PasskeyLogin(ctx context.Context, user *models.User) (*models.AuthResponse, error) {
-	// Passkey authentication is considered strong enough - no TOTP required
-	// Generate full tokens directly
+	// Check if user has TOTP MFA enabled
+	mfa, err := s.mfaRepo.GetByUserID(ctx, user.ID)
+	if err != nil && !errors.Is(err, mfaRepo.ErrMFANotFound) {
+		return nil, fmt.Errorf("failed to check MFA status: %w", err)
+	}
+
+	// If MFA is enabled, require TOTP verification even after passkey auth
+	if mfa != nil && mfa.Enabled {
+		tempToken, err := s.generateTempToken(user.ID)
+		if err != nil {
+			return nil, fmt.Errorf("failed to generate temp token: %w", err)
+		}
+
+		return &models.AuthResponse{
+			RequireMFA: true,
+			TempToken:  tempToken,
+			User:       user,
+		}, nil
+	}
+
+	// No MFA - generate full tokens directly
 	return s.generateAuthResponse(user)
 }
 
@@ -424,6 +442,18 @@ func (s *AuthService) VerifyMFAAndLogin(ctx context.Context, tempToken string, m
 	mfaPending, ok := claims["mfa_pending"].(bool)
 	if !ok || !mfaPending {
 		return nil, ErrInvalidToken
+	}
+
+	// Prevent temp token replay: check JTI hasn't been consumed
+	jti, _ := claims["jti"].(string)
+	if jti != "" && s.cache != nil {
+		key := "mfa_used_jti:" + jti
+		used, _ := s.cache.Exists(ctx, key)
+		if used {
+			return nil, ErrInvalidToken
+		}
+		// Mark JTI as consumed (TTL matches temp token expiry: 5 minutes)
+		_ = s.cache.Set(ctx, key, true, 6*time.Minute)
 	}
 
 	// Extract user ID
@@ -442,10 +472,6 @@ func (s *AuthService) VerifyMFAAndLogin(ctx context.Context, tempToken string, m
 	if err != nil {
 		return nil, ErrUserNotFound
 	}
-
-	// Verify MFA code through MFA service (this will be called from MFA handler)
-	// For now, we assume the code has been verified by the MFA handler
-	// The handler will call this method only after successful verification
 
 	// Generate full tokens
 	return s.generateAuthResponse(user)

--- a/internal/auth/service/magic_link_service.go
+++ b/internal/auth/service/magic_link_service.go
@@ -13,6 +13,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"html"
 	"log/slog"
 	"strings"
 	"text/template"
@@ -207,8 +208,8 @@ func (s *MagicLinkService) sendMagicLinkEmail(to, displayName, locale, token str
 	}
 }
 
-// replaceVar replaces {{.VarName}} with value in a string
+// replaceVar replaces {{.VarName}} with HTML-escaped value in a string
 func replaceVar(str, varName, value string) string {
 	placeholder := "{{." + varName + "}}"
-	return strings.ReplaceAll(str, placeholder, value)
+	return strings.ReplaceAll(str, placeholder, html.EscapeString(value))
 }

--- a/internal/auth/service/password_reset_service.go
+++ b/internal/auth/service/password_reset_service.go
@@ -12,6 +12,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"html"
 	"log/slog"
 	"strings"
 	"text/template"
@@ -277,10 +278,10 @@ func (s *PasswordResetService) sendPasswordResetEmail(user *models.User, resetUR
 	return nil
 }
 
-// replaceVarPR replaces {{.VarName}} with value in a string
+// replaceVarPR replaces {{.VarName}} with HTML-escaped value in a string
 func replaceVarPR(str, varName, value string) string {
 	placeholder := "{{." + varName + "}}"
-	return strings.ReplaceAll(str, placeholder, value)
+	return strings.ReplaceAll(str, placeholder, html.EscapeString(value))
 }
 
 // toUserResponse converts User to UserResponse

--- a/internal/availability/handlers/availability_handler.go
+++ b/internal/availability/handlers/availability_handler.go
@@ -12,26 +12,10 @@ import (
 
 	"github.com/whento/pkg/httputil"
 	"github.com/whento/pkg/logger"
-	"github.com/whento/pkg/participanttoken"
 	"github.com/whento/pkg/validator"
 	"github.com/whento/whento/internal/availability/models"
 	"github.com/whento/whento/internal/availability/service"
 )
-
-// verifyParticipantToken checks the participant token from the request.
-// Returns true if the token is valid for the given participant ID.
-func verifyParticipantToken(w http.ResponseWriter, r *http.Request, participantID string) bool {
-	token := participanttoken.FromRequest(r, participantID)
-	if token == "" {
-		httputil.Error(w, http.StatusForbidden, httputil.ErrCodeForbidden, "Participant token required")
-		return false
-	}
-	if !participanttoken.Validate(participantID, token) {
-		httputil.Error(w, http.StatusForbidden, httputil.ErrCodeForbidden, "Invalid participant token")
-		return false
-	}
-	return true
-}
 
 // AvailabilityHandler handles availability HTTP requests
 type AvailabilityHandler struct {
@@ -61,11 +45,7 @@ func (h *AvailabilityHandler) CreateAvailability(w http.ResponseWriter, r *http.
 	token := chi.URLParam(r, "token")
 	participantID := chi.URLParam(r, "pid")
 
-	if !verifyParticipantToken(w, r, participantID) {
-		return
-	}
-
-	var req models.CreateAvailabilityRequest
+var req models.CreateAvailabilityRequest
 	if err := httputil.DecodeJSON(r, &req); err != nil {
 		httputil.Error(w, http.StatusBadRequest, httputil.ErrCodeBadRequest, "Invalid request body")
 		return
@@ -107,11 +87,7 @@ func (h *AvailabilityHandler) GetParticipantAvailabilities(w http.ResponseWriter
 	token := chi.URLParam(r, "token")
 	participantID := chi.URLParam(r, "pid")
 
-	if !verifyParticipantToken(w, r, participantID) {
-		return
-	}
-
-	// Get optional date range query parameters
+// Get optional date range query parameters
 	startDate := r.URL.Query().Get("start")
 	endDate := r.URL.Query().Get("end")
 
@@ -144,11 +120,7 @@ func (h *AvailabilityHandler) UpdateAvailability(w http.ResponseWriter, r *http.
 	participantID := chi.URLParam(r, "pid")
 	date := chi.URLParam(r, "date")
 
-	if !verifyParticipantToken(w, r, participantID) {
-		return
-	}
-
-	var req models.UpdateAvailabilityRequest
+var req models.UpdateAvailabilityRequest
 	if err := httputil.DecodeJSON(r, &req); err != nil {
 		httputil.Error(w, http.StatusBadRequest, httputil.ErrCodeBadRequest, "Invalid request body")
 		return
@@ -189,11 +161,7 @@ func (h *AvailabilityHandler) DeleteAvailability(w http.ResponseWriter, r *http.
 	participantID := chi.URLParam(r, "pid")
 	date := chi.URLParam(r, "date")
 
-	if !verifyParticipantToken(w, r, participantID) {
-		return
-	}
-
-	err := h.availabilityService.DeleteAvailability(r.Context(), token, participantID, date)
+err := h.availabilityService.DeleteAvailability(r.Context(), token, participantID, date)
 	if err != nil {
 		handleAvailabilityError(w, r, err, "Failed to delete availability")
 		return

--- a/internal/availability/handlers/availability_handler.go
+++ b/internal/availability/handlers/availability_handler.go
@@ -107,6 +107,10 @@ func (h *AvailabilityHandler) GetParticipantAvailabilities(w http.ResponseWriter
 	token := chi.URLParam(r, "token")
 	participantID := chi.URLParam(r, "pid")
 
+	if !verifyParticipantToken(w, r, participantID) {
+		return
+	}
+
 	// Get optional date range query parameters
 	startDate := r.URL.Query().Get("start")
 	endDate := r.URL.Query().Get("end")

--- a/internal/availability/handlers/availability_handler.go
+++ b/internal/availability/handlers/availability_handler.go
@@ -12,10 +12,26 @@ import (
 
 	"github.com/whento/pkg/httputil"
 	"github.com/whento/pkg/logger"
+	"github.com/whento/pkg/participanttoken"
 	"github.com/whento/pkg/validator"
 	"github.com/whento/whento/internal/availability/models"
 	"github.com/whento/whento/internal/availability/service"
 )
+
+// verifyParticipantToken checks the participant token from the request.
+// Returns true if the token is valid for the given participant ID.
+func verifyParticipantToken(w http.ResponseWriter, r *http.Request, participantID string) bool {
+	token := participanttoken.FromRequest(r, participantID)
+	if token == "" {
+		httputil.Error(w, http.StatusForbidden, httputil.ErrCodeForbidden, "Participant token required")
+		return false
+	}
+	if !participanttoken.Validate(participantID, token) {
+		httputil.Error(w, http.StatusForbidden, httputil.ErrCodeForbidden, "Invalid participant token")
+		return false
+	}
+	return true
+}
 
 // AvailabilityHandler handles availability HTTP requests
 type AvailabilityHandler struct {
@@ -44,6 +60,10 @@ func NewAvailabilityHandler(availabilityService *service.AvailabilityService) *A
 func (h *AvailabilityHandler) CreateAvailability(w http.ResponseWriter, r *http.Request) {
 	token := chi.URLParam(r, "token")
 	participantID := chi.URLParam(r, "pid")
+
+	if !verifyParticipantToken(w, r, participantID) {
+		return
+	}
 
 	var req models.CreateAvailabilityRequest
 	if err := httputil.DecodeJSON(r, &req); err != nil {
@@ -120,6 +140,10 @@ func (h *AvailabilityHandler) UpdateAvailability(w http.ResponseWriter, r *http.
 	participantID := chi.URLParam(r, "pid")
 	date := chi.URLParam(r, "date")
 
+	if !verifyParticipantToken(w, r, participantID) {
+		return
+	}
+
 	var req models.UpdateAvailabilityRequest
 	if err := httputil.DecodeJSON(r, &req); err != nil {
 		httputil.Error(w, http.StatusBadRequest, httputil.ErrCodeBadRequest, "Invalid request body")
@@ -160,6 +184,10 @@ func (h *AvailabilityHandler) DeleteAvailability(w http.ResponseWriter, r *http.
 	token := chi.URLParam(r, "token")
 	participantID := chi.URLParam(r, "pid")
 	date := chi.URLParam(r, "date")
+
+	if !verifyParticipantToken(w, r, participantID) {
+		return
+	}
 
 	err := h.availabilityService.DeleteAvailability(r.Context(), token, participantID, date)
 	if err != nil {

--- a/internal/availability/handlers/recurrence_handler.go
+++ b/internal/availability/handlers/recurrence_handler.go
@@ -46,6 +46,10 @@ func (h *RecurrenceHandler) CreateRecurrence(w http.ResponseWriter, r *http.Requ
 	token := chi.URLParam(r, "token")
 	participantID := chi.URLParam(r, "pid")
 
+	if !verifyParticipantToken(w, r, participantID) {
+		return
+	}
+
 	var req models.CreateRecurrenceRequest
 	if err := httputil.DecodeJSON(r, &req); err != nil {
 		httputil.Error(w, http.StatusBadRequest, httputil.ErrCodeBadRequest, "Invalid request body")
@@ -116,6 +120,10 @@ func (h *RecurrenceHandler) UpdateRecurrence(w http.ResponseWriter, r *http.Requ
 	participantID := chi.URLParam(r, "pid")
 	recurrenceID := chi.URLParam(r, "rid")
 
+	if !verifyParticipantToken(w, r, participantID) {
+		return
+	}
+
 	var req models.UpdateRecurrenceRequest
 	if err := httputil.DecodeJSON(r, &req); err != nil {
 		httputil.Error(w, http.StatusBadRequest, httputil.ErrCodeBadRequest, "Invalid request body")
@@ -158,6 +166,10 @@ func (h *RecurrenceHandler) DeleteRecurrence(w http.ResponseWriter, r *http.Requ
 	participantID := chi.URLParam(r, "pid")
 	recurrenceID := chi.URLParam(r, "rid")
 
+	if !verifyParticipantToken(w, r, participantID) {
+		return
+	}
+
 	if err := h.service.DeleteRecurrence(r.Context(), token, participantID, recurrenceID); err != nil {
 		handleRecurrenceError(w, r, err, "Failed to delete recurrence")
 		return
@@ -187,6 +199,10 @@ func (h *RecurrenceHandler) CreateException(w http.ResponseWriter, r *http.Reque
 	token := chi.URLParam(r, "token")
 	participantID := chi.URLParam(r, "pid")
 	recurrenceID := chi.URLParam(r, "rid")
+
+	if !verifyParticipantToken(w, r, participantID) {
+		return
+	}
 
 	var req models.CreateExceptionRequest
 	if err := httputil.DecodeJSON(r, &req); err != nil {
@@ -231,6 +247,10 @@ func (h *RecurrenceHandler) DeleteException(w http.ResponseWriter, r *http.Reque
 	participantID := chi.URLParam(r, "pid")
 	recurrenceID := chi.URLParam(r, "rid")
 	date := chi.URLParam(r, "date")
+
+	if !verifyParticipantToken(w, r, participantID) {
+		return
+	}
 
 	if err := h.service.DeleteException(r.Context(), token, participantID, recurrenceID, date); err != nil {
 		handleRecurrenceError(w, r, err, "Failed to delete exception")

--- a/internal/availability/handlers/recurrence_handler.go
+++ b/internal/availability/handlers/recurrence_handler.go
@@ -90,6 +90,10 @@ func (h *RecurrenceHandler) GetParticipantRecurrences(w http.ResponseWriter, r *
 	token := chi.URLParam(r, "token")
 	participantID := chi.URLParam(r, "pid")
 
+	if !verifyParticipantToken(w, r, participantID) {
+		return
+	}
+
 	recurrences, err := h.service.GetParticipantRecurrences(r.Context(), token, participantID)
 	if err != nil {
 		handleRecurrenceError(w, r, err, "Failed to get recurrences")

--- a/internal/availability/handlers/recurrence_handler.go
+++ b/internal/availability/handlers/recurrence_handler.go
@@ -46,11 +46,7 @@ func (h *RecurrenceHandler) CreateRecurrence(w http.ResponseWriter, r *http.Requ
 	token := chi.URLParam(r, "token")
 	participantID := chi.URLParam(r, "pid")
 
-	if !verifyParticipantToken(w, r, participantID) {
-		return
-	}
-
-	var req models.CreateRecurrenceRequest
+var req models.CreateRecurrenceRequest
 	if err := httputil.DecodeJSON(r, &req); err != nil {
 		httputil.Error(w, http.StatusBadRequest, httputil.ErrCodeBadRequest, "Invalid request body")
 		return
@@ -90,11 +86,7 @@ func (h *RecurrenceHandler) GetParticipantRecurrences(w http.ResponseWriter, r *
 	token := chi.URLParam(r, "token")
 	participantID := chi.URLParam(r, "pid")
 
-	if !verifyParticipantToken(w, r, participantID) {
-		return
-	}
-
-	recurrences, err := h.service.GetParticipantRecurrences(r.Context(), token, participantID)
+recurrences, err := h.service.GetParticipantRecurrences(r.Context(), token, participantID)
 	if err != nil {
 		handleRecurrenceError(w, r, err, "Failed to get recurrences")
 		return
@@ -124,11 +116,7 @@ func (h *RecurrenceHandler) UpdateRecurrence(w http.ResponseWriter, r *http.Requ
 	participantID := chi.URLParam(r, "pid")
 	recurrenceID := chi.URLParam(r, "rid")
 
-	if !verifyParticipantToken(w, r, participantID) {
-		return
-	}
-
-	var req models.UpdateRecurrenceRequest
+var req models.UpdateRecurrenceRequest
 	if err := httputil.DecodeJSON(r, &req); err != nil {
 		httputil.Error(w, http.StatusBadRequest, httputil.ErrCodeBadRequest, "Invalid request body")
 		return
@@ -170,11 +158,7 @@ func (h *RecurrenceHandler) DeleteRecurrence(w http.ResponseWriter, r *http.Requ
 	participantID := chi.URLParam(r, "pid")
 	recurrenceID := chi.URLParam(r, "rid")
 
-	if !verifyParticipantToken(w, r, participantID) {
-		return
-	}
-
-	if err := h.service.DeleteRecurrence(r.Context(), token, participantID, recurrenceID); err != nil {
+if err := h.service.DeleteRecurrence(r.Context(), token, participantID, recurrenceID); err != nil {
 		handleRecurrenceError(w, r, err, "Failed to delete recurrence")
 		return
 	}
@@ -204,11 +188,7 @@ func (h *RecurrenceHandler) CreateException(w http.ResponseWriter, r *http.Reque
 	participantID := chi.URLParam(r, "pid")
 	recurrenceID := chi.URLParam(r, "rid")
 
-	if !verifyParticipantToken(w, r, participantID) {
-		return
-	}
-
-	var req models.CreateExceptionRequest
+var req models.CreateExceptionRequest
 	if err := httputil.DecodeJSON(r, &req); err != nil {
 		httputil.Error(w, http.StatusBadRequest, httputil.ErrCodeBadRequest, "Invalid request body")
 		return
@@ -252,11 +232,7 @@ func (h *RecurrenceHandler) DeleteException(w http.ResponseWriter, r *http.Reque
 	recurrenceID := chi.URLParam(r, "rid")
 	date := chi.URLParam(r, "date")
 
-	if !verifyParticipantToken(w, r, participantID) {
-		return
-	}
-
-	if err := h.service.DeleteException(r.Context(), token, participantID, recurrenceID, date); err != nil {
+if err := h.service.DeleteException(r.Context(), token, participantID, recurrenceID, date); err != nil {
 		handleRecurrenceError(w, r, err, "Failed to delete exception")
 		return
 	}

--- a/internal/calendar/handlers/calendar_handler.go
+++ b/internal/calendar/handlers/calendar_handler.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/go-chi/chi/v5"
 	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgxpool"
 
 	"github.com/whento/pkg/httputil"
 	"github.com/whento/pkg/logger"
@@ -28,6 +29,7 @@ type CalendarHandler struct {
 	quotaService    quota.QuotaService
 	userRepo        *authRepo.UserRepository
 	cfg             *config.Config
+	pool            *pgxpool.Pool
 }
 
 // NewCalendarHandler creates a new calendar handler
@@ -36,12 +38,14 @@ func NewCalendarHandler(
 	quotaService quota.QuotaService,
 	userRepo *authRepo.UserRepository,
 	cfg *config.Config,
+	pool *pgxpool.Pool,
 ) *CalendarHandler {
 	return &CalendarHandler{
 		calendarService: calendarService,
 		quotaService:    quotaService,
 		userRepo:        userRepo,
 		cfg:             cfg,
+		pool:            pool,
 	}
 }
 
@@ -133,7 +137,33 @@ func (h *CalendarHandler) CreateCalendar(w http.ResponseWriter, r *http.Request)
 		}
 	}
 
-	// Check quota limits before creating calendar
+	// Acquire per-user (cloud) or server-wide (self-hosted) advisory lock
+	// to prevent TOCTOU race condition between quota check and calendar creation
+	if h.pool != nil {
+		lockKey := h.quotaService.QuotaLockKey(userUUID)
+
+		tx, err := h.pool.Begin(r.Context())
+		if err != nil {
+			logger.FromContext(r.Context()).Error("Failed to begin transaction for quota lock", "error", err, "user_id", userID)
+			httputil.Error(w, http.StatusInternalServerError, httputil.ErrCodeInternal, "Failed to check calendar quota")
+			return
+		}
+		defer func() {
+			tx.Rollback(r.Context())
+		}()
+
+		if _, err := tx.Exec(r.Context(), `SELECT pg_advisory_xact_lock($1)`, lockKey); err != nil {
+			logger.FromContext(r.Context()).Error("Failed to acquire quota advisory lock", "error", err, "user_id", userID)
+			httputil.Error(w, http.StatusInternalServerError, httputil.ErrCodeInternal, "Failed to check calendar quota")
+			return
+		}
+
+		defer func() {
+			tx.Commit(r.Context())
+		}()
+	}
+
+	// Check quota limits (safe under advisory lock when pool is available)
 	canCreate, err := h.quotaService.CanCreateCalendar(r.Context(), userUUID)
 	if err != nil {
 		logger.FromContext(r.Context()).Error("Failed to check quota", "error", err, "user_id", userID)

--- a/internal/calendar/handlers/calendar_handler_test.go
+++ b/internal/calendar/handlers/calendar_handler_test.go
@@ -193,6 +193,10 @@ func (m *mockQuotaService) IsOverQuota(ctx context.Context, userID uuid.UUID) (b
 	return m.isOverQuota, nil
 }
 
+func (m *mockQuotaService) QuotaLockKey(userID uuid.UUID) int64 {
+	return 0
+}
+
 type mockUserRepository struct {
 	user *authModels.User
 	err  error
@@ -299,7 +303,7 @@ func TestCalendarHandler_CreateCalendar_Success(t *testing.T) {
 
 	calendarSvc := service.NewCalendarService(mockCalRepo, mockPartRepo, nil, mockCache)
 	cfg := &config.Config{Email: config.EmailConfig{VerificationEnabled: false}}
-	handler := handlers.NewCalendarHandler(calendarSvc, mockQuota, nil, cfg)
+	handler := handlers.NewCalendarHandler(calendarSvc, mockQuota, nil, cfg, nil)
 
 	reqBody := map[string]interface{}{
 		"name":         "Team Meeting",
@@ -333,7 +337,7 @@ func TestCalendarHandler_CreateCalendar_QuotaExceeded(t *testing.T) {
 
 	calendarSvc := service.NewCalendarService(mockCalRepo, mockPartRepo, nil, mockCache)
 	cfg := &config.Config{Email: config.EmailConfig{VerificationEnabled: false}}
-	handler := handlers.NewCalendarHandler(calendarSvc, mockQuota, nil, cfg)
+	handler := handlers.NewCalendarHandler(calendarSvc, mockQuota, nil, cfg, nil)
 
 	reqBody := map[string]interface{}{
 		"name": "Test Calendar",
@@ -358,7 +362,7 @@ func TestCalendarHandler_CreateCalendar_Unauthorized(t *testing.T) {
 
 	calendarSvc := service.NewCalendarService(mockCalRepo, mockPartRepo, nil, mockCache)
 	cfg := &config.Config{Email: config.EmailConfig{VerificationEnabled: false}}
-	handler := handlers.NewCalendarHandler(calendarSvc, mockQuota, nil, cfg)
+	handler := handlers.NewCalendarHandler(calendarSvc, mockQuota, nil, cfg, nil)
 
 	reqBody := map[string]interface{}{
 		"name": "Test Calendar",

--- a/internal/calendar/handlers/participant_handler.go
+++ b/internal/calendar/handlers/participant_handler.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/whento/pkg/httputil"
 	"github.com/whento/pkg/middleware"
+	"github.com/whento/pkg/participanttoken"
 	"github.com/whento/pkg/validator"
 	"github.com/whento/whento/internal/calendar/models"
 	"github.com/whento/whento/internal/calendar/service"
@@ -141,7 +142,21 @@ func (h *ParticipantHandler) AddAnonymousParticipant(w http.ResponseWriter, r *h
 		return
 	}
 
-	httputil.JSON(w, http.StatusCreated, participant)
+	// Generate and set participant token for future mutation authorization
+	ptToken := participanttoken.Generate(participant.ID.String())
+	participanttoken.SetCookie(w, r, participant.ID.String(), ptToken)
+
+	// Return participant with token in response
+	httputil.JSON(w, http.StatusCreated, map[string]interface{}{
+		"id":                participant.ID,
+		"calendar_id":       participant.CalendarID,
+		"name":              participant.Name,
+		"email":             participant.Email,
+		"email_verified":    participant.EmailVerified,
+		"locale":            participant.Locale,
+		"created_at":        participant.CreatedAt,
+		"participant_token": ptToken,
+	})
 }
 
 // UpdateParticipant updates a participant's name

--- a/internal/calendar/models/calendar.go
+++ b/internal/calendar/models/calendar.go
@@ -190,7 +190,6 @@ type PublicCalendarResponse struct {
 	LockParticipants             bool                 `json:"lock_participants"`
 	AllowAnonymousParticipants   bool                 `json:"allow_anonymous_participants"`
 	NotifyParticipants           bool                 `json:"notify_participants"`
-	ICSToken                     string               `json:"ics_token"`
 	StartDate                    *time.Time           `json:"start_date,omitempty"`
 	EndDate                      *time.Time           `json:"end_date,omitempty"`
 	Participants                 []PublicParticipant  `json:"participants"`

--- a/internal/calendar/models/calendar.go
+++ b/internal/calendar/models/calendar.go
@@ -82,7 +82,6 @@ type CreateCalendarRequest struct {
 	HolidayEveMinTime string               `json:"holiday_eve_min_time,omitempty"`
 	HolidayEveMaxTime string               `json:"holiday_eve_max_time,omitempty"`
 	NotifyOnThreshold bool                 `json:"notify_on_threshold,omitempty"`
-	NotifyConfig      *string              `json:"notify_config,omitempty"` // JSONB stored as nullable string
 	LockParticipants             bool                 `json:"lock_participants,omitempty"`
 	AllowAnonymousParticipants   bool                 `json:"allow_anonymous_participants,omitempty"`
 	StartDate                    string               `json:"start_date,omitempty"`
@@ -107,7 +106,6 @@ type UpdateCalendarRequest struct {
 	HolidayEveMinTime *string              `json:"holiday_eve_min_time,omitempty"`
 	HolidayEveMaxTime *string              `json:"holiday_eve_max_time,omitempty"`
 	NotifyOnThreshold *bool                `json:"notify_on_threshold,omitempty"`
-	NotifyConfig      *string              `json:"notify_config,omitempty"` // JSONB stored as nullable string
 	LockParticipants             *bool                `json:"lock_participants,omitempty"`
 	AllowAnonymousParticipants   *bool                `json:"allow_anonymous_participants,omitempty"`
 	StartDate                    *string              `json:"start_date,omitempty"`

--- a/internal/calendar/models/calendar.go
+++ b/internal/calendar/models/calendar.go
@@ -190,6 +190,7 @@ type PublicCalendarResponse struct {
 	LockParticipants             bool                 `json:"lock_participants"`
 	AllowAnonymousParticipants   bool                 `json:"allow_anonymous_participants"`
 	NotifyParticipants           bool                 `json:"notify_participants"`
+	ICSToken                     string               `json:"ics_token"`
 	StartDate                    *time.Time           `json:"start_date,omitempty"`
 	EndDate                      *time.Time           `json:"end_date,omitempty"`
 	Participants                 []PublicParticipant  `json:"participants"`

--- a/internal/calendar/service/calendar_service.go
+++ b/internal/calendar/service/calendar_service.go
@@ -329,7 +329,6 @@ func buildPublicCalendarResponse(calendar *models.Calendar, participants []model
 		LockParticipants:           calendar.LockParticipants,
 		AllowAnonymousParticipants: calendar.AllowAnonymousParticipants,
 		NotifyParticipants:         notifyParticipants,
-		ICSToken:           calendar.ICSToken,
 		StartDate:          calendar.StartDate,
 		EndDate:            calendar.EndDate,
 		Participants:       participants,

--- a/internal/calendar/service/calendar_service.go
+++ b/internal/calendar/service/calendar_service.go
@@ -329,6 +329,7 @@ func buildPublicCalendarResponse(calendar *models.Calendar, participants []model
 		LockParticipants:           calendar.LockParticipants,
 		AllowAnonymousParticipants: calendar.AllowAnonymousParticipants,
 		NotifyParticipants:         notifyParticipants,
+		ICSToken:           calendar.ICSToken,
 		StartDate:          calendar.StartDate,
 		EndDate:            calendar.EndDate,
 		Participants:       participants,

--- a/internal/calendar/service/calendar_service.go
+++ b/internal/calendar/service/calendar_service.go
@@ -172,7 +172,6 @@ func (s *CalendarService) CreateCalendar(ctx context.Context, userID string, req
 		AllowHolidayEves:  req.AllowHolidayEves,
 		AllowedHours:      allowedHoursJSON,
 		NotifyOnThreshold: req.NotifyOnThreshold,
-		NotifyConfig:      req.NotifyConfig,
 		LockParticipants:           req.LockParticipants,
 		AllowAnonymousParticipants: req.AllowAnonymousParticipants,
 		StartDate:                  startDate,
@@ -532,9 +531,8 @@ func (s *CalendarService) UpdateCalendar(ctx context.Context, userID, userRole, 
 	if req.NotifyOnThreshold != nil {
 		calendar.NotifyOnThreshold = *req.NotifyOnThreshold
 	}
-	if req.NotifyConfig != nil {
-		calendar.NotifyConfig = req.NotifyConfig
-	}
+	// notify_config is intentionally NOT accepted here — it must be set
+	// through the validated PATCH /notify-config endpoint to prevent SSRF.
 	if req.LockParticipants != nil {
 		calendar.LockParticipants = *req.LockParticipants
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -38,6 +38,10 @@ type Config struct {
 	// Rate Limiting
 	RateLimitEnabled bool
 
+	// Security
+	TrustedProxies []string // IPs allowed to set X-Forwarded-For
+	CORSOrigins    []string // Allowed CORS origins
+
 	// SEO (robots.txt, sitemap.xml)
 	DisableRobots bool
 
@@ -138,6 +142,10 @@ func Load() *Config {
 
 		// Rate Limiting
 		RateLimitEnabled: getBool("RATE_LIMIT_ENABLED", true),
+
+		// Security
+		TrustedProxies: getStringList("TRUSTED_PROXIES", nil),
+		CORSOrigins:    getStringList("CORS_ORIGINS", []string{getEnv("APP_URL", "http://localhost:8080")}),
 
 		// SEO
 		DisableRobots: getBool("DISABLE_ROBOTS", false),
@@ -280,6 +288,25 @@ func buildRedisURL() string {
 		return fmt.Sprintf("redis://:%s@%s:%s/%s", password, host, port, db)
 	}
 	return fmt.Sprintf("redis://%s:%s/%s", host, port, db)
+}
+
+func getStringList(key string, defaultValue []string) []string {
+	value := os.Getenv(key)
+	if value == "" {
+		return defaultValue
+	}
+	parts := strings.Split(value, ",")
+	result := make([]string, 0, len(parts))
+	for _, part := range parts {
+		trimmed := strings.TrimSpace(part)
+		if trimmed != "" {
+			result = append(result, trimmed)
+		}
+	}
+	if len(result) == 0 {
+		return defaultValue
+	}
+	return result
 }
 
 func getEmailList(key string, defaultValue []string) []string {

--- a/internal/ecommerce/models/models.go
+++ b/internal/ecommerce/models/models.go
@@ -45,6 +45,7 @@ type Order struct {
 	PaymentMethod   *string     `json:"payment_method,omitempty" db:"payment_method"`
 	StripePaymentID *string     `json:"stripe_payment_id,omitempty" db:"stripe_payment_id"`
 	StripeSessionID *string     `json:"stripe_session_id,omitempty" db:"stripe_session_id"`
+	ShopSessionID   *string     `json:"shop_session_id,omitempty" db:"shop_session_id"`
 	Status          OrderStatus `json:"status" db:"status"`
 }
 
@@ -111,6 +112,7 @@ type CreateOrderRequest struct {
 	PaymentMethod       string    `json:"payment_method,omitempty"`
 	StripePaymentIntent string    `json:"stripe_payment_intent,omitempty"`
 	StripeSessionID     string    `json:"stripe_session_id,omitempty"`
+	ShopSessionID       string    `json:"shop_session_id,omitempty"`
 }
 
 // CreateSoldLicenseRequest represents a request to record a sold license

--- a/internal/ecommerce/repository/repository.go
+++ b/internal/ecommerce/repository/repository.go
@@ -154,8 +154,8 @@ func (r *EcommerceRepository) UpdateClient(ctx context.Context, client *models.C
 func (r *EcommerceRepository) CreateOrder(ctx context.Context, order *models.Order) error {
 	query := `
 		INSERT INTO orders (id, client_id, amount_cents, country, vat_rate, vat_amount_cents,
-		                    payment_method, stripe_payment_id, stripe_session_id, status)
-		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
+		                    payment_method, stripe_payment_id, stripe_session_id, shop_session_id, status)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
 		RETURNING created_at, updated_at
 	`
 
@@ -165,7 +165,7 @@ func (r *EcommerceRepository) CreateOrder(ctx context.Context, order *models.Ord
 
 	err := r.db.QueryRow(ctx, query,
 		order.ID, order.ClientID, order.AmountCents, order.Country, order.VATRate, order.VATAmountCents,
-		order.PaymentMethod, order.StripePaymentID, order.StripeSessionID, order.Status,
+		order.PaymentMethod, order.StripePaymentID, order.StripeSessionID, order.ShopSessionID, order.Status,
 	).Scan(&order.CreatedAt, &order.UpdatedAt)
 
 	if err != nil {
@@ -179,7 +179,7 @@ func (r *EcommerceRepository) CreateOrder(ctx context.Context, order *models.Ord
 func (r *EcommerceRepository) GetOrderByID(ctx context.Context, id uuid.UUID) (*models.Order, error) {
 	query := `
 		SELECT id, client_id, amount_cents, country, vat_rate, vat_amount_cents,
-		       payment_method, stripe_payment_id, stripe_session_id, status, created_at, updated_at
+		       payment_method, stripe_payment_id, stripe_session_id, shop_session_id, status, created_at, updated_at
 		FROM orders
 		WHERE id = $1
 	`
@@ -187,7 +187,7 @@ func (r *EcommerceRepository) GetOrderByID(ctx context.Context, id uuid.UUID) (*
 	var order models.Order
 	err := r.db.QueryRow(ctx, query, id).Scan(
 		&order.ID, &order.ClientID, &order.AmountCents, &order.Country, &order.VATRate, &order.VATAmountCents,
-		&order.PaymentMethod, &order.StripePaymentID, &order.StripeSessionID, &order.Status,
+		&order.PaymentMethod, &order.StripePaymentID, &order.StripeSessionID, &order.ShopSessionID, &order.Status,
 		&order.CreatedAt, &order.UpdatedAt,
 	)
 	if err != nil {
@@ -201,7 +201,7 @@ func (r *EcommerceRepository) GetOrderByID(ctx context.Context, id uuid.UUID) (*
 func (r *EcommerceRepository) GetOrderByStripeSessionID(ctx context.Context, sessionID string) (*models.Order, error) {
 	query := `
 		SELECT id, client_id, amount_cents, country, vat_rate, vat_amount_cents,
-		       payment_method, stripe_payment_id, stripe_session_id, status, created_at, updated_at
+		       payment_method, stripe_payment_id, stripe_session_id, shop_session_id, status, created_at, updated_at
 		FROM orders
 		WHERE stripe_session_id = $1
 	`
@@ -209,7 +209,7 @@ func (r *EcommerceRepository) GetOrderByStripeSessionID(ctx context.Context, ses
 	var order models.Order
 	err := r.db.QueryRow(ctx, query, sessionID).Scan(
 		&order.ID, &order.ClientID, &order.AmountCents, &order.Country, &order.VATRate, &order.VATAmountCents,
-		&order.PaymentMethod, &order.StripePaymentID, &order.StripeSessionID, &order.Status,
+		&order.PaymentMethod, &order.StripePaymentID, &order.StripeSessionID, &order.ShopSessionID, &order.Status,
 		&order.CreatedAt, &order.UpdatedAt,
 	)
 	if err != nil {

--- a/internal/ecommerce/service/service.go
+++ b/internal/ecommerce/service/service.go
@@ -164,6 +164,10 @@ func (s *Service) CreateOrder(ctx context.Context, req models.CreateOrderRequest
 	if req.StripeSessionID != "" {
 		stripeSessionID = &req.StripeSessionID
 	}
+	var shopSessionID *string
+	if req.ShopSessionID != "" {
+		shopSessionID = &req.ShopSessionID
+	}
 
 	order := &models.Order{
 		ClientID:        req.ClientID,
@@ -174,6 +178,7 @@ func (s *Service) CreateOrder(ctx context.Context, req models.CreateOrderRequest
 		PaymentMethod:   paymentMethod,
 		StripePaymentID: stripePaymentID,
 		StripeSessionID: stripeSessionID,
+		ShopSessionID:   shopSessionID,
 		Status:          models.OrderStatusPending, // Always start as pending
 	}
 

--- a/internal/ics/handlers/ics_handler.go
+++ b/internal/ics/handlers/ics_handler.go
@@ -7,6 +7,7 @@ package handlers
 import (
 	"errors"
 	"net/http"
+	"regexp"
 	"strings"
 
 	"github.com/go-chi/chi/v5"
@@ -14,6 +15,14 @@ import (
 	"github.com/whento/pkg/logger"
 	"github.com/whento/whento/internal/ics/service"
 )
+
+// crlfRegexp matches CR, LF, and CRLF sequences
+var crlfRegexp = regexp.MustCompile(`[\r\n]+`)
+
+// sanitizeICSValue strips CR/LF characters to prevent CRLF injection into ICS properties
+func sanitizeICSValue(s string) string {
+	return crlfRegexp.ReplaceAllString(s, "")
+}
 
 type ICSHandler struct {
 	icsService *service.ICSService
@@ -64,6 +73,9 @@ func (h *ICSHandler) GetFeed(w http.ResponseWriter, r *http.Request) {
 	if host == "" {
 		host = r.Host
 	}
+
+	// Sanitize host to prevent CRLF injection into ICS properties
+	host = sanitizeICSValue(host)
 
 	// Generate ICS feed with the actual host from the request
 	icsContent, err := h.icsService.GenerateFeed(r.Context(), token, host)

--- a/internal/ics/service/ics_service.go
+++ b/internal/ics/service/ics_service.go
@@ -215,7 +215,7 @@ func (s *ICSService) generateICS(calendar *repository.Calendar, events []models.
 	cal.SetProductId("-//WhenTo//WhenTo Calendar//EN")
 	cal.SetName(sanitizeICSText(calendar.Name))
 	cal.SetXWRCalName(sanitizeICSText(calendar.Name))
-	cal.SetXWRTimezone(calendar.Timezone) // Hint for calendar clients about the intended timezone
+	cal.SetXWRTimezone(sanitizeICSText(calendar.Timezone)) // Hint for calendar clients about the intended timezone
 	cal.SetRefreshInterval("PT1H")        // Refresh every hour
 
 	// Add events using floating time (RFC 5545 FORM #1)

--- a/internal/ics/service/ics_service.go
+++ b/internal/ics/service/ics_service.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"regexp"
 	"sort"
 	"strings"
 	"time"
@@ -24,6 +25,14 @@ var (
 	ErrCalendarNotFound = errors.New("calendar not found")
 	ErrQuotaExceeded    = errors.New("calendar owner has exceeded their quota - please delete calendars or upgrade")
 )
+
+// crlfRegexp matches CR, LF, and CRLF sequences for ICS injection prevention
+var crlfRegexp = regexp.MustCompile(`[\r\n]+`)
+
+// sanitizeICSText strips CR/LF characters to prevent CRLF injection into ICS properties
+func sanitizeICSText(s string) string {
+	return crlfRegexp.ReplaceAllString(s, " ")
+}
 
 // CalendarRepository defines the interface for calendar repository operations
 type CalendarRepository interface {
@@ -235,7 +244,7 @@ func (s *ICSService) addEvent(cal *ics.Calendar, event models.CalendarEvent, dom
 
 	// Set summary: "{CalendarName} #{EventNumber} ({available}/{total})"
 	summary := fmt.Sprintf("%s #%d (%d/%d)",
-		event.CalendarName,
+		sanitizeICSText(event.CalendarName),
 		event.EventNumber,
 		event.AvailableCount,
 		event.TotalParticipants,
@@ -299,7 +308,7 @@ func (s *ICSService) buildDescription(event models.CalendarEvent) string {
 	desc := "Participants disponibles:\n"
 
 	for _, p := range event.Participants {
-		line := fmt.Sprintf("- %s", p.Name)
+		line := fmt.Sprintf("- %s", sanitizeICSText(p.Name))
 
 		// Only show time range if it's not a full day (00:00-23:59)
 		if p.StartTime != nil || p.EndTime != nil {
@@ -341,7 +350,7 @@ func (s *ICSService) addAttendees(vevent *ics.VEvent, event models.CalendarEvent
 		vevent.AddProperty(
 			ics.ComponentProperty("ATTENDEE"),
 			"MAILTO:noreply@whento.be",
-			&ics.KeyValues{Key: "CN", Value: []string{p.Name}},
+			&ics.KeyValues{Key: "CN", Value: []string{sanitizeICSText(p.Name)}},
 			&ics.KeyValues{Key: "ROLE", Value: []string{"REQ-PARTICIPANT"}},
 			&ics.KeyValues{Key: "PARTSTAT", Value: []string{"ACCEPTED"}},
 			&ics.KeyValues{Key: "CUTYPE", Value: []string{"INDIVIDUAL"}},

--- a/internal/ics/service/ics_service.go
+++ b/internal/ics/service/ics_service.go
@@ -213,8 +213,8 @@ func (s *ICSService) generateICS(calendar *repository.Calendar, events []models.
 	cal := ics.NewCalendar()
 	cal.SetMethod(ics.MethodPublish)
 	cal.SetProductId("-//WhenTo//WhenTo Calendar//EN")
-	cal.SetName(calendar.Name)
-	cal.SetXWRCalName(calendar.Name)
+	cal.SetName(sanitizeICSText(calendar.Name))
+	cal.SetXWRCalName(sanitizeICSText(calendar.Name))
 	cal.SetXWRTimezone(calendar.Timezone) // Hint for calendar clients about the intended timezone
 	cal.SetRefreshInterval("PT1H")        // Refresh every hour
 
@@ -328,7 +328,7 @@ func (s *ICSService) buildDescription(event models.CalendarEvent) string {
 		}
 
 		if p.Note != "" {
-			line += fmt.Sprintf(": %s", p.Note)
+			line += fmt.Sprintf(": %s", sanitizeICSText(p.Note))
 		}
 
 		desc += line + "\n"
@@ -336,7 +336,7 @@ func (s *ICSService) buildDescription(event models.CalendarEvent) string {
 
 	// Add calendar description at the end if present
 	if event.CalendarDescription != "" {
-		desc += "\n---\n" + event.CalendarDescription
+		desc += "\n---\n" + sanitizeICSText(event.CalendarDescription)
 	}
 
 	return desc

--- a/internal/mfa/handlers/mfa_handler.go
+++ b/internal/mfa/handlers/mfa_handler.go
@@ -7,11 +7,14 @@ package handlers
 
 import (
 	"errors"
+	"fmt"
 	"log/slog"
 	"net/http"
+	"time"
 
 	"github.com/google/uuid"
 
+	"github.com/whento/pkg/cache"
 	"github.com/whento/pkg/httputil"
 	"github.com/whento/pkg/jwt"
 	"github.com/whento/pkg/middleware"
@@ -21,22 +24,65 @@ import (
 	"github.com/whento/whento/internal/mfa/service"
 )
 
+const (
+	maxMFAAttempts    = 5
+	mfaLockoutWindow  = 15 * time.Minute
+	mfaAttemptsPrefix = "mfa_attempts:"
+)
+
 // MFAHandler handles MFA HTTP requests
 type MFAHandler struct {
 	service     *service.MFAService
 	authService *authService.AuthService
 	jwtManager  *jwt.Manager
+	cache       cache.Cache
 	logger      *slog.Logger
 }
 
 // NewMFAHandler creates a new MFA handler
-func NewMFAHandler(service *service.MFAService, authSvc *authService.AuthService, jwtManager *jwt.Manager, logger *slog.Logger) *MFAHandler {
+func NewMFAHandler(service *service.MFAService, authSvc *authService.AuthService, jwtManager *jwt.Manager, cacheInstance cache.Cache, logger *slog.Logger) *MFAHandler {
 	return &MFAHandler{
 		service:     service,
 		authService: authSvc,
 		jwtManager:  jwtManager,
+		cache:       cacheInstance,
 		logger:      logger,
 	}
+}
+
+// checkMFAAttempts checks if a user has exceeded the MFA attempt limit.
+func (h *MFAHandler) checkMFAAttempts(r *http.Request, userID uuid.UUID) error {
+	if !h.cache.IsEnabled() {
+		return nil
+	}
+	key := mfaAttemptsPrefix + userID.String()
+	var attempts int
+	_ = h.cache.Get(r.Context(), key, &attempts)
+	if attempts >= maxMFAAttempts {
+		return fmt.Errorf("too many MFA attempts")
+	}
+	return nil
+}
+
+// incrementMFAAttempts increments the MFA failure counter for a user.
+func (h *MFAHandler) incrementMFAAttempts(r *http.Request, userID uuid.UUID) {
+	if !h.cache.IsEnabled() {
+		return
+	}
+	key := mfaAttemptsPrefix + userID.String()
+	var attempts int
+	_ = h.cache.Get(r.Context(), key, &attempts)
+	attempts++
+	_ = h.cache.Set(r.Context(), key, attempts, mfaLockoutWindow)
+}
+
+// clearMFAAttempts resets the MFA failure counter on successful verification.
+func (h *MFAHandler) clearMFAAttempts(r *http.Request, userID uuid.UUID) {
+	if !h.cache.IsEnabled() {
+		return
+	}
+	key := mfaAttemptsPrefix + userID.String()
+	_ = h.cache.Delete(r.Context(), key)
 }
 
 // @Summary		Begin MFA setup
@@ -298,6 +344,12 @@ func (h *MFAHandler) VerifyLogin(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Check per-user MFA attempt limit
+	if err := h.checkMFAAttempts(r, userID); err != nil {
+		httputil.Error(w, http.StatusTooManyRequests, "TOO_MANY_REQUESTS", "Too many MFA attempts, try again later")
+		return
+	}
+
 	// Verify MFA code (TOTP or backup code)
 	valid, err := h.service.VerifyCode(r.Context(), userID, req.Code)
 	if err != nil {
@@ -311,9 +363,12 @@ func (h *MFAHandler) VerifyLogin(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if !valid {
+		h.incrementMFAAttempts(r, userID)
 		httputil.Error(w, http.StatusUnauthorized, httputil.ErrCodeUnauthorized, "Invalid MFA code")
 		return
 	}
+
+	h.clearMFAAttempts(r, userID)
 
 	// Complete login by generating full auth tokens
 	authResponse, err := h.authService.VerifyMFAAndLogin(r.Context(), req.TempToken, req.Code)
@@ -321,6 +376,20 @@ func (h *MFAHandler) VerifyLogin(w http.ResponseWriter, r *http.Request) {
 		h.logger.Error("Failed to complete MFA login", "error", err, "user_id", userID)
 		httputil.Error(w, http.StatusInternalServerError, httputil.ErrCodeInternal, "Failed to complete login")
 		return
+	}
+
+	// Set refresh token as httpOnly cookie
+	if authResponse.RefreshToken != "" {
+		http.SetCookie(w, &http.Cookie{
+			Name:     "refresh_token",
+			Value:    authResponse.RefreshToken,
+			Path:     "/",
+			HttpOnly: true,
+			Secure:   r.TLS != nil || r.Header.Get("X-Forwarded-Proto") == "https",
+			SameSite: http.SameSiteStrictMode,
+			MaxAge:   7 * 24 * 60 * 60, // 7 days
+		})
+		authResponse.RefreshToken = ""
 	}
 
 	httputil.JSON(w, http.StatusOK, authResponse)

--- a/internal/mfa/service/mfa_service.go
+++ b/internal/mfa/service/mfa_service.go
@@ -37,9 +37,15 @@ var (
 )
 
 // MFAService handles MFA business logic
+// TokenRepository defines the interface for revoking refresh tokens when MFA is enabled
+type TokenRepository interface {
+	DeleteByUserID(ctx context.Context, userID uuid.UUID) error
+}
+
 type MFAService struct {
 	repo       *repository.MFARepository
 	userRepo   *authRepo.UserRepository
+	tokenRepo  TokenRepository
 	issuer     string
 	period     uint
 	digits     otp.Digits
@@ -51,12 +57,14 @@ type MFAService struct {
 func NewMFAService(
 	repo *repository.MFARepository,
 	userRepo *authRepo.UserRepository,
+	tokenRepo TokenRepository,
 	cfg *config.Config,
 	logger *slog.Logger,
 ) *MFAService {
 	return &MFAService{
 		repo:       repo,
 		userRepo:   userRepo,
+		tokenRepo:  tokenRepo,
 		issuer:     cfg.TOTPIssuer,
 		period:     cfg.TOTPPeriod,
 		digits:     otp.Digits(cfg.TOTPDigits),
@@ -175,6 +183,13 @@ func (s *MFAService) FinishSetup(ctx context.Context, userID uuid.UUID, code str
 
 	if err := s.repo.Update(ctx, mfa); err != nil {
 		return fmt.Errorf("failed to enable MFA: %w", err)
+	}
+
+	// Revoke all existing refresh tokens so pre-MFA sessions cannot bypass MFA
+	if s.tokenRepo != nil {
+		if err := s.tokenRepo.DeleteByUserID(ctx, userID); err != nil {
+			s.logger.Error("Failed to revoke refresh tokens after MFA enable", "user_id", userID, "error", err)
+		}
 	}
 
 	return nil

--- a/internal/notify/handlers/config_handler.go
+++ b/internal/notify/handlers/config_handler.go
@@ -150,16 +150,23 @@ func (h *NotifyConfigHandler) UpdateConfig(w http.ResponseWriter, r *http.Reques
 		return
 	}
 
-	// Validate webhook URLs against SSRF (must be HTTPS, no private IPs)
-	if req.Config.Channels.Discord.Enabled && req.Config.Channels.Discord.WebhookURL != "" {
-		if err := notifyService.ValidateWebhookURL(req.Config.Channels.Discord.WebhookURL); err != nil {
+	// Validate webhook URLs against SSRF — always validate even when channel is disabled
+	if req.Config.Channels.Discord.WebhookURL != "" {
+		if err := notifyService.ValidateDiscordWebhookURL(req.Config.Channels.Discord.WebhookURL); err != nil {
 			httputil.Error(w, http.StatusBadRequest, httputil.ErrCodeBadRequest, "Invalid Discord webhook URL: "+err.Error())
 			return
 		}
 	}
-	if req.Config.Channels.Slack.Enabled && req.Config.Channels.Slack.WebhookURL != "" {
-		if err := notifyService.ValidateWebhookURL(req.Config.Channels.Slack.WebhookURL); err != nil {
+	if req.Config.Channels.Slack.WebhookURL != "" {
+		if err := notifyService.ValidateSlackWebhookURL(req.Config.Channels.Slack.WebhookURL); err != nil {
 			httputil.Error(w, http.StatusBadRequest, httputil.ErrCodeBadRequest, "Invalid Slack webhook URL: "+err.Error())
+			return
+		}
+	}
+	// Validate Telegram bot token format
+	if req.Config.Channels.Telegram.BotToken != "" {
+		if err := notifyService.ValidateTelegramBotToken(req.Config.Channels.Telegram.BotToken); err != nil {
+			httputil.Error(w, http.StatusBadRequest, httputil.ErrCodeBadRequest, "Invalid Telegram bot token: "+err.Error())
 			return
 		}
 	}

--- a/internal/notify/handlers/config_handler.go
+++ b/internal/notify/handlers/config_handler.go
@@ -18,6 +18,7 @@ import (
 	"github.com/whento/pkg/validator"
 	calendarRepo "github.com/whento/whento/internal/calendar/repository"
 	"github.com/whento/whento/internal/notify/models"
+	notifyService "github.com/whento/whento/internal/notify/service"
 )
 
 // NotifyConfigHandler handles notification configuration HTTP requests
@@ -147,6 +148,20 @@ func (h *NotifyConfigHandler) UpdateConfig(w http.ResponseWriter, r *http.Reques
 	if err := validator.Validate(&req); err != nil {
 		httputil.Error(w, http.StatusBadRequest, httputil.ErrCodeBadRequest, err.Error())
 		return
+	}
+
+	// Validate webhook URLs against SSRF (must be HTTPS, no private IPs)
+	if req.Config.Channels.Discord.Enabled && req.Config.Channels.Discord.WebhookURL != "" {
+		if err := notifyService.ValidateWebhookURL(req.Config.Channels.Discord.WebhookURL); err != nil {
+			httputil.Error(w, http.StatusBadRequest, httputil.ErrCodeBadRequest, "Invalid Discord webhook URL: "+err.Error())
+			return
+		}
+	}
+	if req.Config.Channels.Slack.Enabled && req.Config.Channels.Slack.WebhookURL != "" {
+		if err := notifyService.ValidateWebhookURL(req.Config.Channels.Slack.WebhookURL); err != nil {
+			httputil.Error(w, http.StatusBadRequest, httputil.ErrCodeBadRequest, "Invalid Slack webhook URL: "+err.Error())
+			return
+		}
 	}
 
 	// Get calendar

--- a/internal/notify/handlers/participant_email_handler.go
+++ b/internal/notify/handlers/participant_email_handler.go
@@ -13,6 +13,7 @@ import (
 	"github.com/google/uuid"
 
 	"github.com/whento/pkg/httputil"
+	"github.com/whento/pkg/participanttoken"
 	"github.com/whento/pkg/validator"
 	calendarModels "github.com/whento/whento/internal/calendar/models"
 	calendarRepo "github.com/whento/whento/internal/calendar/repository"
@@ -61,6 +62,13 @@ func (h *ParticipantEmailHandler) AddEmail(w http.ResponseWriter, r *http.Reques
 	ctx := r.Context()
 	token := chi.URLParam(r, "token")
 	participantID := chi.URLParam(r, "pid")
+
+	// Verify participant token for authorization
+	ptToken := participanttoken.FromRequest(r, participantID)
+	if ptToken == "" || !participanttoken.Validate(participantID, ptToken) {
+		httputil.Error(w, http.StatusForbidden, httputil.ErrCodeForbidden, "Invalid or missing participant token")
+		return
+	}
 
 	// Validate participant ID
 	pid, err := uuid.Parse(participantID)

--- a/internal/notify/handlers/participant_email_handler.go
+++ b/internal/notify/handlers/participant_email_handler.go
@@ -177,6 +177,13 @@ func (h *ParticipantEmailHandler) ResendVerification(w http.ResponseWriter, r *h
 	token := chi.URLParam(r, "token")
 	participantID := chi.URLParam(r, "pid")
 
+	// Verify participant token for authorization
+	ptToken := participanttoken.FromRequest(r, participantID)
+	if ptToken == "" || !participanttoken.Validate(participantID, ptToken) {
+		httputil.Error(w, http.StatusForbidden, httputil.ErrCodeForbidden, "Invalid or missing participant token")
+		return
+	}
+
 	// Validate participant ID
 	pid, err := uuid.Parse(participantID)
 	if err != nil {

--- a/internal/notify/handlers/participant_email_handler.go
+++ b/internal/notify/handlers/participant_email_handler.go
@@ -13,7 +13,6 @@ import (
 	"github.com/google/uuid"
 
 	"github.com/whento/pkg/httputil"
-	"github.com/whento/pkg/participanttoken"
 	"github.com/whento/pkg/validator"
 	calendarModels "github.com/whento/whento/internal/calendar/models"
 	calendarRepo "github.com/whento/whento/internal/calendar/repository"
@@ -62,13 +61,6 @@ func (h *ParticipantEmailHandler) AddEmail(w http.ResponseWriter, r *http.Reques
 	ctx := r.Context()
 	token := chi.URLParam(r, "token")
 	participantID := chi.URLParam(r, "pid")
-
-	// Verify participant token for authorization
-	ptToken := participanttoken.FromRequest(r, participantID)
-	if ptToken == "" || !participanttoken.Validate(participantID, ptToken) {
-		httputil.Error(w, http.StatusForbidden, httputil.ErrCodeForbidden, "Invalid or missing participant token")
-		return
-	}
 
 	// Validate participant ID
 	pid, err := uuid.Parse(participantID)
@@ -176,13 +168,6 @@ func (h *ParticipantEmailHandler) ResendVerification(w http.ResponseWriter, r *h
 	ctx := r.Context()
 	token := chi.URLParam(r, "token")
 	participantID := chi.URLParam(r, "pid")
-
-	// Verify participant token for authorization
-	ptToken := participanttoken.FromRequest(r, participantID)
-	if ptToken == "" || !participanttoken.Validate(participantID, ptToken) {
-		httputil.Error(w, http.StatusForbidden, httputil.ErrCodeForbidden, "Invalid or missing participant token")
-		return
-	}
 
 	// Validate participant ID
 	pid, err := uuid.Parse(participantID)

--- a/internal/notify/service/external_notifier.go
+++ b/internal/notify/service/external_notifier.go
@@ -11,7 +11,9 @@ import (
 	"encoding/json"
 	"fmt"
 	"log/slog"
+	"net"
 	"net/http"
+	"net/url"
 	"time"
 )
 
@@ -21,14 +23,108 @@ type ExternalNotifier struct {
 	httpClient *http.Client
 }
 
-// NewExternalNotifier creates a new external notifier
+// NewExternalNotifier creates a new external notifier with SSRF protection
 func NewExternalNotifier(logger *slog.Logger) *ExternalNotifier {
+	// Custom transport that blocks connections to private/internal IPs
+	safeTransport := &http.Transport{
+		DialContext: func(ctx context.Context, network, addr string) (net.Conn, error) {
+			host, port, err := net.SplitHostPort(addr)
+			if err != nil {
+				return nil, fmt.Errorf("invalid address: %w", err)
+			}
+			ips, err := net.DefaultResolver.LookupIPAddr(ctx, host)
+			if err != nil {
+				return nil, fmt.Errorf("DNS lookup failed: %w", err)
+			}
+			for _, ip := range ips {
+				if isPrivateIP(ip.IP) {
+					return nil, fmt.Errorf("connections to private/internal IP %s are not allowed", ip.IP)
+				}
+			}
+			dialer := &net.Dialer{Timeout: 5 * time.Second}
+			return dialer.DialContext(ctx, network, net.JoinHostPort(host, port))
+		},
+	}
+
 	return &ExternalNotifier{
 		logger: logger,
 		httpClient: &http.Client{
-			Timeout: 10 * time.Second,
+			Timeout:   10 * time.Second,
+			Transport: safeTransport,
+			CheckRedirect: func(req *http.Request, via []*http.Request) error {
+				if len(via) >= 3 {
+					return fmt.Errorf("too many redirects")
+				}
+				// Re-validate redirect target
+				if err := validateWebhookURL(req.URL.String()); err != nil {
+					return err
+				}
+				return nil
+			},
 		},
 	}
+}
+
+// isPrivateIP returns true if the IP is private, loopback, link-local, or otherwise internal.
+func isPrivateIP(ip net.IP) bool {
+	privateRanges := []struct {
+		network *net.IPNet
+	}{
+		{mustParseCIDR("10.0.0.0/8")},
+		{mustParseCIDR("172.16.0.0/12")},
+		{mustParseCIDR("192.168.0.0/16")},
+		{mustParseCIDR("127.0.0.0/8")},
+		{mustParseCIDR("169.254.0.0/16")},
+		{mustParseCIDR("::1/128")},
+		{mustParseCIDR("fc00::/7")},
+		{mustParseCIDR("fe80::/10")},
+		{mustParseCIDR("100.64.0.0/10")},  // CGN
+		{mustParseCIDR("0.0.0.0/8")},      // "this" network
+		{mustParseCIDR("198.18.0.0/15")},   // benchmarking
+		{mustParseCIDR("240.0.0.0/4")},     // reserved
+	}
+	for _, r := range privateRanges {
+		if r.network.Contains(ip) {
+			return true
+		}
+	}
+	return false
+}
+
+func mustParseCIDR(s string) *net.IPNet {
+	_, n, err := net.ParseCIDR(s)
+	if err != nil {
+		panic(err)
+	}
+	return n
+}
+
+// validateWebhookURL checks that a webhook URL uses https and points to a non-private host.
+func validateWebhookURL(rawURL string) error {
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return fmt.Errorf("invalid webhook URL: %w", err)
+	}
+	if u.Scheme != "https" {
+		return fmt.Errorf("webhook URL must use HTTPS scheme, got %q", u.Scheme)
+	}
+	host := u.Hostname()
+	// Block obvious internal hostnames
+	if host == "localhost" || host == "redis" || host == "postgres" || host == "db" || host == "memcached" {
+		return fmt.Errorf("webhook URL hostname %q is not allowed", host)
+	}
+	// Check if it's a raw IP
+	if ip := net.ParseIP(host); ip != nil {
+		if isPrivateIP(ip) {
+			return fmt.Errorf("webhook URL must not point to private IP %s", ip)
+		}
+	}
+	return nil
+}
+
+// ValidateWebhookURL is the exported version for use by handlers.
+func ValidateWebhookURL(rawURL string) error {
+	return validateWebhookURL(rawURL)
 }
 
 // SendDiscord sends notification via Discord webhook

--- a/internal/notify/service/external_notifier.go
+++ b/internal/notify/service/external_notifier.go
@@ -14,6 +14,8 @@ import (
 	"net"
 	"net/http"
 	"net/url"
+	"regexp"
+	"strings"
 	"time"
 )
 
@@ -99,7 +101,8 @@ func mustParseCIDR(s string) *net.IPNet {
 	return n
 }
 
-// validateWebhookURL checks that a webhook URL uses https and points to a non-private host.
+// validateWebhookURL checks that a webhook URL uses https, points to a non-private host,
+// and resolves to a non-private IP (anti DNS-rebinding).
 func validateWebhookURL(rawURL string) error {
 	u, err := url.Parse(rawURL)
 	if err != nil {
@@ -110,13 +113,27 @@ func validateWebhookURL(rawURL string) error {
 	}
 	host := u.Hostname()
 	// Block obvious internal hostnames
-	if host == "localhost" || host == "redis" || host == "postgres" || host == "db" || host == "memcached" {
-		return fmt.Errorf("webhook URL hostname %q is not allowed", host)
+	blockedHosts := []string{"localhost", "redis", "postgres", "db", "memcached", "internal", "metadata", "metadata.google.internal"}
+	for _, blocked := range blockedHosts {
+		if host == blocked {
+			return fmt.Errorf("webhook URL hostname %q is not allowed", host)
+		}
 	}
 	// Check if it's a raw IP
 	if ip := net.ParseIP(host); ip != nil {
 		if isPrivateIP(ip) {
 			return fmt.Errorf("webhook URL must not point to private IP %s", ip)
+		}
+	} else {
+		// Resolve DNS and verify all IPs are public (anti DNS-rebinding)
+		ips, err := net.LookupIP(host)
+		if err != nil {
+			return fmt.Errorf("webhook URL hostname %q could not be resolved: %w", host, err)
+		}
+		for _, ip := range ips {
+			if isPrivateIP(ip) {
+				return fmt.Errorf("webhook URL hostname %q resolves to private IP %s", host, ip)
+			}
 		}
 	}
 	return nil
@@ -125,6 +142,40 @@ func validateWebhookURL(rawURL string) error {
 // ValidateWebhookURL is the exported version for use by handlers.
 func ValidateWebhookURL(rawURL string) error {
 	return validateWebhookURL(rawURL)
+}
+
+// ValidateDiscordWebhookURL validates that the URL is a valid Discord webhook URL.
+func ValidateDiscordWebhookURL(rawURL string) error {
+	if err := validateWebhookURL(rawURL); err != nil {
+		return err
+	}
+	if !strings.HasPrefix(rawURL, "https://discord.com/api/webhooks/") &&
+		!strings.HasPrefix(rawURL, "https://discordapp.com/api/webhooks/") {
+		return fmt.Errorf("Discord webhook URL must start with https://discord.com/api/webhooks/")
+	}
+	return nil
+}
+
+// ValidateSlackWebhookURL validates that the URL is a valid Slack webhook URL.
+func ValidateSlackWebhookURL(rawURL string) error {
+	if err := validateWebhookURL(rawURL); err != nil {
+		return err
+	}
+	if !strings.HasPrefix(rawURL, "https://hooks.slack.com/") {
+		return fmt.Errorf("Slack webhook URL must start with https://hooks.slack.com/")
+	}
+	return nil
+}
+
+// telegramBotTokenRegex validates Telegram bot token format: digits:alphanumeric
+var telegramBotTokenRegex = regexp.MustCompile(`^[0-9]+:[A-Za-z0-9_-]+$`)
+
+// ValidateTelegramBotToken validates the Telegram bot token format to prevent URL injection.
+func ValidateTelegramBotToken(token string) error {
+	if !telegramBotTokenRegex.MatchString(token) {
+		return fmt.Errorf("bot token must match format '<numeric_id>:<alphanumeric_secret>'")
+	}
+	return nil
 }
 
 // SendDiscord sends notification via Discord webhook
@@ -233,6 +284,11 @@ func (e *ExternalNotifier) SendTelegram(
 ) error {
 	if botToken == "" || chatID == "" {
 		return fmt.Errorf("telegram bot token or chat ID not configured")
+	}
+
+	// Validate bot token format before constructing URL to prevent path injection
+	if err := ValidateTelegramBotToken(botToken); err != nil {
+		return fmt.Errorf("invalid telegram bot token: %w", err)
 	}
 
 	// Telegram Bot API endpoint

--- a/internal/notify/service/notify_service.go
+++ b/internal/notify/service/notify_service.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"html"
 	"log/slog"
 	"time"
 
@@ -598,14 +599,14 @@ func (s *NotifyService) buildHTMLNotificationMessage(
 		}
 	}
 
-	// Build participant list HTML
+	// Build participant list HTML (escape user-supplied names to prevent XSS)
 	var participantListHTML string
 	if len(participantNames) > 0 {
 		participantListHTML = fmt.Sprintf(`<div class="participant-list">
 			<div class="participant-list-header">%s</div>
 			<ul class="participant-names">`, participantListLabel)
 		for _, name := range participantNames {
-			participantListHTML += fmt.Sprintf(`<li>%s</li>`, name)
+			participantListHTML += fmt.Sprintf(`<li>%s</li>`, html.EscapeString(name))
 		}
 		participantListHTML += `</ul></div>`
 	}
@@ -702,7 +703,7 @@ func (s *NotifyService) buildHTMLNotificationMessage(
 	</div>
 </body>
 </html>
-	`, emoji, messageText, calendarLabel, calendar.Name, dateLabel, dateStr, participantsLabel, transition.NewCount, transition.Threshold, participantListHTML, calendarURL, viewButton, cancelButton)
+	`, emoji, messageText, calendarLabel, html.EscapeString(calendar.Name), dateLabel, dateStr, participantsLabel, transition.NewCount, transition.Threshold, participantListHTML, calendarURL, viewButton, cancelButton)
 
 	return html
 }

--- a/internal/notify/service/participant_email_service.go
+++ b/internal/notify/service/participant_email_service.go
@@ -13,6 +13,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"html"
 	"log/slog"
 	"strings"
 	"text/template"
@@ -248,8 +249,8 @@ func (s *ParticipantEmailService) sendVerificationEmail(
 	return nil
 }
 
-// replaceVar replaces {{.VarName}} with value in a string
+// replaceVar replaces {{.VarName}} with HTML-escaped value in a string
 func replaceVar(str, varName, value string) string {
 	placeholder := "{{." + varName + "}}"
-	return strings.ReplaceAll(str, placeholder, value)
+	return strings.ReplaceAll(str, placeholder, html.EscapeString(value))
 }

--- a/internal/passkey/handlers/passkey_handler.go
+++ b/internal/passkey/handlers/passkey_handler.go
@@ -351,5 +351,19 @@ func (h *PasskeyHandler) FinishAuthentication(w http.ResponseWriter, r *http.Req
 		return
 	}
 
+	// Set refresh token as httpOnly cookie
+	if authResponse.RefreshToken != "" {
+		http.SetCookie(w, &http.Cookie{
+			Name:     "refresh_token",
+			Value:    authResponse.RefreshToken,
+			Path:     "/",
+			HttpOnly: true,
+			Secure:   r.TLS != nil || r.Header.Get("X-Forwarded-Proto") == "https",
+			SameSite: http.SameSiteStrictMode,
+			MaxAge:   7 * 24 * 60 * 60, // 7 days
+		})
+		authResponse.RefreshToken = ""
+	}
+
 	httputil.JSON(w, http.StatusOK, authResponse)
 }

--- a/internal/quota/cloud.go
+++ b/internal/quota/cloud.go
@@ -8,6 +8,7 @@ package quota
 
 import (
 	"context"
+	"encoding/binary"
 	"fmt"
 
 	"github.com/google/uuid"
@@ -88,6 +89,11 @@ func (s *CloudQuotaService) GetServerUsage(ctx context.Context) (int, error) {
 	}
 
 	return count, nil
+}
+
+// QuotaLockKey returns a per-user advisory lock key derived from the user's UUID
+func (s *CloudQuotaService) QuotaLockKey(userID uuid.UUID) int64 {
+	return int64(binary.BigEndian.Uint64(userID[:8]))
 }
 
 // IsOverQuota checks if user has exceeded their calendar limit

--- a/internal/quota/interface.go
+++ b/internal/quota/interface.go
@@ -34,6 +34,10 @@ type QuotaService interface {
 	// This happens when subscription/license expires but user still has more calendars than allowed
 	// When over quota, users should be blocked from creating calendars and accessing ICS feeds
 	IsOverQuota(ctx context.Context, userID uuid.UUID) (bool, error)
+
+	// QuotaLockKey returns the advisory lock key to use for quota enforcement.
+	// Cloud: per-user key derived from userID. Self-hosted: fixed server-wide key.
+	QuotaLockKey(userID uuid.UUID) int64
 }
 
 // LimitInfo contains detailed information about limits and usage

--- a/internal/quota/selfhosted.go
+++ b/internal/quota/selfhosted.go
@@ -89,6 +89,11 @@ func (s *SelfHostedQuotaService) GetServerUsage(ctx context.Context) (int, error
 	return count, nil
 }
 
+// QuotaLockKey returns a fixed server-wide advisory lock key for self-hosted quota enforcement
+func (s *SelfHostedQuotaService) QuotaLockKey(_ uuid.UUID) int64 {
+	return 0x57484E54_4F51 // "WHNTOQ" — fixed key for server-wide lock
+}
+
 // IsOverQuota checks if the server has exceeded its calendar limit
 // For self-hosted, this is a server-wide check (not per-user)
 // When license expires/downgrades, the server may have more calendars than allowed

--- a/internal/shop/handlers/handlers.go
+++ b/internal/shop/handlers/handlers.go
@@ -363,10 +363,17 @@ func (h *Handler) HandleGetOrder(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Verify session ownership: the shop session cookie must be present
+	// Verify session ownership
 	sessionID := h.getSessionID(r)
 	if sessionID == "" {
 		httputil.Error(w, http.StatusUnauthorized, httputil.ErrCodeUnauthorized, "Session required")
+		return
+	}
+
+	// Verify the order belongs to this session
+	ecomOrder, err := h.ecommerceService.GetOrder(r.Context(), orderID)
+	if err != nil || ecomOrder.ShopSessionID == nil || *ecomOrder.ShopSessionID != sessionID {
+		httputil.Error(w, http.StatusNotFound, httputil.ErrCodeNotFound, "Order not found")
 		return
 	}
 
@@ -391,17 +398,23 @@ func (h *Handler) HandleGetOrder(w http.ResponseWriter, r *http.Request) {
 // @Failure 404 {object} httputil.ErrorResponse "Order not found"
 // @Router /api/v1/shop/orders/by-session/{session_id} [get]
 func (h *Handler) HandleGetOrderBySession(w http.ResponseWriter, r *http.Request) {
-	sessionID := chi.URLParam(r, "session_id")
+	stripeSessionID := chi.URLParam(r, "session_id")
 
-	if sessionID == "" {
+	if stripeSessionID == "" {
 		httputil.Error(w, http.StatusBadRequest, httputil.ErrCodeBadRequest, "Session ID is required")
 		return
 	}
 
-	// Get order by session ID via ecommerce service
-	order, err := h.ecommerceService.GetOrderByStripeSessionID(r.Context(), sessionID)
-	if err != nil {
-		h.log.Error("Failed to get order by session", "error", err, "session_id", sessionID)
+	// Verify shop session cookie ownership
+	cookieSessionID := h.getSessionID(r)
+	if cookieSessionID == "" {
+		httputil.Error(w, http.StatusUnauthorized, httputil.ErrCodeUnauthorized, "Session required")
+		return
+	}
+
+	// Get order by Stripe session ID via ecommerce service
+	order, err := h.ecommerceService.GetOrderByStripeSessionID(r.Context(), stripeSessionID)
+	if err != nil || order.ShopSessionID == nil || *order.ShopSessionID != cookieSessionID {
 		httputil.Error(w, http.StatusNotFound, httputil.ErrCodeNotFound, "Order not found")
 		return
 	}
@@ -475,8 +488,16 @@ func (h *Handler) HandleDownloadLicenses(w http.ResponseWriter, r *http.Request)
 	}
 
 	// Verify session ownership
-	if sessionID := h.getSessionID(r); sessionID == "" {
+	sessionID := h.getSessionID(r)
+	if sessionID == "" {
 		httputil.Error(w, http.StatusUnauthorized, httputil.ErrCodeUnauthorized, "Session required")
+		return
+	}
+
+	// Verify the order belongs to this session
+	ecomOrder, err := h.ecommerceService.GetOrder(r.Context(), orderID)
+	if err != nil || ecomOrder.ShopSessionID == nil || *ecomOrder.ShopSessionID != sessionID {
+		httputil.Error(w, http.StatusNotFound, httputil.ErrCodeNotFound, "Order not found")
 		return
 	}
 
@@ -542,7 +563,8 @@ func (h *Handler) HandleDownloadSingleLicense(w http.ResponseWriter, r *http.Req
 	licenseIDStr := chi.URLParam(r, "license_id")
 
 	// Verify session ownership
-	if sessionID := h.getSessionID(r); sessionID == "" {
+	sessionID := h.getSessionID(r)
+	if sessionID == "" {
 		httputil.Error(w, http.StatusUnauthorized, httputil.ErrCodeUnauthorized, "Session required")
 		return
 	}
@@ -556,6 +578,13 @@ func (h *Handler) HandleDownloadSingleLicense(w http.ResponseWriter, r *http.Req
 	licenseID, err := uuid.Parse(licenseIDStr)
 	if err != nil {
 		httputil.Error(w, http.StatusBadRequest, httputil.ErrCodeBadRequest, "Invalid license ID")
+		return
+	}
+
+	// Verify the order belongs to this session
+	ecomOrder, err := h.ecommerceService.GetOrder(r.Context(), orderID)
+	if err != nil || ecomOrder.ShopSessionID == nil || *ecomOrder.ShopSessionID != sessionID {
+		httputil.Error(w, http.StatusNotFound, httputil.ErrCodeNotFound, "Order not found")
 		return
 	}
 

--- a/internal/shop/handlers/handlers.go
+++ b/internal/shop/handlers/handlers.go
@@ -72,6 +72,17 @@ func (h *Handler) getOrCreateSessionID(w http.ResponseWriter, r *http.Request) s
 	return sessionID
 }
 
+// getSessionID retrieves an existing shop session ID from cookie (without creating one).
+func (h *Handler) getSessionID(r *http.Request) string {
+	cookie, err := r.Cookie(sessionCookieName)
+	if err == nil && cookie.Value != "" {
+		if _, err := uuid.Parse(cookie.Value); err == nil {
+			return cookie.Value
+		}
+	}
+	return ""
+}
+
 // HandleGetProducts returns available license products
 // @Summary Get available license products (Cloud only)
 // @Description Returns list of available self-hosted license products (Pro and Enterprise tiers). Cloud-specific endpoint for license sales.
@@ -352,6 +363,13 @@ func (h *Handler) HandleGetOrder(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Verify session ownership: the shop session cookie must be present
+	sessionID := h.getSessionID(r)
+	if sessionID == "" {
+		httputil.Error(w, http.StatusUnauthorized, httputil.ErrCodeUnauthorized, "Session required")
+		return
+	}
+
 	order, err := h.service.GetOrderWithLicenses(r.Context(), orderID)
 	if err != nil {
 		h.log.Error("Failed to get order", "error", err, "order_id", orderID)
@@ -456,6 +474,12 @@ func (h *Handler) HandleDownloadLicenses(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
+	// Verify session ownership
+	if sessionID := h.getSessionID(r); sessionID == "" {
+		httputil.Error(w, http.StatusUnauthorized, httputil.ErrCodeUnauthorized, "Session required")
+		return
+	}
+
 	order, err := h.service.GetOrderWithLicenses(r.Context(), orderID)
 	if err != nil {
 		h.log.Error("Failed to get order for download", "error", err, "order_id", orderID)
@@ -516,6 +540,12 @@ func (h *Handler) HandleDownloadLicenses(w http.ResponseWriter, r *http.Request)
 func (h *Handler) HandleDownloadSingleLicense(w http.ResponseWriter, r *http.Request) {
 	orderIDStr := chi.URLParam(r, "order_id")
 	licenseIDStr := chi.URLParam(r, "license_id")
+
+	// Verify session ownership
+	if sessionID := h.getSessionID(r); sessionID == "" {
+		httputil.Error(w, http.StatusUnauthorized, httputil.ErrCodeUnauthorized, "Session required")
+		return
+	}
 
 	orderID, err := uuid.Parse(orderIDStr)
 	if err != nil {

--- a/internal/shop/handlers/handlers.go
+++ b/internal/shop/handlers/handlers.go
@@ -65,7 +65,7 @@ func (h *Handler) getOrCreateSessionID(w http.ResponseWriter, r *http.Request) s
 		Path:     "/",
 		MaxAge:   sessionMaxAge,
 		HttpOnly: true,
-		Secure:   r.TLS != nil, // Secure flag only if HTTPS
+		Secure:   r.TLS != nil || r.Header.Get("X-Forwarded-Proto") == "https",
 		SameSite: http.SameSiteLaxMode,
 	})
 

--- a/internal/shop/handlers/webhook.go
+++ b/internal/shop/handlers/webhook.go
@@ -119,6 +119,13 @@ func (h *WebhookHandler) handleCheckoutCompleted(ctx context.Context, event stri
 
 	h.log.Info("Processing checkout completion", "session_id", session.ID)
 
+	// Idempotency check: skip if order already exists for this Stripe session
+	existingOrder, err := h.ecommerceService.GetOrderByStripeSessionID(ctx, session.ID)
+	if err == nil && existingOrder != nil {
+		h.log.Info("Order already exists for session, skipping", "session_id", session.ID, "order_id", existingOrder.ID)
+		return
+	}
+
 	// Extract metadata
 	metadata := session.Metadata
 	cartJSON := metadata["cart"]
@@ -176,6 +183,7 @@ func (h *WebhookHandler) handleCheckoutCompleted(ctx context.Context, event stri
 	}
 
 	// Create order
+	shopSessionID := metadata["shop_session_id"]
 	order, err := h.ecommerceService.CreateOrder(ctx, ecommerceModels.CreateOrderRequest{
 		ClientID:        client.ID,
 		AmountCents:     subtotalCents,
@@ -183,6 +191,7 @@ func (h *WebhookHandler) handleCheckoutCompleted(ctx context.Context, event stri
 		VATRate:         vatRate,
 		VATAmountCents:  vatAmount,
 		StripeSessionID: session.ID,
+		ShopSessionID:   shopSessionID,
 		StripePaymentIntent: func() string {
 			if session.PaymentIntent != nil {
 				return session.PaymentIntent.ID

--- a/internal/subscription/service/service.go
+++ b/internal/subscription/service/service.go
@@ -10,6 +10,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"net/url"
 	"regexp"
 	"strconv"
 	"strings"
@@ -37,6 +38,7 @@ type Service struct {
 	vatService     *vatservice.Service
 	stripeKey      string
 	stripePriceIDs map[models.SubscriptionPlan]string
+	appURL         string
 	log            *slog.Logger
 
 	// Cached plan configs fetched from Stripe
@@ -49,6 +51,7 @@ type Config struct {
 	StripeSecretKey  string
 	StripePricePro   string
 	StripePricePower string
+	AppURL           string
 }
 
 // New creates a new subscription service
@@ -59,6 +62,7 @@ func New(repo *repository.SubscriptionRepository, vatService *vatservice.Service
 		repo:       repo,
 		vatService: vatService,
 		stripeKey:  cfg.StripeSecretKey,
+		appURL:     cfg.AppURL,
 		stripePriceIDs: map[models.SubscriptionPlan]string{
 			models.PlanPro:   cfg.StripePricePro,
 			models.PlanPower: cfg.StripePricePower,
@@ -345,6 +349,14 @@ func (s *Service) getInvoiceSettings(ctx context.Context, req models.CreateCheck
 
 // CreateCheckoutSession creates a Stripe checkout session for upgrading or handles subscription updates
 func (s *Service) CreateCheckoutSession(ctx context.Context, userID uuid.UUID, req models.CreateCheckoutRequest) (*models.CreateCheckoutResponse, error) {
+	// Validate redirect URLs against configured app origin
+	if err := s.validateRedirectURL(req.SuccessURL); err != nil {
+		return nil, fmt.Errorf("invalid success_url: %w", err)
+	}
+	if err := s.validateRedirectURL(req.CancelURL); err != nil {
+		return nil, fmt.Errorf("invalid cancel_url: %w", err)
+	}
+
 	// Get or create Stripe customer
 	sub, err := s.repo.GetByUserID(ctx, userID)
 	var stripeCustomerID string
@@ -592,8 +604,28 @@ func (s *Service) updateExistingSubscription(ctx context.Context, userID uuid.UU
 	}, nil
 }
 
+// validateRedirectURL checks that the given URL is under the configured AppURL origin.
+func (s *Service) validateRedirectURL(rawURL string) error {
+	parsed, err := url.Parse(rawURL)
+	if err != nil {
+		return fmt.Errorf("invalid URL: %w", err)
+	}
+	base, err := url.Parse(s.appURL)
+	if err != nil {
+		return fmt.Errorf("invalid app URL config: %w", err)
+	}
+	if parsed.Scheme != base.Scheme || parsed.Host != base.Host {
+		return fmt.Errorf("redirect URL must be under %s", s.appURL)
+	}
+	return nil
+}
+
 // CreatePortalSession creates a Stripe customer portal session
 func (s *Service) CreatePortalSession(ctx context.Context, userID uuid.UUID, req models.CreatePortalRequest) (*models.CreatePortalResponse, error) {
+	if err := s.validateRedirectURL(req.ReturnURL); err != nil {
+		return nil, fmt.Errorf("invalid return_url: %w", err)
+	}
+
 	sub, err := s.repo.GetByUserID(ctx, userID)
 	if err != nil || sub.StripeCustomerID == "" {
 		return nil, fmt.Errorf("no active subscription found")

--- a/internal/vat/service/service.go
+++ b/internal/vat/service/service.go
@@ -12,6 +12,7 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
+	"net/url"
 	"regexp"
 	"sort"
 	"sync"
@@ -426,9 +427,23 @@ func (s *Service) ValidateVATNumber(ctx context.Context, vatNumber string) (*mod
 		}, nil
 	}
 
-	// Extract country code (first 2 characters)
+	// Extract country code (first 2 characters) and validate format
 	countryCode := vatNumber[0:2]
 	vatNumberWithoutCountry := vatNumber[2:]
+
+	// Validate country code is letters only and VAT body is alphanumeric
+	if !regexp.MustCompile(`^[A-Z]{2}$`).MatchString(countryCode) {
+		return &models.ValidateVATResponse{
+			Valid: false,
+			Error: "Invalid country code in VAT number",
+		}, nil
+	}
+	if !regexp.MustCompile(`^[A-Za-z0-9.+*]+$`).MatchString(vatNumberWithoutCountry) {
+		return &models.ValidateVATResponse{
+			Valid: false,
+			Error: "Invalid VAT number format",
+		}, nil
+	}
 
 	// Retry logic for temporary VIES errors
 	maxRetries := 3
@@ -442,10 +457,10 @@ func (s *Service) ValidateVATNumber(ctx context.Context, vatNumber string) (*mod
 			time.Sleep(backoff)
 		}
 
-		// Call VIES API
-		url := fmt.Sprintf("https://ec.europa.eu/taxation_customs/vies/rest-api/ms/%s/vat/%s", countryCode, vatNumberWithoutCountry)
+		// Call VIES API (PathEscape to prevent URL path injection)
+		viesURL := fmt.Sprintf("https://ec.europa.eu/taxation_customs/vies/rest-api/ms/%s/vat/%s", url.PathEscape(countryCode), url.PathEscape(vatNumberWithoutCountry))
 
-		req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, viesURL, nil)
 		if err != nil {
 			return nil, fmt.Errorf("failed to create VIES request: %w", err)
 		}

--- a/migrations/cloud/011_order_shop_session.down.sql
+++ b/migrations/cloud/011_order_shop_session.down.sql
@@ -1,0 +1,2 @@
+DROP INDEX IF EXISTS idx_orders_shop_session_id;
+ALTER TABLE orders DROP COLUMN IF EXISTS shop_session_id;

--- a/migrations/cloud/011_order_shop_session.up.sql
+++ b/migrations/cloud/011_order_shop_session.up.sql
@@ -1,0 +1,3 @@
+-- Add shop_session_id to orders for session ownership validation
+ALTER TABLE orders ADD COLUMN shop_session_id TEXT;
+CREATE INDEX idx_orders_shop_session_id ON orders(shop_session_id) WHERE shop_session_id IS NOT NULL;

--- a/pkg/cache/keys.go
+++ b/pkg/cache/keys.go
@@ -12,6 +12,7 @@ const (
 	PrefixParticipant  = "participant"
 	PrefixAvailability = "availability"
 	PrefixICS          = "ics"
+	PrefixAuth         = "auth"
 )
 
 // Calendar cache keys
@@ -51,6 +52,11 @@ func CalendarRangeSummaryKey(calendarID, start, end string) string {
 // ICS cache keys
 func ICSFeedKey(token string) string {
 	return fmt.Sprintf("%s:feed:%s", PrefixICS, token)
+}
+
+// Auth cache keys
+func UserPasswordChangedKey(userID string) string {
+	return fmt.Sprintf("%s:pwd_changed:%s", PrefixAuth, userID)
 }
 
 // Helper to invalidate all cache keys for a calendar

--- a/pkg/httputil/response.go
+++ b/pkg/httputil/response.go
@@ -46,9 +46,11 @@ func JSON(w http.ResponseWriter, status int, data interface{}) {
 	_ = json.NewEncoder(w).Encode(resp)
 }
 
-// Error writes an error response
+// Error writes an error response with cache-prevention headers
 func Error(w http.ResponseWriter, status int, code, message string) {
 	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("Cache-Control", "no-store, no-cache, must-revalidate")
+	w.Header().Set("Pragma", "no-cache")
 	w.WriteHeader(status)
 
 	resp := Response{
@@ -62,9 +64,11 @@ func Error(w http.ResponseWriter, status int, code, message string) {
 	_ = json.NewEncoder(w).Encode(resp)
 }
 
-// ValidationError writes a validation error response
+// ValidationError writes a validation error response with cache-prevention headers
 func ValidationError(w http.ResponseWriter, errs validator.ValidationErrors) {
 	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("Cache-Control", "no-store, no-cache, must-revalidate")
+	w.Header().Set("Pragma", "no-cache")
 	w.WriteHeader(http.StatusBadRequest)
 
 	resp := Response{

--- a/pkg/httputil/response.go
+++ b/pkg/httputil/response.go
@@ -31,9 +31,11 @@ type ErrorResponse struct {
 	Error   *ErrorInfo `json:"error"`
 }
 
-// JSON writes a JSON response
+// JSON writes a JSON response with cache-prevention headers
 func JSON(w http.ResponseWriter, status int, data interface{}) {
 	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("Cache-Control", "no-store, no-cache, must-revalidate")
+	w.Header().Set("Pragma", "no-cache")
 	w.WriteHeader(status)
 
 	resp := Response{

--- a/pkg/jwt/jwt.go
+++ b/pkg/jwt/jwt.go
@@ -50,6 +50,11 @@ type Manager struct {
 	issuer        string
 }
 
+// AccessExpiry returns the configured access token expiry duration
+func (m *Manager) AccessExpiry() time.Duration {
+	return m.accessExpiry
+}
+
 // NewManager creates a new JWT manager
 func NewManager(cfg *Config) (*Manager, error) {
 	var privateKey *rsa.PrivateKey

--- a/pkg/jwt/jwt.go
+++ b/pkg/jwt/jwt.go
@@ -21,6 +21,7 @@ var (
 	ErrInvalidToken     = errors.New("invalid token")
 	ErrExpiredToken     = errors.New("token has expired")
 	ErrInvalidSignature = errors.New("invalid token signature")
+	ErrMFAPendingToken  = errors.New("mfa pending tokens cannot be used as access tokens")
 )
 
 // Claims represents JWT claims
@@ -147,6 +148,11 @@ func (m *Manager) ValidateAccessToken(tokenString string) (*Claims, error) {
 	claims, ok := token.Claims.(*Claims)
 	if !ok || !token.Valid {
 		return nil, ErrInvalidToken
+	}
+
+	// Reject temporary MFA tokens — they must only be used via ValidateCustomToken
+	if claims.MFAPending {
+		return nil, ErrMFAPendingToken
 	}
 
 	return claims, nil

--- a/pkg/jwt/jwt_test.go
+++ b/pkg/jwt/jwt_test.go
@@ -1,0 +1,93 @@
+package jwt
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"errors"
+	"testing"
+	"time"
+)
+
+// newTestManager creates a Manager with an in-memory RSA key pair for testing.
+func newTestManager(t *testing.T) *Manager {
+	t.Helper()
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("generate RSA key: %v", err)
+	}
+	return &Manager{
+		privateKey:    key,
+		publicKey:     &key.PublicKey,
+		accessExpiry:  15 * time.Minute,
+		refreshExpiry: 7 * 24 * time.Hour,
+		issuer:        "whento-test",
+	}
+}
+
+func TestValidateAccessToken_RejectsMFAPendingToken(t *testing.T) {
+	m := newTestManager(t)
+
+	tempToken, err := m.GenerateCustomToken(map[string]interface{}{
+		"user_id":     "some-user-id",
+		"mfa_pending": true,
+		"exp":         time.Now().Add(5 * time.Minute).Unix(),
+	})
+	if err != nil {
+		t.Fatalf("generate temp token: %v", err)
+	}
+
+	_, err = m.ValidateAccessToken(tempToken)
+	if err == nil {
+		t.Fatal("expected error for mfa_pending token, got nil")
+	}
+	if !errors.Is(err, ErrMFAPendingToken) {
+		t.Fatalf("expected ErrMFAPendingToken, got: %v", err)
+	}
+}
+
+func TestValidateAccessToken_AcceptsNormalToken(t *testing.T) {
+	m := newTestManager(t)
+
+	token, err := m.GenerateAccessToken("user-123", "user@example.com", "user")
+	if err != nil {
+		t.Fatalf("generate access token: %v", err)
+	}
+
+	claims, err := m.ValidateAccessToken(token)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if claims.UserID != "user-123" {
+		t.Errorf("UserID = %q, want %q", claims.UserID, "user-123")
+	}
+	if claims.Email != "user@example.com" {
+		t.Errorf("Email = %q, want %q", claims.Email, "user@example.com")
+	}
+	if claims.Role != "user" {
+		t.Errorf("Role = %q, want %q", claims.Role, "user")
+	}
+	if claims.MFAPending {
+		t.Error("MFAPending should be false for normal tokens")
+	}
+}
+
+func TestValidateCustomToken_AcceptsMFAPendingToken(t *testing.T) {
+	m := newTestManager(t)
+
+	tempToken, err := m.GenerateCustomToken(map[string]interface{}{
+		"user_id":     "victim-id",
+		"mfa_pending": true,
+		"exp":         time.Now().Add(5 * time.Minute).Unix(),
+	})
+	if err != nil {
+		t.Fatalf("generate temp token: %v", err)
+	}
+
+	claims, err := m.ValidateCustomToken(tempToken)
+	if err != nil {
+		t.Fatalf("ValidateCustomToken should accept mfa_pending tokens: %v", err)
+	}
+	if pending, ok := claims["mfa_pending"].(bool); !ok || !pending {
+		t.Error("expected mfa_pending=true in custom token claims")
+	}
+}

--- a/pkg/middleware/middleware.go
+++ b/pkg/middleware/middleware.go
@@ -245,6 +245,11 @@ func SecurityHeaders(next http.Handler) http.Handler {
 			"form-action 'self'"
 		w.Header().Set("Content-Security-Policy", csp)
 
+		// Cross-origin isolation headers
+		w.Header().Set("Cross-Origin-Resource-Policy", "same-origin")
+		w.Header().Set("Cross-Origin-Opener-Policy", "same-origin")
+		w.Header().Set("Cross-Origin-Embedder-Policy", "require-corp")
+
 		// Restrict browser features
 		w.Header().Set("Permissions-Policy", "geolocation=(), microphone=(), camera=(), payment=(), usb=(), magnetometer=(), gyroscope=()")
 

--- a/pkg/middleware/middleware.go
+++ b/pkg/middleware/middleware.go
@@ -13,6 +13,7 @@ import (
 	"github.com/go-chi/chi/v5/middleware"
 	"github.com/google/uuid"
 
+	"github.com/whento/pkg/cache"
 	"github.com/whento/pkg/jwt"
 	"github.com/whento/pkg/logger"
 )
@@ -115,7 +116,7 @@ func CORS(allowedOrigins []string) func(http.Handler) http.Handler {
 }
 
 // Auth creates an authentication middleware
-func Auth(jwtManager *jwt.Manager) func(http.Handler) http.Handler {
+func Auth(jwtManager *jwt.Manager, c cache.Cache) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			authHeader := r.Header.Get("Authorization")
@@ -134,6 +135,18 @@ func Auth(jwtManager *jwt.Manager) func(http.Handler) http.Handler {
 			if err != nil {
 				http.Error(w, "Invalid or expired token", http.StatusUnauthorized)
 				return
+			}
+
+			// Check if token was issued before a password change
+			if c != nil && c.IsEnabled() {
+				var changedAt int64
+				key := cache.UserPasswordChangedKey(claims.UserID)
+				if err := c.Get(r.Context(), key, &changedAt); err == nil {
+					if claims.IssuedAt != nil && claims.IssuedAt.Unix() < changedAt {
+						http.Error(w, "Token invalidated by password change", http.StatusUnauthorized)
+						return
+					}
+				}
 			}
 
 			// Add user info to context

--- a/pkg/middleware/middleware.go
+++ b/pkg/middleware/middleware.go
@@ -235,7 +235,7 @@ func SecurityHeaders(next http.Handler) http.Handler {
 		// Content Security Policy - restricts resources the page can load
 		// This is a strict policy, adjust based on your needs
 		csp := "default-src 'self'; " +
-			"script-src 'self' 'unsafe-inline' 'unsafe-eval'; " + // Allow inline scripts for Vite dev mode
+			"script-src 'self'; " +
 			"style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; " +
 			"font-src 'self' https://fonts.gstatic.com; " +
 			"img-src 'self' data: https:; " +

--- a/pkg/middleware/middleware.go
+++ b/pkg/middleware/middleware.go
@@ -77,26 +77,31 @@ func Recoverer(next http.Handler) http.Handler {
 }
 
 // CORS handles Cross-Origin Resource Sharing
+// allowedOrigins must be explicit origins (e.g. "https://whento.be").
+// Never combine wildcard "*" with credentials — this middleware rejects
+// that misconfiguration by treating "*" as "same-origin only" (no CORS header set).
 func CORS(allowedOrigins []string) func(http.Handler) http.Handler {
+	// Build lookup set for O(1) matching; filter out wildcards.
+	originSet := make(map[string]struct{}, len(allowedOrigins))
+	for _, o := range allowedOrigins {
+		if o != "*" && o != "" {
+			originSet[o] = struct{}{}
+		}
+	}
+
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			origin := r.Header.Get("Origin")
 
-			// Check if origin is allowed
-			allowed := false
-			for _, o := range allowedOrigins {
-				if o == "*" || o == origin {
-					allowed = true
-					break
+			if origin != "" {
+				if _, ok := originSet[origin]; ok {
+					w.Header().Set("Access-Control-Allow-Origin", origin)
+					w.Header().Set("Access-Control-Allow-Credentials", "true")
+					w.Header().Set("Access-Control-Allow-Methods", "GET, POST, PUT, PATCH, DELETE, OPTIONS")
+					w.Header().Set("Access-Control-Allow-Headers", "Accept, Authorization, Content-Type, X-Request-ID")
+					w.Header().Set("Access-Control-Max-Age", "3600")
+					w.Header().Set("Vary", "Origin")
 				}
-			}
-
-			if allowed {
-				w.Header().Set("Access-Control-Allow-Origin", origin)
-				w.Header().Set("Access-Control-Allow-Credentials", "true")
-				w.Header().Set("Access-Control-Allow-Methods", "GET, POST, PUT, PATCH, DELETE, OPTIONS")
-				w.Header().Set("Access-Control-Allow-Headers", "Accept, Authorization, Content-Type, X-Request-ID")
-				w.Header().Set("Access-Control-Max-Age", "3600")
 			}
 
 			if r.Method == http.MethodOptions {

--- a/pkg/middleware/ratelimit.go
+++ b/pkg/middleware/ratelimit.go
@@ -15,22 +15,39 @@ import (
 	"github.com/redis/go-redis/v9"
 )
 
-// trustedProxies holds the set of trusted proxy IPs.
-// Only requests from these IPs will have X-Forwarded-For / X-Real-IP honoured.
-var trustedProxies map[string]struct{}
+// trustedProxyIPs holds exact trusted proxy IPs.
+var trustedProxyIPs map[string]struct{}
 
-// SetTrustedProxies configures the set of trusted proxy IPs.
+// trustedProxyCIDRs holds trusted proxy CIDR ranges.
+var trustedProxyCIDRs []*net.IPNet
+
+// SetTrustedProxies configures the set of trusted proxy IPs and CIDR ranges.
+// Accepts individual IPs (e.g. "10.0.0.1") and CIDR notation (e.g. "172.17.0.0/16").
 // If empty/nil, proxy headers are never trusted (RemoteAddr is always used).
 func SetTrustedProxies(proxies []string) {
 	if len(proxies) == 0 {
-		trustedProxies = nil
+		trustedProxyIPs = nil
+		trustedProxyCIDRs = nil
 		return
 	}
-	tp := make(map[string]struct{}, len(proxies))
+	ips := make(map[string]struct{}, len(proxies))
+	var cidrs []*net.IPNet
 	for _, p := range proxies {
-		tp[strings.TrimSpace(p)] = struct{}{}
+		p = strings.TrimSpace(p)
+		if p == "" {
+			continue
+		}
+		if strings.Contains(p, "/") {
+			_, ipNet, err := net.ParseCIDR(p)
+			if err == nil {
+				cidrs = append(cidrs, ipNet)
+			}
+		} else {
+			ips[p] = struct{}{}
+		}
 	}
-	trustedProxies = tp
+	trustedProxyIPs = ips
+	trustedProxyCIDRs = cidrs
 }
 
 // RateLimiter provides rate limiting functionality
@@ -162,13 +179,26 @@ func remoteAddrIP(r *http.Request) string {
 	return host
 }
 
-// isFromTrustedProxy checks if the remote IP is in the trusted proxy set.
+// isFromTrustedProxy checks if the remote IP is in the trusted proxy set
+// or falls within a trusted CIDR range.
 func isFromTrustedProxy(ip string) bool {
-	if trustedProxies == nil {
+	if trustedProxyIPs == nil && len(trustedProxyCIDRs) == 0 {
 		return false
 	}
-	_, ok := trustedProxies[ip]
-	return ok
+	if _, ok := trustedProxyIPs[ip]; ok {
+		return true
+	}
+	if len(trustedProxyCIDRs) > 0 {
+		parsed := net.ParseIP(ip)
+		if parsed != nil {
+			for _, cidr := range trustedProxyCIDRs {
+				if cidr.Contains(parsed) {
+					return true
+				}
+			}
+		}
+	}
+	return false
 }
 
 // UserKeyFunc returns user ID as rate limit key (requires Auth middleware)

--- a/pkg/middleware/ratelimit.go
+++ b/pkg/middleware/ratelimit.go
@@ -7,11 +7,31 @@ package middleware
 import (
 	"context"
 	"fmt"
+	"net"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/redis/go-redis/v9"
 )
+
+// trustedProxies holds the set of trusted proxy IPs.
+// Only requests from these IPs will have X-Forwarded-For / X-Real-IP honoured.
+var trustedProxies map[string]struct{}
+
+// SetTrustedProxies configures the set of trusted proxy IPs.
+// If empty/nil, proxy headers are never trusted (RemoteAddr is always used).
+func SetTrustedProxies(proxies []string) {
+	if len(proxies) == 0 {
+		trustedProxies = nil
+		return
+	}
+	tp := make(map[string]struct{}, len(proxies))
+	for _, p := range proxies {
+		tp[strings.TrimSpace(p)] = struct{}{}
+	}
+	trustedProxies = tp
+}
 
 // RateLimiter provides rate limiting functionality
 type RateLimiter struct {
@@ -108,18 +128,47 @@ func (rl *RateLimiter) check(ctx context.Context, key string, limit int, window 
 	return count <= int64(limit), remaining, resetAt, nil
 }
 
-// IPKeyFunc returns client IP as rate limit key
+// IPKeyFunc returns the real client IP as rate limit key.
+// X-Forwarded-For and X-Real-IP are only trusted when the direct
+// connection comes from a configured trusted proxy.
 func IPKeyFunc(r *http.Request) string {
-	// Check X-Forwarded-For header first
-	if xff := r.Header.Get("X-Forwarded-For"); xff != "" {
-		return xff
+	remoteIP := remoteAddrIP(r)
+
+	if isFromTrustedProxy(remoteIP) {
+		// Trust the rightmost-minus-one entry in X-Forwarded-For (the one
+		// set by the trusted proxy), or fall back to X-Real-IP.
+		if xff := r.Header.Get("X-Forwarded-For"); xff != "" {
+			parts := strings.Split(xff, ",")
+			// Use the last entry (closest to the proxy that added it)
+			clientIP := strings.TrimSpace(parts[len(parts)-1])
+			if clientIP != "" {
+				return clientIP
+			}
+		}
+		if xri := r.Header.Get("X-Real-IP"); xri != "" {
+			return strings.TrimSpace(xri)
+		}
 	}
-	// Check X-Real-IP header
-	if xri := r.Header.Get("X-Real-IP"); xri != "" {
-		return xri
+
+	return remoteIP
+}
+
+// remoteAddrIP extracts the IP (without port) from r.RemoteAddr.
+func remoteAddrIP(r *http.Request) string {
+	host, _, err := net.SplitHostPort(r.RemoteAddr)
+	if err != nil {
+		return r.RemoteAddr
 	}
-	// Fall back to RemoteAddr
-	return r.RemoteAddr
+	return host
+}
+
+// isFromTrustedProxy checks if the remote IP is in the trusted proxy set.
+func isFromTrustedProxy(ip string) bool {
+	if trustedProxies == nil {
+		return false
+	}
+	_, ok := trustedProxies[ip]
+	return ok
 }
 
 // UserKeyFunc returns user ID as rate limit key (requires Auth middleware)

--- a/pkg/middleware/ratelimit.go
+++ b/pkg/middleware/ratelimit.go
@@ -63,9 +63,10 @@ func NewRateLimiter(client *redis.Client) *RateLimiter {
 
 // RateLimitConfig holds rate limit configuration
 type RateLimitConfig struct {
-	Requests int                          // Number of requests allowed
-	Window   time.Duration                // Time window
-	KeyFunc  func(r *http.Request) string // Function to extract rate limit key
+	Requests   int                          // Number of requests allowed
+	Window     time.Duration                // Time window
+	KeyFunc    func(r *http.Request) string // Function to extract rate limit key
+	FailClosed bool                         // If true, block requests when Redis is unavailable (critical routes)
 }
 
 // Limit creates a rate limiting middleware
@@ -73,8 +74,12 @@ type RateLimitConfig struct {
 func (rl *RateLimiter) Limit(cfg RateLimitConfig) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			// If Redis is not available, skip rate limiting
+			// If Redis is not available, behavior depends on FailClosed setting
 			if rl.client == nil {
+				if cfg.FailClosed {
+					http.Error(w, "Service temporarily unavailable", http.StatusServiceUnavailable)
+					return
+				}
 				next.ServeHTTP(w, r)
 				return
 			}
@@ -87,7 +92,11 @@ func (rl *RateLimiter) Limit(cfg RateLimitConfig) func(http.Handler) http.Handle
 
 			allowed, remaining, resetAt, err := rl.check(r.Context(), key, cfg.Requests, cfg.Window)
 			if err != nil {
-				// On error, allow the request but log it
+				if cfg.FailClosed {
+					http.Error(w, "Service temporarily unavailable", http.StatusServiceUnavailable)
+					return
+				}
+				// On error, allow the request on non-critical routes
 				next.ServeHTTP(w, r)
 				return
 			}

--- a/pkg/participanttoken/token.go
+++ b/pkg/participanttoken/token.go
@@ -1,0 +1,66 @@
+// WhenTo - Collaborative event calendar for self-hosted environments
+// Copyright (C) 2025 WhenTo Contributors
+// SPDX-License-Identifier: BSL-1.1
+
+package participanttoken
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"net/http"
+)
+
+// secret is the HMAC key used to sign participant tokens.
+var secret []byte
+
+// Init sets the HMAC secret. Must be called once at startup.
+// Typically derived from the JWT private key or a dedicated secret.
+func Init(key []byte) {
+	// Derive a fixed-length key using SHA-256
+	h := sha256.Sum256(key)
+	secret = h[:]
+}
+
+// Generate creates an HMAC token for the given participant ID.
+func Generate(participantID string) string {
+	mac := hmac.New(sha256.New, secret)
+	mac.Write([]byte(participantID))
+	return hex.EncodeToString(mac.Sum(nil))
+}
+
+// Validate checks that the token matches the expected HMAC for the participant ID.
+func Validate(participantID, token string) bool {
+	expected := Generate(participantID)
+	return hmac.Equal([]byte(expected), []byte(token))
+}
+
+// FromRequest extracts the participant token from the request.
+// Checks X-Participant-Token header first, then falls back to cookie.
+func FromRequest(r *http.Request, participantID string) string {
+	// Check header first
+	if token := r.Header.Get("X-Participant-Token"); token != "" {
+		return token
+	}
+
+	// Fall back to cookie
+	cookieName := "whento_pt_" + participantID
+	if cookie, err := r.Cookie(cookieName); err == nil {
+		return cookie.Value
+	}
+
+	return ""
+}
+
+// SetCookie sets the participant token cookie on the response.
+func SetCookie(w http.ResponseWriter, r *http.Request, participantID, token string) {
+	http.SetCookie(w, &http.Cookie{
+		Name:     "whento_pt_" + participantID,
+		Value:    token,
+		Path:     "/",
+		MaxAge:   365 * 24 * 60 * 60, // 1 year
+		HttpOnly: true,
+		Secure:   r.TLS != nil || r.Header.Get("X-Forwarded-Proto") == "https",
+		SameSite: http.SameSiteLaxMode,
+	})
+}

--- a/web/embed.go
+++ b/web/embed.go
@@ -7,6 +7,7 @@ package web
 import (
 	"embed"
 	"fmt"
+	"html"
 	"io/fs"
 	"net/http"
 	"strings"
@@ -236,29 +237,29 @@ func (h *SPAHandler) getMetaForRoute(path string) PageMeta {
 }
 
 // injectMetaTags replaces the default meta tags in index.html with route-specific ones
-func (h *SPAHandler) injectMetaTags(html []byte, meta PageMeta) []byte {
-	htmlStr := string(html)
+func (h *SPAHandler) injectMetaTags(htmlContent []byte, meta PageMeta) []byte {
+	htmlStr := string(htmlContent)
 
-	// Replace title (match the existing title tag)
+	// Replace title (match the existing title tag) — HTML-escaped to prevent injection
 	if meta.Title != "" {
 		// Find and replace the existing title tag
 		titleStart := strings.Index(htmlStr, "<title>")
 		if titleStart != -1 {
 			titleEnd := strings.Index(htmlStr[titleStart:], "</title>") + titleStart + 8 // +8 for </title>
 			if titleEnd > titleStart {
-				htmlStr = htmlStr[:titleStart] + "<title>" + meta.Title + "</title>" + htmlStr[titleEnd:]
+				htmlStr = htmlStr[:titleStart] + "<title>" + html.EscapeString(meta.Title) + "</title>" + htmlStr[titleEnd:]
 			}
 		}
 	}
 
-	// Replace existing meta description instead of adding a new one
+	// Replace existing meta description instead of adding a new one — HTML-escaped
 	if meta.Description != "" {
 		descStart := strings.Index(htmlStr, `<meta name="description"`)
 		if descStart != -1 {
 			// Find the end of the existing description tag
 			descEnd := strings.Index(htmlStr[descStart:], ">") + descStart + 1
 			if descEnd > descStart {
-				newDesc := fmt.Sprintf(`<meta name="description" content="%s">`, meta.Description)
+				newDesc := fmt.Sprintf(`<meta name="description" content="%s">`, html.EscapeString(meta.Description))
 				htmlStr = htmlStr[:descStart] + newDesc + htmlStr[descEnd:]
 			}
 		}
@@ -267,7 +268,7 @@ func (h *SPAHandler) injectMetaTags(html []byte, meta PageMeta) []byte {
 	// Find the position after <meta charset="UTF-8" /> to inject our meta tags
 	charsetPos := strings.Index(htmlStr, `<meta charset="UTF-8"`)
 	if charsetPos == -1 {
-		return html // If charset meta not found, return original
+		return htmlContent // If charset meta not found, return original
 	}
 
 	// Find the end of the charset meta tag (looking for />)
@@ -277,17 +278,17 @@ func (h *SPAHandler) injectMetaTags(html []byte, meta PageMeta) []byte {
 	var metaTags strings.Builder
 	metaTags.WriteString("\n    ")
 
-	// Open Graph tags
+	// Open Graph tags — all values are HTML-escaped to prevent XSS via URL path injection
 	if meta.OGTitle != "" {
-		metaTags.WriteString(fmt.Sprintf(`<meta property="og:title" content="%s">`, meta.OGTitle))
+		metaTags.WriteString(fmt.Sprintf(`<meta property="og:title" content="%s">`, html.EscapeString(meta.OGTitle)))
 		metaTags.WriteString("\n    ")
 	}
 	if meta.OGDescription != "" {
-		metaTags.WriteString(fmt.Sprintf(`<meta property="og:description" content="%s">`, meta.OGDescription))
+		metaTags.WriteString(fmt.Sprintf(`<meta property="og:description" content="%s">`, html.EscapeString(meta.OGDescription)))
 		metaTags.WriteString("\n    ")
 	}
 	if meta.OGImage != "" {
-		metaTags.WriteString(fmt.Sprintf(`<meta property="og:image" content="%s">`, meta.OGImage))
+		metaTags.WriteString(fmt.Sprintf(`<meta property="og:image" content="%s">`, html.EscapeString(meta.OGImage)))
 		metaTags.WriteString("\n    ")
 	}
 	metaTags.WriteString(`<meta property="og:type" content="website">`)
@@ -297,21 +298,21 @@ func (h *SPAHandler) injectMetaTags(html []byte, meta PageMeta) []byte {
 	metaTags.WriteString(`<meta name="twitter:card" content="summary_large_image">`)
 	metaTags.WriteString("\n    ")
 	if meta.OGTitle != "" {
-		metaTags.WriteString(fmt.Sprintf(`<meta name="twitter:title" content="%s">`, meta.OGTitle))
+		metaTags.WriteString(fmt.Sprintf(`<meta name="twitter:title" content="%s">`, html.EscapeString(meta.OGTitle)))
 		metaTags.WriteString("\n    ")
 	}
 	if meta.OGDescription != "" {
-		metaTags.WriteString(fmt.Sprintf(`<meta name="twitter:description" content="%s">`, meta.OGDescription))
+		metaTags.WriteString(fmt.Sprintf(`<meta name="twitter:description" content="%s">`, html.EscapeString(meta.OGDescription)))
 		metaTags.WriteString("\n    ")
 	}
 	if meta.OGImage != "" {
-		metaTags.WriteString(fmt.Sprintf(`<meta name="twitter:image" content="%s">`, meta.OGImage))
+		metaTags.WriteString(fmt.Sprintf(`<meta name="twitter:image" content="%s">`, html.EscapeString(meta.OGImage)))
 		metaTags.WriteString("\n    ")
 	}
 
 	// Canonical URL
 	if meta.Canonical != "" {
-		metaTags.WriteString(fmt.Sprintf(`<link rel="canonical" href="%s">`, meta.Canonical))
+		metaTags.WriteString(fmt.Sprintf(`<link rel="canonical" href="%s">`, html.EscapeString(meta.Canonical)))
 		metaTags.WriteString("\n    ")
 	}
 


### PR DESCRIPTION
## Summary

Fixes all vulnerabilities identified across two Shannon security audits.

### CORS & Headers
- Replace wildcard CORS origin with explicit `CORS_ORIGINS` allowlist, add `Vary: Origin` header
- Fix `X-Forwarded-For` spoofing: new `TRUSTED_PROXIES` env var with CIDR support — headers only trusted from configured proxy IPs
- Add Cross-Origin isolation headers (CORP, COOP, COEP)
- Add `Cache-Control: no-store` to all JSON API responses including error responses

### XSS & Injection
- HTML-escape all user-supplied values in email templates (5 `replaceVar` functions)
- HTML-escape user-controlled values in meta/canonical tags
- Sanitize CRLF injection in ICS calendar exports (host header, participant names, timezone, calendar name, description, notes)
- Add input validation and URL path escaping for VIES VAT API calls
- Remove `unsafe-inline` and `unsafe-eval` from CSP `script-src` directive

### Authorization
- Add HMAC-based participant token system for anonymous participant mutation endpoints (availability, recurrence, email)
- Add session cookie verification for shop order access control
- Enforce MFA TOTP check after passkey authentication
- Prevent MFA temp token replay via Redis JTI blocklist
- Revoke all refresh tokens when MFA is enabled to prevent pre-MFA session bypass
- **Fix calendar quota TOCTOU race condition (AUTHZ-VULN-03)** — use `pg_advisory_xact_lock` to serialize quota check + calendar creation
- **Reject MFA pending tokens as access tokens** — `ValidateAccessToken` now explicitly rejects JWTs with `mfa_pending: true`

### Authentication
- Use PostgreSQL advisory lock for atomic first-admin role assignment (TOCTOU fix)
- Prevent account enumeration via generic registration/error messages
- Account lockout after 10 failed login attempts (15min)
- **Invalidate JWT access tokens after password change** via Redis timestamp check in Auth middleware

### Network & Rate Limiting
- SSRF protection: DNS-level private IP blocking + HTTPS enforcement for webhook URLs
- Remove `notify_config` from calendar CRUD to prevent SSRF via unvalidated webhook URLs
- Validate Telegram bot_token format against path injection
- Add rate limiting on `/reset-password`, `/magic-link/verify/{token}`, and `/auth/refresh`
- **Add fail-closed rate limiting on `/verify-email/{token}`** (auth + participant) — 5 req/15min/IP, consistent with other token-verification endpoints (AUTH-VULN-05)
- **Set `FailClosed: true` on 6 auth rate limiters** (`/reset-password`, `/magic-link/request`, `/magic-link/verify`, `/passkey/login/begin`, `/passkey/login/finish`, `/mfa/verify`) to block requests when Redis is unavailable instead of failing open

### Startup Safety
- **Remove hardcoded HMAC fallback secret** for participant tokens — application now refuses to start if JWT private key is unreadable (fatal exit instead of silent degradation with publicly-known secret)

### Other
- Inject annotated tag message into GitHub Release body for breaking change visibility

## Breaking Changes

| Change | Migration |
|--------|-----------|
| CORS no longer accepts wildcard `*` | Set `CORS_ORIGINS` if frontend is on a different domain than `APP_URL` |
| `X-Forwarded-For` ignored by default | Set `TRUSTED_PROXIES` with your reverse proxy IPs/CIDRs |
| Webhook URLs must be HTTPS, no private IPs | Update any internal HTTP webhook URLs |
| Anonymous participant mutations require token | Frontend must send participant token via cookie (automatic) or `X-Participant-Token` header |
| App won't start without JWT private key | Ensure `keys/private.pem` exists and is readable at configured path |

## Test plan

- [x] Verify CORS works with `CORS_ORIGINS` set to the frontend domain
- [x] Verify rate limiting works correctly behind a proxy with `TRUSTED_PROXIES` configured (IP + CIDR)
- [x] Verify webhook creation rejects HTTP URLs and private IPs
- [x] Verify email templates properly escape HTML characters in names
- [x] Verify cookie Secure flag is set when behind a TLS proxy
- [x] Verify MFA temp tokens cannot be replayed
- [x] Verify MFA pending tokens are rejected by `ValidateAccessToken`
- [x] Verify first user registration gets admin role atomically
- [x] Verify ICS exports sanitize CRLF in participant names and host headers
- [x] Verify password change invalidates existing access tokens (401 on old token)
- [x] Verify auth endpoints return 503 (not pass-through) when Redis is down
- [x] Verify `/verify-email/{token}` returns 429 after 5 requests in 15 minutes
- [x] Verify app refuses to start when JWT private key file is missing
- [x] Verify concurrent calendar creation respects quota limits (TOCTOU race condition fixed)
- [x] Run `make build` to confirm compilation