### PR TITLE
chore: upgrade base images and tooling versions

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,9 +1,4 @@
-FROM mcr.microsoft.com/devcontainers/go:1.25-bookworm
-
-# Node.js for the frontend
-RUN curl -fsSL https://deb.nodesource.com/setup_20.x | bash - \
-    && apt-get install -y nodejs \
-    && npm install -g npm@latest
+FROM mcr.microsoft.com/devcontainers/go:1.25-trixie
 
 # Configure Go to use /home/vscode/go
 ENV GOPATH=/home/vscode/go

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -5,7 +5,10 @@
   "workspaceFolder": "/workspace",
   "features": {
     "ghcr.io/devcontainers/features/git:1": {},
-    "ghcr.io/devcontainers/features/github-cli:1": {}
+    "ghcr.io/devcontainers/features/github-cli:1": {},
+    "ghcr.io/devcontainers/features/node:1": {
+      "version": "20"
+    }
   },
   "customizations": {
     "vscode": {
@@ -25,7 +28,6 @@
       "settings": {
         "go.useLanguageServer": true,
         "go.lintTool": "golangci-lint",
-        "go.lintFlags": ["--fast"],
         "editor.formatOnSave": true,
         "editor.defaultFormatter": null,
         "[go]": {

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       dockerfile: Dockerfile
     volumes:
       - ..:/workspace:cached
-      - go-cache:/home/vscode/go
+      - whento-go-cache:/home/vscode/go
     command: sleep infinity
     ports:
       - "8080:8080"   # Application (backend in prod, frontend in dev)
@@ -41,7 +41,7 @@ services:
     ports:
       - "5432:5432"
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U whento"]
+      test: ["CMD-SHELL", "pg_isready -U whento_user -d whento_db"]
       interval: 5s
       timeout: 5s
       retries: 5
@@ -58,4 +58,4 @@ services:
 
 volumes:
   postgres-data:
-  go-cache:
+  whento-go-cache:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,7 +80,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.23'
+          go-version: '1.25'
 
       - name: Install swag CLI
         run: go install github.com/swaggo/swag/cmd/swag@latest
@@ -141,7 +141,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.23'
+          go-version: '1.25'
 
       - name: Download dependencies
         run: go mod download
@@ -174,7 +174,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.23'
+          go-version: '1.25'
 
       - name: Build selfhosted
         run: go build -tags selfhosted -o /dev/null ./cmd/

--- a/build/cloud/Dockerfile
+++ b/build/cloud/Dockerfile
@@ -45,7 +45,7 @@ RUN apk add --no-cache curl && \
     chmod +x /usr/local/bin/migrate
 
 # Runtime stage
-FROM alpine:3.19
+FROM alpine:3.22
 
 # Install runtime dependencies
 RUN apk add --no-cache ca-certificates tzdata openssl netcat-openbsd

--- a/build/selfhosted/Dockerfile
+++ b/build/selfhosted/Dockerfile
@@ -45,7 +45,7 @@ RUN apk add --no-cache curl && \
     chmod +x /usr/local/bin/migrate
 
 # Runtime stage
-FROM alpine:3.19
+FROM alpine:3.22
 
 # Install runtime dependencies
 RUN apk add --no-cache ca-certificates tzdata openssl netcat-openbsd


### PR DESCRIPTION
## Summary
- Bump Alpine base images from 3.19 to 3.22 (cloud & selfhosted Dockerfiles)
- Upgrade Go from 1.23 to 1.25 in CI workflows
- Switch devcontainer to Debian Trixie and install Node.js via devcontainer features
- Fix docker-compose healthcheck and rename go-cache volume

## Test plan
- [x] Verify CI pipelines pass with Go 1.25
- [x] Rebuild devcontainer and confirm Node.js + Go are available
- [x] Build cloud and selfhosted Docker images successfully