### PR TITLE
chore: add OCI metadata labels to container image

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -225,6 +225,12 @@ jobs:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
             type=raw,value=dev
+          labels: |
+            org.opencontainers.image.description=WhenTo - Self-hosted scheduling and calendar application
+            org.opencontainers.image.url=https://github.com/${{ github.repository }}
+            org.opencontainers.image.documentation=https://github.com/${{ github.repository }}#readme
+            org.opencontainers.image.vendor=WhenTo Contributors
+            org.opencontainers.image.licenses=BSL-1.1
 
       - name: Build and push Docker image
         uses: docker/build-push-action@v6

--- a/.github/workflows/release-selfhosted.yml
+++ b/.github/workflows/release-selfhosted.yml
@@ -138,6 +138,12 @@ jobs:
             type=raw,value=${{ steps.version.outputs.version }}
             type=semver,pattern={{version}},value=${{ steps.version.outputs.tag }}
             type=semver,pattern={{major}}.{{minor}},value=${{ steps.version.outputs.tag }}
+          labels: |
+            org.opencontainers.image.description=WhenTo - Self-hosted scheduling and calendar application
+            org.opencontainers.image.url=https://github.com/${{ github.repository }}
+            org.opencontainers.image.documentation=https://github.com/${{ github.repository }}#readme
+            org.opencontainers.image.vendor=WhenTo Contributors
+            org.opencontainers.image.licenses=BSL-1.1
 
       - name: Build and push Docker image
         uses: docker/build-push-action@v6

--- a/build/selfhosted/Dockerfile
+++ b/build/selfhosted/Dockerfile
@@ -47,6 +47,11 @@ RUN apk add --no-cache curl && \
 # Runtime stage
 FROM alpine:3.22
 
+LABEL org.opencontainers.image.title="WhenTo" \
+      org.opencontainers.image.description="Self-hosted scheduling and calendar application" \
+      org.opencontainers.image.vendor="WhenTo Contributors" \
+      org.opencontainers.image.licenses="BSL-1.1"
+
 # Install runtime dependencies
 RUN apk add --no-cache ca-certificates tzdata openssl netcat-openbsd
 


### PR DESCRIPTION
## Summary
- Add OCI labels (description, URL, documentation, vendor, license) to `docker/metadata-action` in release and CI workflows
- Add `LABEL` instructions to the selfhosted Dockerfile for local builds
- Fixes the "No description provided" on the GHCR package page

## Test plan
- [x] Verify workflows pass CI lint/validation
- [ ] On next release tag, confirm GHCR page shows the description
- [x] `make docker-build` locally, then `docker inspect whento:latest --format '{{json .Config.Labels}}'` to verify labels