### PR TITLE
feat: include license sales in accounting and add paginated license list

### DIFF
--- a/cmd/init_cloud.go
+++ b/cmd/init_cloud.go
@@ -171,11 +171,15 @@ func RegisterBillingRoutes(r chi.Router, services *Services, cfg *config.Config,
 	ecommService := ecommerceService.New(ecommRepo, log)
 	ecommHandler := ecommerceHandlers.New(ecommService, log)
 
+	// Wire ecommerce accounting data into subscription service
+	subService.SetEcommerceAccountingProvider(ecommService)
+
 	r.Route("/api/v1/admin/ecommerce", func(r chi.Router) {
 		r.Use(middleware.Auth(jwtManager.(*jwt.Manager), cacheInstance))
 		r.Use(middleware.RequireRole("admin"))
 
-		// License search by support key
+		// License listing and search
+		r.Get("/licenses", ecommHandler.HandleListLicenses)
 		r.Get("/licenses/search", ecommHandler.HandleSearchLicense)
 		r.Get("/licenses/{id}", ecommHandler.HandleGetLicense)
 

--- a/frontend/src/api/ecommerce.ts
+++ b/frontend/src/api/ecommerce.ts
@@ -65,6 +65,11 @@ export interface ListOrdersResponse {
   total: number;
 }
 
+export interface ListLicensesResponse {
+  licenses: SoldLicenseWithDetails[];
+  total: number;
+}
+
 export const ecommerceApi = {
   /**
    * Search for a license by support key (admin only)
@@ -80,6 +85,15 @@ export const ecommerceApi = {
       }
       throw error;
     }
+  },
+
+  /**
+   * List all sold licenses with details (admin only)
+   */
+  async listLicenses(limit = 20, offset = 0): Promise<ListLicensesResponse> {
+    return apiClient.get<ListLicensesResponse>(
+      `/admin/ecommerce/licenses?limit=${limit}&offset=${offset}`
+    );
   },
 
   /**

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -873,7 +873,13 @@
       "completed": "Completed",
       "refunded": "Refunded",
       "failed": "Failed"
-    }
+    },
+    "allLicenses": "All Sold Licenses",
+    "noLicenses": "No licenses sold yet",
+    "paginationPrevious": "Previous",
+    "paginationNext": "Next",
+    "paginationPage": "Page {page} of {totalPages}",
+    "paginationShowing": "Showing {from} to {to} of {total}"
   },
   "license": {
     "title": "License Management",

--- a/frontend/src/locales/fr.json
+++ b/frontend/src/locales/fr.json
@@ -876,7 +876,13 @@
       "completed": "Complétée",
       "refunded": "Remboursée",
       "failed": "Échouée"
-    }
+    },
+    "allLicenses": "Toutes les licences vendues",
+    "noLicenses": "Aucune licence vendue",
+    "paginationPrevious": "Précédent",
+    "paginationNext": "Suivant",
+    "paginationPage": "Page {page} sur {totalPages}",
+    "paginationShowing": "Affichage de {from} à {to} sur {total}"
   },
   "license": {
     "title": "Gestion des licences",

--- a/frontend/src/views/AdminLicenseSearch.vue
+++ b/frontend/src/views/AdminLicenseSearch.vue
@@ -293,12 +293,188 @@
           </div>
         </div>
       </div>
+
+      <!-- All Sold Licenses Table -->
+      <div class="mt-12">
+        <div class="mb-6">
+          <h2 class="font-display text-2xl font-bold text-gray-900 dark:text-white">
+            {{ t('adminLicense.allLicenses') }}
+          </h2>
+        </div>
+
+        <!-- Loading state -->
+        <div v-if="loadingLicenses" class="card">
+          <div class="flex items-center justify-center py-12">
+            <div
+              class="h-8 w-8 animate-spin rounded-full border-4 border-primary-500 border-t-transparent"
+            />
+            <span class="ml-3 text-gray-600 dark:text-gray-400">{{ t('common.loading') }}</span>
+          </div>
+        </div>
+
+        <!-- Licenses table -->
+        <div v-else-if="licenses.length > 0" class="card overflow-hidden p-0">
+          <div class="overflow-x-auto">
+            <table class="w-full">
+              <thead
+                class="border-b border-gray-200 bg-gray-50 dark:border-gray-700 dark:bg-gray-900"
+              >
+                <tr>
+                  <th
+                    class="px-6 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500 dark:text-gray-400"
+                  >
+                    {{ t('adminLicense.supportKey') }}
+                  </th>
+                  <th
+                    class="px-6 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500 dark:text-gray-400"
+                  >
+                    {{ t('adminLicense.tier') }}
+                  </th>
+                  <th
+                    class="px-6 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500 dark:text-gray-400"
+                  >
+                    {{ t('adminLicense.issuedTo') }}
+                  </th>
+                  <th
+                    class="px-6 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500 dark:text-gray-400"
+                  >
+                    {{ t('adminLicense.clientEmail') }}
+                  </th>
+                  <th
+                    class="px-6 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500 dark:text-gray-400"
+                  >
+                    {{ t('adminLicense.orderStatus') }}
+                  </th>
+                  <th
+                    class="px-6 py-3 text-right text-xs font-medium uppercase tracking-wider text-gray-500 dark:text-gray-400"
+                  >
+                    {{ t('adminLicense.orderAmount') }}
+                  </th>
+                  <th
+                    class="px-6 py-3 text-right text-xs font-medium uppercase tracking-wider text-gray-500 dark:text-gray-400"
+                  >
+                    {{ t('adminLicense.orderDate') }}
+                  </th>
+                </tr>
+              </thead>
+              <tbody
+                class="divide-y divide-gray-200 bg-white dark:divide-gray-700 dark:bg-gray-800"
+              >
+                <tr
+                  v-for="lic in licenses"
+                  :key="lic.id"
+                  class="hover:bg-gray-50 dark:hover:bg-gray-700/50"
+                >
+                  <td class="whitespace-nowrap px-6 py-4 font-mono text-sm text-gray-900 dark:text-white">
+                    {{ lic.support_key }}
+                  </td>
+                  <td class="whitespace-nowrap px-6 py-4">
+                    <span
+                      :class="[
+                        'inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium',
+                        getTierClass(lic.license.tier),
+                      ]"
+                    >
+                      {{ lic.license.tier }}
+                    </span>
+                  </td>
+                  <td class="whitespace-nowrap px-6 py-4 text-sm text-gray-900 dark:text-white">
+                    {{ lic.license.issued_to }}
+                  </td>
+                  <td class="whitespace-nowrap px-6 py-4 text-sm text-gray-500 dark:text-gray-400">
+                    {{ lic.client?.email }}
+                  </td>
+                  <td class="whitespace-nowrap px-6 py-4">
+                    <span
+                      v-if="lic.order"
+                      :class="[
+                        'inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium',
+                        getStatusClass(lic.order.status),
+                      ]"
+                    >
+                      {{ t(`adminLicense.status.${lic.order.status}`) }}
+                    </span>
+                  </td>
+                  <td
+                    class="whitespace-nowrap px-6 py-4 text-right font-mono text-sm text-gray-900 dark:text-white"
+                  >
+                    {{ lic.order ? formatAmount(lic.order.amount_cents) : '-' }}
+                  </td>
+                  <td
+                    class="whitespace-nowrap px-6 py-4 text-right text-sm text-gray-500 dark:text-gray-400"
+                  >
+                    {{ formatDate(lic.created_at) }}
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+
+          <!-- Pagination -->
+          <div
+            class="flex items-center justify-between border-t border-gray-200 bg-gray-50 px-6 py-3 dark:border-gray-700 dark:bg-gray-900"
+          >
+            <div class="text-sm text-gray-600 dark:text-gray-400">
+              {{
+                t('adminLicense.paginationShowing', {
+                  from: (currentPage - 1) * pageSize + 1,
+                  to: Math.min(currentPage * pageSize, totalLicenses),
+                  total: totalLicenses,
+                })
+              }}
+            </div>
+            <div class="flex items-center gap-4">
+              <span class="text-sm text-gray-600 dark:text-gray-400">
+                {{ t('adminLicense.paginationPage', { page: currentPage, totalPages }) }}
+              </span>
+              <div class="flex gap-2">
+                <button
+                  :disabled="currentPage <= 1"
+                  class="btn btn-secondary px-3 py-1 text-sm"
+                  @click="goToPage(currentPage - 1)"
+                >
+                  {{ t('adminLicense.paginationPrevious') }}
+                </button>
+                <button
+                  :disabled="currentPage >= totalPages"
+                  class="btn btn-secondary px-3 py-1 text-sm"
+                  @click="goToPage(currentPage + 1)"
+                >
+                  {{ t('adminLicense.paginationNext') }}
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <!-- Empty state -->
+        <div v-else class="card">
+          <div class="text-center py-12">
+            <svg
+              class="mx-auto h-12 w-12 text-gray-400"
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+            >
+              <path
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+                d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"
+              />
+            </svg>
+            <h3 class="mt-2 text-sm font-medium text-gray-900 dark:text-white">
+              {{ t('adminLicense.noLicenses') }}
+            </h3>
+          </div>
+        </div>
+      </div>
     </div>
   </div>
 </template>
 
 <script setup lang="ts">
-import { ref } from 'vue';
+import { ref, computed, onMounted } from 'vue';
 import { useI18n } from 'vue-i18n';
 import { useToastStore } from '@/stores/toast';
 import { useAuthStore } from '@/stores/auth';
@@ -312,6 +488,42 @@ const supportKey = ref('');
 const searching = ref(false);
 const searched = ref(false);
 const license = ref<SoldLicenseWithDetails | null>(null);
+
+// License list state
+const licenses = ref<SoldLicenseWithDetails[]>([]);
+const totalLicenses = ref(0);
+const currentPage = ref(1);
+const pageSize = 20;
+const loadingLicenses = ref(false);
+
+const totalPages = computed(() => {
+  return Math.max(1, Math.ceil(totalLicenses.value / pageSize));
+});
+
+onMounted(() => {
+  loadLicenses();
+});
+
+async function loadLicenses() {
+  loadingLicenses.value = true;
+  try {
+    const offset = (currentPage.value - 1) * pageSize;
+    const resp = await ecommerceApi.listLicenses(pageSize, offset);
+    licenses.value = resp.licenses || [];
+    totalLicenses.value = resp.total;
+  } catch (err: any) {
+    console.error('Failed to load licenses:', err);
+    toastStore.error(err.message || t('errors.generic'));
+  } finally {
+    loadingLicenses.value = false;
+  }
+}
+
+function goToPage(page: number) {
+  if (page < 1 || page > totalPages.value) return;
+  currentPage.value = page;
+  loadLicenses();
+}
 
 async function searchLicense() {
   if (!supportKey.value.trim()) return;

--- a/internal/ecommerce/handlers/handlers.go
+++ b/internal/ecommerce/handlers/handlers.go
@@ -219,6 +219,33 @@ func (h *Handler) HandleGetOrder(w http.ResponseWriter, r *http.Request) {
 	httputil.JSON(w, http.StatusOK, order)
 }
 
+// HandleListLicenses retrieves all sold licenses with details and pagination
+//
+//	@Summary		List licenses (Cloud only, Admin)
+//	@Description	Retrieves all sold licenses with client and order details. Admin-only endpoint. Cloud-specific.
+//	@Tags			E-Commerce
+//	@Produce		json
+//	@Security		BearerAuth
+//	@Param			limit	query		int	false	"Number of results per page (default: 20)"
+//	@Param			offset	query		int	false	"Offset for pagination (default: 0)"
+//	@Success		200		{object}	object	"List of licenses with details"
+//	@Failure		401		{object}	httputil.ErrorResponse	"User not authenticated"
+//	@Failure		403		{object}	httputil.ErrorResponse	"Admin role required"
+//	@Failure		500		{object}	httputil.ErrorResponse	"Internal server error"
+//	@Router			/api/v1/admin/ecommerce/licenses [get]
+func (h *Handler) HandleListLicenses(w http.ResponseWriter, r *http.Request) {
+	limit, offset := getPagination(r)
+
+	resp, err := h.service.ListSoldLicensesWithDetails(r.Context(), limit, offset)
+	if err != nil {
+		h.log.Error("Failed to list licenses", "error", err)
+		httputil.Error(w, http.StatusInternalServerError, httputil.ErrCodeInternal, "Failed to list licenses")
+		return
+	}
+
+	httputil.JSON(w, http.StatusOK, resp)
+}
+
 // getPagination extracts pagination parameters from request
 func getPagination(r *http.Request) (limit, offset int) {
 	limit = 20

--- a/internal/ecommerce/models/models.go
+++ b/internal/ecommerce/models/models.go
@@ -127,3 +127,17 @@ type CreateLicenseRequest struct {
 	OrderID uuid.UUID       `json:"order_id" validate:"required"`
 	License json.RawMessage `json:"license" validate:"required"`
 }
+
+// OrderAccountingRow represents aggregated order data for a country (used by accounting)
+type OrderAccountingRow struct {
+	Country        string `json:"country" db:"country"`
+	AmountCents    int    `json:"amount_cents" db:"total_amount_cents"`
+	VATAmountCents int    `json:"vat_amount_cents" db:"total_vat_amount_cents"`
+	OrderCount     int    `json:"order_count" db:"order_count"`
+}
+
+// ListLicensesResponse contains a paginated list of sold licenses with details
+type ListLicensesResponse struct {
+	Licenses []SoldLicenseWithDetails `json:"licenses"`
+	Total    int                      `json:"total"`
+}

--- a/internal/ecommerce/repository/repository.go
+++ b/internal/ecommerce/repository/repository.go
@@ -9,6 +9,7 @@ package repository
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
@@ -442,6 +443,83 @@ func (r *EcommerceRepository) ListSoldLicenses(ctx context.Context, limit, offse
 			return nil, 0, fmt.Errorf("failed to scan sold license: %w", err)
 		}
 		licenses = append(licenses, license)
+	}
+
+	return licenses, total, nil
+}
+
+// GetOrderAccountingData returns order revenue aggregated by country for a time period
+func (r *EcommerceRepository) GetOrderAccountingData(ctx context.Context, startTime, endTime time.Time) ([]models.OrderAccountingRow, error) {
+	query := `
+		SELECT country, SUM(amount_cents)::int AS total_amount_cents,
+		       COALESCE(SUM(vat_amount_cents), 0)::int AS total_vat_amount_cents,
+		       COUNT(*)::int AS order_count
+		FROM orders
+		WHERE status = 'completed' AND created_at >= $1 AND created_at < $2 AND country IS NOT NULL
+		GROUP BY country
+	`
+
+	rows, err := r.db.Query(ctx, query, startTime, endTime)
+	if err != nil {
+		return nil, fmt.Errorf("failed to query order accounting data: %w", err)
+	}
+	defer rows.Close()
+
+	var result []models.OrderAccountingRow
+	for rows.Next() {
+		var row models.OrderAccountingRow
+		if err := rows.Scan(&row.Country, &row.AmountCents, &row.VATAmountCents, &row.OrderCount); err != nil {
+			return nil, fmt.Errorf("failed to scan order accounting row: %w", err)
+		}
+		result = append(result, row)
+	}
+
+	return result, nil
+}
+
+// ListSoldLicensesWithDetails retrieves all sold licenses with client and order info, paginated
+func (r *EcommerceRepository) ListSoldLicensesWithDetails(ctx context.Context, limit, offset int) ([]models.SoldLicenseWithDetails, int, error) {
+	countQuery := `SELECT COUNT(*) FROM sold_licenses`
+	var total int
+	if err := r.db.QueryRow(ctx, countQuery).Scan(&total); err != nil {
+		return nil, 0, fmt.Errorf("failed to count sold licenses: %w", err)
+	}
+
+	query := `
+		SELECT
+			sl.id, sl.order_id, sl.support_key, sl.license, sl.created_at, sl.updated_at,
+			o.id, o.client_id, o.amount_cents, o.payment_method, o.stripe_payment_id, o.status, o.created_at, o.updated_at,
+			c.id, c.name, c.email, c.company, c.vat_number, c.address, c.country, c.created_at, c.updated_at
+		FROM sold_licenses sl
+		JOIN orders o ON sl.order_id = o.id
+		JOIN clients c ON o.client_id = c.id
+		ORDER BY sl.created_at DESC
+		LIMIT $1 OFFSET $2
+	`
+
+	rows, err := r.db.Query(ctx, query, limit, offset)
+	if err != nil {
+		return nil, 0, fmt.Errorf("failed to list sold licenses with details: %w", err)
+	}
+	defer rows.Close()
+
+	var licenses []models.SoldLicenseWithDetails
+	for rows.Next() {
+		var result models.SoldLicenseWithDetails
+		var order models.Order
+		var client models.Client
+
+		if err := rows.Scan(
+			&result.ID, &result.OrderID, &result.SupportKey, &result.License, &result.CreatedAt, &result.UpdatedAt,
+			&order.ID, &order.ClientID, &order.AmountCents, &order.PaymentMethod, &order.StripePaymentID, &order.Status, &order.CreatedAt, &order.UpdatedAt,
+			&client.ID, &client.Name, &client.Email, &client.Company, &client.VATNumber, &client.Address, &client.Country, &client.CreatedAt, &client.UpdatedAt,
+		); err != nil {
+			return nil, 0, fmt.Errorf("failed to scan sold license with details: %w", err)
+		}
+
+		result.Order = &order
+		result.Client = &client
+		licenses = append(licenses, result)
 	}
 
 	return licenses, total, nil

--- a/internal/ecommerce/service/service.go
+++ b/internal/ecommerce/service/service.go
@@ -11,6 +11,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log/slog"
+	"time"
 
 	"github.com/google/uuid"
 
@@ -324,4 +325,33 @@ func (s *Service) GetLicensesByOrderID(ctx context.Context, orderID uuid.UUID) (
 		return nil, fmt.Errorf("failed to get licenses by order ID: %w", err)
 	}
 	return licenses, nil
+}
+
+// GetOrderAccountingData returns order revenue aggregated by country for a time period
+func (s *Service) GetOrderAccountingData(ctx context.Context, startTime, endTime time.Time) ([]models.OrderAccountingRow, error) {
+	return s.repo.GetOrderAccountingData(ctx, startTime, endTime)
+}
+
+// ListSoldLicensesWithDetails retrieves all sold licenses with client and order info, paginated
+func (s *Service) ListSoldLicensesWithDetails(ctx context.Context, limit, offset int) (*models.ListLicensesResponse, error) {
+	if limit <= 0 {
+		limit = 20
+	}
+	if limit > 100 {
+		limit = 100
+	}
+
+	licenses, total, err := s.repo.ListSoldLicensesWithDetails(ctx, limit, offset)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list sold licenses with details: %w", err)
+	}
+
+	if licenses == nil {
+		licenses = []models.SoldLicenseWithDetails{}
+	}
+
+	return &models.ListLicensesResponse{
+		Licenses: licenses,
+		Total:    total,
+	}, nil
 }

--- a/internal/subscription/service/service.go
+++ b/internal/subscription/service/service.go
@@ -27,10 +27,16 @@ import (
 	"github.com/stripe/stripe-go/v84/subscription"
 
 	pkgmodels "github.com/whento/pkg/models"
+	ecommerceModels "github.com/whento/whento/internal/ecommerce/models"
 	"github.com/whento/whento/internal/subscription/models"
 	"github.com/whento/whento/internal/subscription/repository"
 	vatservice "github.com/whento/whento/internal/vat/service"
 )
+
+// EcommerceAccountingProvider provides ecommerce order data for accounting
+type EcommerceAccountingProvider interface {
+	GetOrderAccountingData(ctx context.Context, startTime, endTime time.Time) ([]ecommerceModels.OrderAccountingRow, error)
+}
 
 // Service handles subscription business logic
 type Service struct {
@@ -44,6 +50,9 @@ type Service struct {
 	// Cached plan configs fetched from Stripe
 	planConfigsMu sync.RWMutex
 	planConfigs   map[models.SubscriptionPlan]models.PlanConfig
+
+	// Optional ecommerce accounting data provider
+	ecommerceAccounting EcommerceAccountingProvider
 }
 
 // Config holds the configuration for the subscription service
@@ -78,6 +87,11 @@ func New(repo *repository.SubscriptionRepository, vatService *vatservice.Service
 	}
 
 	return s
+}
+
+// SetEcommerceAccountingProvider sets the ecommerce accounting data provider
+func (s *Service) SetEcommerceAccountingProvider(provider EcommerceAccountingProvider) {
+	s.ecommerceAccounting = provider
 }
 
 // GetPlanConfig returns the configuration for a plan (fetched from Stripe)
@@ -838,6 +852,31 @@ func (s *Service) GetAccountingData(ctx context.Context, req models.AccountingRe
 
 	if err := iter.Err(); err != nil {
 		return nil, fmt.Errorf("failed to fetch invoices from Stripe: %w", err)
+	}
+
+	// Merge ecommerce order data (license sales) if provider is available
+	if s.ecommerceAccounting != nil {
+		orderRows, err := s.ecommerceAccounting.GetOrderAccountingData(ctx, startTime, endTime)
+		if err != nil {
+			s.log.Error("Failed to fetch ecommerce accounting data, continuing with Stripe data only", "error", err)
+		} else {
+			for _, row := range orderRows {
+				country := row.Country
+				if _, exists := countryData[country]; !exists {
+					countryData[country] = &models.AccountingCountryRow{
+						Country:     country,
+						CountryName: s.getCountryName(country),
+					}
+				}
+				orderHT := float64(row.AmountCents-row.VATAmountCents) / 100.0
+				orderVAT := float64(row.VATAmountCents) / 100.0
+				orderTTC := float64(row.AmountCents) / 100.0
+				countryData[country].RevenueHT += orderHT
+				countryData[country].VAT += orderVAT
+				countryData[country].RevenueTTC += orderTTC
+				countryData[country].InvoiceCount += row.OrderCount
+			}
+		}
 	}
 
 	// Convert map to slice and calculate totals


### PR DESCRIPTION
## Summary
- **Accounting** now aggregates both Stripe subscription invoices and ecommerce license sales (completed orders) by country, giving a complete revenue view
- **Admin license view** (`/admin/licenses`) displays all sold licenses in a paginated table below the existing support-key search, with tier, client, order status, amount and date columns
- Fixed null licenses array crash when no licenses exist

## Test plan
- [x] Navigate to `/admin/accounting`, verify totals include both subscription and license revenue
- [x] Navigate to `/admin/licenses`, verify the paginated table loads below the search form
- [x] With no licenses in DB, verify the empty state renders correctly (no crash)
- [x] Test pagination controls (previous/next) with multiple pages of licenses
- [x] Verify both endpoints require admin authentication