### PR TITLE
feat(calendar): add list view for participant calendar

### DIFF
--- a/frontend/src/components/CalendarGrid.vue
+++ b/frontend/src/components/CalendarGrid.vue
@@ -34,11 +34,13 @@
         <!-- View mode selector (only shown for first month) -->
         <select
           v-if="props.showNavigation !== false"
-          v-model="viewMode"
+          :value="viewMode"
           class="text-xs md:text-sm px-2 py-1 rounded border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 text-gray-700 dark:text-gray-300 focus:outline-none focus:ring-2 focus:ring-primary-500"
+          @change="handleViewModeSelect"
         >
           <option value="classic">{{ t('calendar.viewClassic') }}</option>
           <option value="compact">{{ t('calendar.viewCompact') }}</option>
+          <option value="list">{{ t('calendar.listView') }}</option>
         </select>
       </div>
 
@@ -799,6 +801,7 @@ import { getWeekStartDay } from '@/i18n';
 import { availabilitiesApi } from '@/api/availabilities';
 import type { Availability, RecurrenceWithExceptions } from '@/types';
 import { useDateValidation, clearHolidaysCache } from '@/composables/useDateValidation';
+import { formatDateISO } from '@/utils/dateFormatting';
 import TimeSelect from '@/components/TimeSelect.vue';
 
 interface Props {
@@ -828,6 +831,7 @@ interface Emits {
   (e: 'add-exception', recurrenceId: string, date: string): void;
   (e: 'month-change', year: number, month: number): void;
   (e: 'availability-updated'): void;
+  (e: 'view-style-change', style: 'classic' | 'list'): void;
 }
 
 const props = defineProps<Props>();
@@ -906,6 +910,18 @@ watch(viewMode, newMode => {
     window.dispatchEvent(new CustomEvent('calendar-view-mode-change', { detail: newMode }));
   }
 });
+
+// Handle view mode selection from dropdown (includes 'list' which is handled by parent)
+function handleViewModeSelect(event: Event) {
+  const value = (event.target as HTMLSelectElement).value;
+  if (value === 'list') {
+    // Reset the select to current mode (list is rendered by parent, not CalendarGrid)
+    (event.target as HTMLSelectElement).value = viewMode.value;
+    emit('view-style-change', 'list');
+  } else {
+    viewMode.value = value as 'classic' | 'compact';
+  }
+}
 
 const isCompactMode = computed(() => viewMode.value === 'compact');
 
@@ -1061,7 +1077,7 @@ const calendarDays = computed((): CalendarDay[] => {
     const date = daysInPrevMonth - i;
     const dateObj = new Date(year, month - 1, date);
     dateObj.setHours(0, 0, 0, 0);
-    const dateString = formatDateString(dateObj);
+    const dateString = formatDateISO(dateObj);
     const isPast = dateObj < today;
     const timezone = props.timezone || 'Europe/Paris';
 
@@ -1087,7 +1103,7 @@ const calendarDays = computed((): CalendarDay[] => {
   for (let date = 1; date <= daysInMonth; date++) {
     const dateObj = new Date(year, month, date);
     dateObj.setHours(0, 0, 0, 0);
-    const dateString = formatDateString(dateObj);
+    const dateString = formatDateISO(dateObj);
     const dayOfWeek = dateObj.getDay();
     const isPast = dateObj < today;
 
@@ -1151,7 +1167,7 @@ const calendarDays = computed((): CalendarDay[] => {
   for (let date = 1; date <= remainingDays; date++) {
     const dateObj = new Date(year, month + 1, date);
     dateObj.setHours(0, 0, 0, 0);
-    const dateString = formatDateString(dateObj);
+    const dateString = formatDateISO(dateObj);
     const isPast = dateObj < today;
     const timezone = props.timezone || 'Europe/Paris';
 
@@ -1175,13 +1191,6 @@ const calendarDays = computed((): CalendarDay[] => {
 
   return days;
 });
-
-function formatDateString(date: Date): string {
-  const year = date.getFullYear();
-  const month = String(date.getMonth() + 1).padStart(2, '0');
-  const day = String(date.getDate()).padStart(2, '0');
-  return `${year}-${month}-${day}`;
-}
 
 function previousMonth() {
   const newDate = new Date(currentDate.value.getFullYear(), currentDate.value.getMonth() - 1, 1);

--- a/frontend/src/components/CalendarListView.vue
+++ b/frontend/src/components/CalendarListView.vue
@@ -1,0 +1,431 @@
+<!--
+  WhenTo - Collaborative event calendar for self-hosted environments
+  Copyright (C) 2025 WhenTo Contributors
+  SPDX-License-Identifier: BSL-1.1
+-->
+
+<template>
+  <div class="calendar-list-view">
+    <!-- Navigation header -->
+    <div class="mb-4 flex items-center justify-between gap-2">
+      <button
+        class="btn btn-ghost p-2 md:p-2 min-h-11 md:min-h-0 min-w-11 md:min-w-0"
+        :title="
+          props.displayMode === 'week'
+            ? t('calendar.previousWeek', 'Previous week')
+            : t('calendar.previousMonth', 'Previous month')
+        "
+        @click="navigatePrevious"
+      >
+        <svg class="h-6 w-6 md:h-5 md:w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+          <path
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="2"
+            d="M15 19l-7-7 7-7"
+          />
+        </svg>
+      </button>
+
+      <div class="flex flex-col items-center gap-1 flex-1 px-2">
+        <h3
+          class="font-display text-base md:text-lg font-semibold text-gray-900 dark:text-white text-center"
+        >
+          {{ rangeLabel }}
+        </h3>
+        <select
+          value="list"
+          class="text-xs md:text-sm px-2 py-1 rounded border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 text-gray-700 dark:text-gray-300 focus:outline-none focus:ring-2 focus:ring-primary-500"
+          @change="handleViewStyleSelect"
+        >
+          <option value="classic">{{ t('calendar.viewClassic') }}</option>
+          <option v-if="props.displayMode === 'month'" value="compact">{{ t('calendar.viewCompact') }}</option>
+          <option value="list">{{ t('calendar.listView') }}</option>
+        </select>
+      </div>
+
+      <button
+        class="btn btn-ghost p-2 md:p-2 min-h-[44px] md:min-h-0 min-w-[44px] md:min-w-0"
+        :title="
+          props.displayMode === 'week'
+            ? t('calendar.nextWeek', 'Next week')
+            : t('calendar.nextMonth', 'Next month')
+        "
+        @click="navigateNext"
+      >
+        <svg class="h-6 w-6 md:h-5 md:w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" />
+        </svg>
+      </button>
+    </div>
+
+    <!-- Empty state -->
+    <div
+      v-if="actionableDays.length === 0"
+      class="py-12 text-center text-gray-500 dark:text-gray-400"
+    >
+      <p class="text-sm">{{ t('calendar.noActionableDays', 'No available days in this period') }}</p>
+    </div>
+
+    <!-- Day cards list -->
+    <div v-else class="space-y-2">
+      <button
+        v-for="day in actionableDays"
+        :key="day.dateString"
+        type="button"
+        class="w-full text-left rounded-lg border p-3 md:p-4 transition-all cursor-pointer"
+        :class="[
+          day.meetsThreshold
+            ? 'border-green-200 bg-green-50 hover:border-green-300 hover:shadow-sm dark:border-green-700 dark:bg-green-900/20 dark:hover:border-green-600'
+            : day.hasAvailability
+              ? 'border-primary-200 bg-primary-50 hover:border-primary-300 hover:shadow-sm dark:border-primary-700 dark:bg-primary-900/20 dark:hover:border-primary-600'
+              : day.hasRecurrence
+                ? 'border-blue-200 bg-blue-50 hover:border-blue-300 hover:shadow-sm dark:border-blue-700 dark:bg-blue-900/20 dark:hover:border-blue-600'
+                : 'border-gray-200 bg-white hover:border-primary-300 hover:shadow-sm dark:border-gray-700 dark:bg-gray-800 dark:hover:border-primary-600',
+          day.isToday && 'ring-2 ring-primary-500 ring-offset-1',
+          day.isHighlighted &&
+            'ring-2 ring-amber-400 ring-offset-1 dark:ring-amber-500 dark:ring-offset-gray-900',
+        ]"
+        @click="emit('day-click', day.dateString)"
+      >
+        <div class="flex items-center justify-between gap-3">
+          <!-- Left: date info -->
+          <div class="flex flex-col min-w-0">
+            <div class="flex items-center gap-2 flex-wrap">
+              <span class="font-semibold text-sm md:text-base text-gray-900 dark:text-white">
+                {{ day.dayName }}
+              </span>
+              <span class="text-sm text-gray-600 dark:text-gray-400">
+                {{ day.dateFormatted }}
+              </span>
+              <span
+                v-if="day.isToday"
+                class="inline-flex items-center rounded-full bg-primary-100 px-2 py-0.5 text-xs font-medium text-primary-700 dark:bg-primary-900/40 dark:text-primary-300"
+              >
+                {{ t('calendar.today', 'Today') }}
+              </span>
+            </div>
+            <!-- Holiday / holiday eve badges -->
+            <div v-if="day.isHoliday || day.isHolidayEve" class="mt-1 flex items-center gap-1">
+              <span
+                v-if="day.isHoliday"
+                class="inline-flex items-center rounded-full bg-orange-100 px-2 py-0.5 text-xs font-medium text-orange-700 dark:bg-orange-900/40 dark:text-orange-300"
+              >
+                {{ day.holidayName || t('calendar.publicHoliday', 'Public holiday') }}
+              </span>
+              <span
+                v-else-if="day.isHolidayEve"
+                class="inline-flex items-center rounded-full bg-purple-100 px-2 py-0.5 text-xs font-medium text-purple-700 dark:bg-purple-900/40 dark:text-purple-300"
+              >
+                {{ t('calendar.holidayEve', 'Holiday eve') }}
+              </span>
+            </div>
+            <!-- Time info for availabilities -->
+            <div v-if="day.timeLabel" class="mt-1">
+              <span class="text-xs text-gray-500 dark:text-gray-400">{{ day.timeLabel }}</span>
+            </div>
+          </div>
+
+          <!-- Right: availability status + participant count -->
+          <div class="flex items-center gap-2 shrink-0">
+            <!-- Availability indicator -->
+            <span
+              v-if="day.hasAvailability"
+              class="inline-flex items-center rounded-full px-2 py-0.5 text-xs font-bold text-white"
+              :class="
+                day.meetsThreshold
+                  ? 'bg-green-600 dark:bg-green-500'
+                  : 'bg-primary-600 dark:bg-primary-500'
+              "
+            >
+              {{ t('availability.available', 'Available') }}
+            </span>
+            <!-- Recurrence indicator -->
+            <span
+              v-else-if="day.hasRecurrence"
+              class="inline-flex items-center rounded-full bg-blue-600 px-2 py-0.5 text-xs font-bold text-white dark:bg-blue-500"
+            >
+              {{ t('availability.recurring', 'Recurring') }}
+            </span>
+            <!-- Participant count -->
+            <span
+              v-if="day.participantCount > 0"
+              class="inline-flex items-center gap-1 text-xs font-medium"
+              :class="
+                day.meetsThreshold
+                  ? 'text-green-700 dark:text-green-400'
+                  : 'text-gray-600 dark:text-gray-400'
+              "
+            >
+              <svg class="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  stroke-width="2"
+                  d="M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0z"
+                />
+              </svg>
+              {{ day.participantCount }}
+            </span>
+            <!-- Threshold met icon -->
+            <span
+              v-if="day.meetsThreshold"
+              class="text-green-600 dark:text-green-400"
+              :title="t('calendar.thresholdMet', 'Threshold met')"
+            >
+              <svg class="h-4 w-4" fill="currentColor" viewBox="0 0 20 20">
+                <path
+                  fill-rule="evenodd"
+                  d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z"
+                  clip-rule="evenodd"
+                />
+              </svg>
+            </span>
+          </div>
+        </div>
+      </button>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue';
+import { useI18n } from 'vue-i18n';
+import { useDateValidation, clearHolidaysCache } from '@/composables/useDateValidation';
+import {
+  formatDateISO,
+  formatWeekday,
+  formatFullDate,
+} from '@/utils/dateFormatting';
+import type { Availability, RecurrenceWithExceptions } from '@/types';
+
+interface MonthConfig {
+  year: number;
+  month: number;
+}
+
+interface WeekConfig {
+  weekStartDate: Date;
+}
+
+interface Props {
+  displayMode: 'month' | 'week';
+  monthsToDisplay: MonthConfig[];
+  weeksToDisplay: WeekConfig[];
+  availabilities: Availability[];
+  recurrences: RecurrenceWithExceptions[];
+  participantCounts: Record<string, number>;
+  threshold: number;
+  allowedWeekdays?: number[];
+  timezone?: string;
+  holidaysPolicy?: string;
+  allowHolidayEves?: boolean;
+  startDate?: string;
+  endDate?: string;
+  displayedYear: number;
+  displayedMonth: number;
+  currentWeekStartDate: Date;
+  currentParticipantId: string;
+  highlightedDates?: Set<string>;
+}
+
+interface ListDay {
+  dateString: string;
+  dateObj: Date;
+  dayOfWeek: number;
+  dayName: string;
+  dateFormatted: string;
+  isToday: boolean;
+  isHoliday: boolean;
+  isHolidayEve: boolean;
+  holidayName?: string;
+  hasAvailability: boolean;
+  hasRecurrence: boolean;
+  meetsThreshold: boolean;
+  participantCount: number;
+  isHighlighted: boolean;
+  timeLabel?: string;
+}
+
+const props = defineProps<Props>();
+
+const emit = defineEmits<{
+  (e: 'day-click', dateString: string): void;
+  (e: 'month-change', year: number, month: number): void;
+  (e: 'week-change', weekStartDate: Date): void;
+  (e: 'view-style-change', style: 'classic' | 'compact' | 'list'): void;
+}>();
+
+const { t, locale } = useI18n();
+
+// Handle view style selection (classic/compact are rendered by parent grid components)
+function handleViewStyleSelect(event: Event) {
+  const value = (event.target as HTMLSelectElement).value as 'classic' | 'compact' | 'list';
+  if (value !== 'list') {
+    // Reset dropdown back to 'list' visually, then emit the switch
+    (event.target as HTMLSelectElement).value = 'list';
+    emit('view-style-change', value);
+  }
+}
+const { isDateAllowed, checkIsHoliday, checkIsHolidayEve, getHolidayName } = useDateValidation();
+
+// Range label for navigation header
+const rangeLabel = computed(() => {
+  const localeCode = locale.value === 'fr' ? 'fr-FR' : 'en-US';
+
+  if (props.displayMode === 'week') {
+    if (props.weeksToDisplay.length === 0) return '';
+    const first = props.weeksToDisplay[0].weekStartDate;
+    const last = props.weeksToDisplay[props.weeksToDisplay.length - 1].weekStartDate;
+    const lastEnd = new Date(last);
+    lastEnd.setDate(lastEnd.getDate() + 6);
+
+    return `${first.toLocaleDateString(localeCode, { day: 'numeric', month: 'short' })} — ${lastEnd.toLocaleDateString(localeCode, { day: 'numeric', month: 'short', year: 'numeric' })}`;
+  }
+
+  // Month mode
+  if (props.monthsToDisplay.length === 0) return '';
+  const first = props.monthsToDisplay[0];
+  const last = props.monthsToDisplay[props.monthsToDisplay.length - 1];
+  const firstDate = new Date(first.year, first.month, 1);
+  const lastDate = new Date(last.year, last.month, 1);
+
+  if (first.year === last.year && first.month === last.month) {
+    return firstDate.toLocaleDateString(localeCode, { month: 'long', year: 'numeric' });
+  }
+
+  return `${firstDate.toLocaleDateString(localeCode, { month: 'short' })} — ${lastDate.toLocaleDateString(localeCode, { month: 'short', year: 'numeric' })}`;
+});
+
+// Generate all dates in the displayed period, then filter to actionable ones
+const actionableDays = computed((): ListDay[] => {
+  clearHolidaysCache();
+
+  const allDates: Date[] = [];
+
+  if (props.displayMode === 'month') {
+    for (const mc of props.monthsToDisplay) {
+      const daysInMonth = new Date(mc.year, mc.month + 1, 0).getDate();
+      for (let d = 1; d <= daysInMonth; d++) {
+        allDates.push(new Date(mc.year, mc.month, d));
+      }
+    }
+  } else {
+    for (const wc of props.weeksToDisplay) {
+      for (let i = 0; i < 7; i++) {
+        const date = new Date(wc.weekStartDate);
+        date.setDate(wc.weekStartDate.getDate() + i);
+        allDates.push(date);
+      }
+    }
+  }
+
+  const today = new Date();
+  today.setHours(0, 0, 0, 0);
+
+  const timezone = props.timezone || 'Europe/Paris';
+  const allowedWeekdays = props.allowedWeekdays || [0, 1, 2, 3, 4, 5, 6];
+  const holidaysPolicy = (props.holidaysPolicy as 'ignore' | 'allow' | 'block') || 'ignore';
+  const allowHolidayEves = props.allowHolidayEves || false;
+
+  // Deduplicate dates (month ranges may overlap with week ranges)
+  const seen = new Set<string>();
+  const days: ListDay[] = [];
+
+  for (const dateObj of allDates) {
+    dateObj.setHours(0, 0, 0, 0);
+    const dateString = formatDateISO(dateObj);
+
+    if (seen.has(dateString)) continue;
+    seen.add(dateString);
+
+    // Filter: not past
+    if (dateObj < today) continue;
+
+    // Filter: within calendar date range
+    if (props.startDate && dateString < props.startDate) continue;
+    if (props.endDate && dateString > props.endDate) continue;
+
+    // Filter: isAllowed (weekdays + holidays policy)
+    if (!isDateAllowed(dateObj, timezone, allowedWeekdays, holidaysPolicy, allowHolidayEves))
+      continue;
+
+    const dayOfWeek = dateObj.getDay();
+
+    // Check availability
+    const dateAvailabilities = (props.availabilities || []).filter(a => a.date === dateString);
+    const hasAvailability = dateAvailabilities.length > 0;
+
+    // Check recurrence
+    let hasRecurrence = false;
+    (props.recurrences || []).some(rec => {
+      if (rec.day_of_week !== dayOfWeek) return false;
+      if (dateString < rec.start_date) return false;
+      if (rec.end_date && dateString > rec.end_date) return false;
+      const isException = rec.exceptions?.some(ex => ex.excluded_date === dateString);
+      if (!isException) {
+        hasRecurrence = true;
+        return true;
+      }
+      return false;
+    });
+
+    const participantCount = props.participantCounts?.[dateString] || 0;
+    const meetsThreshold = participantCount >= (props.threshold || 1);
+
+    // Build time label from availabilities
+    let timeLabel: string | undefined;
+    if (hasAvailability && dateAvailabilities.length > 0) {
+      const firstAvail = dateAvailabilities[0];
+      if (firstAvail.start_time && firstAvail.end_time) {
+        timeLabel = `${firstAvail.start_time} - ${firstAvail.end_time}`;
+      }
+    }
+
+    days.push({
+      dateString,
+      dateObj: new Date(dateObj),
+      dayOfWeek,
+      dayName: formatWeekday(dateObj, locale.value, 'long'),
+      dateFormatted: formatFullDate(dateObj, locale.value),
+      isToday: dateObj.getTime() === today.getTime(),
+      isHoliday: checkIsHoliday(dateObj, timezone),
+      isHolidayEve: checkIsHolidayEve(dateObj, timezone),
+      holidayName: getHolidayName(dateObj, timezone) ?? undefined,
+      hasAvailability,
+      hasRecurrence,
+      meetsThreshold,
+      participantCount,
+      isHighlighted: props.highlightedDates?.has(dateString) || false,
+      timeLabel,
+    });
+  }
+
+  // Sort by date
+  days.sort((a, b) => a.dateObj.getTime() - b.dateObj.getTime());
+
+  return days;
+});
+
+function navigatePrevious() {
+  if (props.displayMode === 'week') {
+    const newStart = new Date(props.currentWeekStartDate);
+    newStart.setDate(newStart.getDate() - 7);
+    emit('week-change', newStart);
+  } else {
+    const newDate = new Date(props.displayedYear, props.displayedMonth - 1, 1);
+    emit('month-change', newDate.getFullYear(), newDate.getMonth());
+  }
+}
+
+function navigateNext() {
+  if (props.displayMode === 'week') {
+    const newStart = new Date(props.currentWeekStartDate);
+    newStart.setDate(newStart.getDate() + 7);
+    emit('week-change', newStart);
+  } else {
+    const newDate = new Date(props.displayedYear, props.displayedMonth + 1, 1);
+    emit('month-change', newDate.getFullYear(), newDate.getMonth());
+  }
+}
+</script>

--- a/frontend/src/components/CalendarListView.vue
+++ b/frontend/src/components/CalendarListView.vue
@@ -84,9 +84,13 @@
                 : 'border-gray-200 bg-white hover:border-primary-300 hover:shadow-sm dark:border-gray-700 dark:bg-gray-800 dark:hover:border-primary-600',
           day.isToday && 'ring-2 ring-primary-500 ring-offset-1',
           day.isHighlighted &&
-            'ring-2 ring-amber-400 ring-offset-1 dark:ring-amber-500 dark:ring-offset-gray-900',
+            'ring-2 ring-purple-500 bg-purple-100 dark:bg-purple-900/40',
         ]"
-        @click="emit('day-click', day.dateString)"
+        @pointerdown="onRowPointerDown(day, $event)"
+        @pointermove="onRowPointerMove($event)"
+        @pointerup="onRowPointerUp()"
+        @pointercancel="onRowPointerCancel()"
+        @click="onRowClick(day, $event)"
       >
         <div class="flex items-center justify-between gap-3">
           <!-- Left: date info -->
@@ -185,11 +189,84 @@
         </div>
       </button>
     </div>
+
+    <!-- Legend -->
+    <div
+      v-if="actionableDays.length > 0"
+      class="mt-4 flex flex-wrap gap-4 text-xs"
+    >
+      <div class="flex items-center gap-1">
+        <div class="h-3 w-3 rounded border-2 border-primary-500" />
+        <span class="text-gray-600 dark:text-gray-400">{{ t('calendar.today', 'Today') }}</span>
+      </div>
+      <div class="flex items-center gap-1">
+        <div
+          class="h-3 w-3 rounded bg-green-100 border border-green-200 dark:bg-green-900/20 dark:border-green-700"
+        />
+        <span class="text-gray-600 dark:text-gray-400">{{
+          t('availability.thresholdMet', 'Threshold met')
+        }}</span>
+      </div>
+      <div class="flex items-center gap-1">
+        <div
+          class="h-3 w-3 rounded bg-primary-100 border border-primary-200 dark:bg-primary-900/20 dark:border-primary-700"
+        />
+        <span class="text-gray-600 dark:text-gray-400">{{
+          t('availability.available', 'Available')
+        }}</span>
+      </div>
+      <div class="flex items-center gap-1">
+        <div
+          class="h-3 w-3 rounded bg-blue-100 border border-blue-200 dark:bg-blue-900/20 dark:border-blue-700"
+        />
+        <span class="text-gray-600 dark:text-gray-400">{{
+          t('availability.recurring', 'Recurring')
+        }}</span>
+      </div>
+      <div class="flex items-center gap-1">
+        <div
+          class="h-3 w-3 rounded bg-orange-100 border border-orange-200 dark:bg-orange-900/40 dark:border-orange-700"
+        />
+        <span class="text-gray-600 dark:text-gray-400">{{
+          t('calendar.publicHoliday', 'Public holiday')
+        }}</span>
+      </div>
+      <div v-if="allowHolidayEves" class="flex items-center gap-1">
+        <div
+          class="h-3 w-3 rounded bg-purple-100 border border-purple-200 dark:bg-purple-900/40 dark:border-purple-700"
+        />
+        <span class="text-gray-600 dark:text-gray-400">{{
+          t('calendar.holidayEve', 'Holiday eve')
+        }}</span>
+      </div>
+      <div
+        v-if="props.highlightedDates && props.highlightedDates.size > 0"
+        class="flex items-center gap-1"
+      >
+        <div
+          class="h-3 w-3 rounded border border-purple-500 ring-2 ring-purple-500 bg-purple-100 dark:bg-purple-900/40"
+        />
+        <span class="text-gray-600 dark:text-gray-400">
+          {{ t('participant.commonDates', 'Common dates') }}
+        </span>
+      </div>
+    </div>
+
+    <ParticipantDetailsPopup
+      v-if="popupDate && popupAnchor"
+      :calendar-token="calendarToken"
+      :current-participant-id="currentParticipantId"
+      :current-participant-name="currentParticipantName"
+      :date="popupDate"
+      :anchor-rect="popupAnchor"
+      @close="onPopupClose"
+      @availability-updated="onPopupAvailabilityUpdated"
+    />
   </div>
 </template>
 
 <script setup lang="ts">
-import { computed } from 'vue';
+import { computed, ref } from 'vue';
 import { useI18n } from 'vue-i18n';
 import { useDateValidation, clearHolidaysCache } from '@/composables/useDateValidation';
 import {
@@ -198,6 +275,7 @@ import {
   formatFullDate,
 } from '@/utils/dateFormatting';
 import type { Availability, RecurrenceWithExceptions } from '@/types';
+import ParticipantDetailsPopup from './ParticipantDetailsPopup.vue';
 
 interface MonthConfig {
   year: number;
@@ -226,6 +304,8 @@ interface Props {
   displayedMonth: number;
   currentWeekStartDate: Date;
   currentParticipantId: string;
+  currentParticipantName: string;
+  calendarToken: string;
   highlightedDates?: Set<string>;
 }
 
@@ -254,7 +334,78 @@ const emit = defineEmits<{
   (e: 'month-change', year: number, month: number): void;
   (e: 'week-change', weekStartDate: Date): void;
   (e: 'view-style-change', style: 'classic' | 'compact' | 'list'): void;
+  (e: 'availability-updated'): void;
 }>();
+
+// Long-press detection for opening the participant details popup
+const LONG_PRESS_MS = 500;
+const MOVE_THRESHOLD_PX = 8;
+const popupDate = ref<string | null>(null);
+const popupAnchor = ref<DOMRect | null>(null);
+let holdTimer: number | null = null;
+let longPressFired = false;
+let pointerStartX = 0;
+let pointerStartY = 0;
+
+function clearHoldTimer() {
+  if (holdTimer !== null) {
+    window.clearTimeout(holdTimer);
+    holdTimer = null;
+  }
+}
+
+function onRowPointerDown(day: ListDay, event: PointerEvent) {
+  if (!event.isPrimary) return;
+  if (day.participantCount === 0) return;
+  const target = event.currentTarget as HTMLElement;
+  pointerStartX = event.clientX;
+  pointerStartY = event.clientY;
+  longPressFired = false;
+  clearHoldTimer();
+  holdTimer = window.setTimeout(() => {
+    popupAnchor.value = target.getBoundingClientRect();
+    popupDate.value = day.dateString;
+    longPressFired = true;
+    holdTimer = null;
+  }, LONG_PRESS_MS);
+}
+
+function onRowPointerMove(event: PointerEvent) {
+  if (holdTimer === null) return;
+  const dx = event.clientX - pointerStartX;
+  const dy = event.clientY - pointerStartY;
+  if (Math.hypot(dx, dy) > MOVE_THRESHOLD_PX) {
+    clearHoldTimer();
+  }
+}
+
+function onRowPointerUp() {
+  clearHoldTimer();
+}
+
+function onRowPointerCancel() {
+  clearHoldTimer();
+  longPressFired = false;
+}
+
+function onRowClick(day: ListDay, event: MouseEvent) {
+  if (longPressFired) {
+    event.preventDefault();
+    event.stopPropagation();
+    longPressFired = false;
+    return;
+  }
+  emit('day-click', day.dateString);
+}
+
+function onPopupClose() {
+  popupDate.value = null;
+  popupAnchor.value = null;
+}
+
+function onPopupAvailabilityUpdated() {
+  emit('availability-updated');
+}
 
 const { t, locale } = useI18n();
 

--- a/frontend/src/components/ParticipantDetailsPopup.vue
+++ b/frontend/src/components/ParticipantDetailsPopup.vue
@@ -1,0 +1,435 @@
+<!--
+  WhenTo - Collaborative event calendar for self-hosted environments
+  Copyright (C) 2025 WhenTo Contributors
+  SPDX-License-Identifier: BSL-1.1
+-->
+
+<template>
+  <div
+    ref="tooltipRef"
+    class="fixed z-50 bg-white dark:bg-gray-800 rounded-lg shadow-xl max-w-[calc(100vw-2rem)] md:max-w-md p-4 md:p-6 border border-gray-200 dark:border-gray-700 pointer-events-auto"
+    :style="{
+      left: `${popupPosition.x}px`,
+      top: `${popupPosition.y}px`,
+    }"
+  >
+    <div>
+      <div class="mb-4 flex items-center justify-between">
+        <h3 class="text-lg font-semibold text-gray-900 dark:text-white">
+          {{ t('participant.participantsForDate', 'Participants for') }}
+          {{ formatSelectedDate }}
+        </h3>
+        <button
+          class="text-gray-400 hover:text-gray-600 dark:hover:text-gray-300"
+          @click="emit('close')"
+        >
+          <svg class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+              d="M6 18L18 6M6 6l12 12"
+            />
+          </svg>
+        </button>
+      </div>
+
+      <div v-if="loadingDetails" class="text-center py-8">
+        <div
+          class="inline-block h-8 w-8 animate-spin rounded-full border-4 border-solid border-primary-600 border-r-transparent"
+        />
+        <p class="mt-2 text-sm text-gray-600 dark:text-gray-400">
+          {{ t('common.loading', 'Loading...') }}
+        </p>
+      </div>
+
+      <div v-else-if="participantDetails">
+        <div class="mb-4">
+          <p class="text-sm text-gray-600 dark:text-gray-400">
+            {{ participantDetails.total_count }}
+            {{
+              participantDetails.total_count > 1
+                ? t('calendar.participants', 'Participants')
+                : t('calendar.participantCount', 'participant(s)')
+            }}
+          </p>
+        </div>
+
+        <div class="space-y-2">
+          <div
+            v-for="participant in participantDetails.participants"
+            :key="participant.participant_id || participant.participant_name"
+            :class="[
+              'rounded-lg border p-3',
+              participant.participant_name === props.currentParticipantName
+                ? 'border-primary-300 bg-primary-50/50 dark:border-primary-700 dark:bg-primary-900/10'
+                : 'border-gray-200 dark:border-gray-700',
+            ]"
+          >
+            <div class="flex items-start justify-between">
+              <div class="flex-1">
+                <div class="flex items-center gap-2">
+                  <div class="font-medium text-gray-900 dark:text-white">
+                    {{ participant.participant_name }}
+                  </div>
+                  <span
+                    v-if="participant.participant_name === props.currentParticipantName"
+                    class="text-xs px-2 py-0.5 rounded-full bg-primary-100 text-primary-700 dark:bg-primary-900 dark:text-primary-300"
+                  >
+                    {{ t('common.you', 'You') }}
+                  </span>
+                </div>
+                <div class="mt-1 text-sm text-gray-600 dark:text-gray-400">
+                  {{ formatTimeRange(participant.start_time, participant.end_time) }}
+                </div>
+
+                <!-- Availability edit form -->
+                <div
+                  v-if="participant.participant_name === props.currentParticipantName && editingNote"
+                  class="mt-2"
+                >
+                  <!-- Time Range -->
+                  <div class="grid grid-cols-2 gap-2 mb-2">
+                    <div>
+                      <label
+                        class="block text-xs font-medium text-gray-700 dark:text-gray-300 mb-1"
+                      >
+                        {{ t('availability.startTime', 'Start time') }}
+                      </label>
+                      <TimeSelect
+                        v-model="editedStartTime"
+                        class="w-full text-sm"
+                        :max="editedEndTime || undefined"
+                      />
+                    </div>
+                    <div>
+                      <label
+                        class="block text-xs font-medium text-gray-700 dark:text-gray-300 mb-1"
+                      >
+                        {{ t('availability.endTime', 'End time') }}
+                      </label>
+                      <TimeSelect
+                        v-model="editedEndTime"
+                        class="w-full text-sm"
+                        :min="editedStartTime || undefined"
+                      />
+                    </div>
+                  </div>
+
+                  <!-- Note -->
+                  <div class="mb-2">
+                    <label
+                      class="block text-xs font-medium text-gray-700 dark:text-gray-300 mb-1"
+                    >
+                      {{ t('availability.note', 'Note') }}
+                    </label>
+                    <textarea
+                      v-model="editedNote"
+                      rows="2"
+                      class="input w-full text-sm"
+                      :placeholder="t('availability.note', 'Note')"
+                    />
+                  </div>
+
+                  <!-- Action buttons -->
+                  <div class="flex gap-2">
+                    <button
+                      :disabled="savingNote"
+                      class="btn btn-primary btn-sm"
+                      @click="saveNote"
+                    >
+                      <svg
+                        v-if="savingNote"
+                        class="mr-1 h-3 w-3 animate-spin"
+                        fill="none"
+                        viewBox="0 0 24 24"
+                      >
+                        <circle
+                          class="opacity-25"
+                          cx="12"
+                          cy="12"
+                          r="10"
+                          stroke="currentColor"
+                          stroke-width="4"
+                        />
+                        <path
+                          class="opacity-75"
+                          fill="currentColor"
+                          d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
+                        />
+                      </svg>
+                      {{ t('common.save', 'Save') }}
+                    </button>
+                    <button
+                      :disabled="savingNote"
+                      class="btn btn-ghost btn-sm"
+                      @click="cancelEdit"
+                    >
+                      {{ t('common.cancel', 'Cancel') }}
+                    </button>
+                  </div>
+                </div>
+                <div
+                  v-else-if="participant.note"
+                  class="mt-1 text-sm text-gray-500 dark:text-gray-400 italic"
+                >
+                  {{ participant.note }}
+                </div>
+                <div
+                  v-else-if="participant.participant_name === props.currentParticipantName"
+                  class="mt-1 text-sm text-gray-400 dark:text-gray-500 italic"
+                >
+                  {{ t('availability.noNote', 'No note') }}
+                </div>
+              </div>
+
+              <!-- Edit button for current participant -->
+              <button
+                v-if="
+                  participant.participant_name === props.currentParticipantName && !editingNote
+                "
+                class="ml-2 text-gray-400 hover:text-gray-600 dark:hover:text-gray-300"
+                :title="t('common.edit', 'Edit')"
+                @click="
+                  startEdit(participant.note || '', participant.start_time, participant.end_time)
+                "
+              >
+                <svg class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                  <path
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                    stroke-width="2"
+                    d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z"
+                  />
+                </svg>
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div v-else class="text-center py-8">
+        <p class="text-sm text-gray-600 dark:text-gray-400">
+          {{ t('availability.noAvailabilities', 'No availabilities') }}
+        </p>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, computed, nextTick, onMounted, onUnmounted, watch } from 'vue';
+import { useI18n } from 'vue-i18n';
+import { availabilitiesApi } from '@/api/availabilities';
+import TimeSelect from '@/components/TimeSelect.vue';
+
+interface Props {
+  calendarToken: string;
+  currentParticipantId: string;
+  currentParticipantName: string;
+  date: string;
+  anchorRect: DOMRect;
+}
+
+interface Emits {
+  (e: 'close'): void;
+  (e: 'availability-updated'): void;
+}
+
+const props = defineProps<Props>();
+const emit = defineEmits<Emits>();
+const { t, locale } = useI18n();
+
+const participantDetails = ref<any>(null);
+const loadingDetails = ref(false);
+const popupPosition = ref({ x: 0, y: 0 });
+const tooltipRef = ref<HTMLElement | null>(null);
+
+const editingNote = ref(false);
+const editedNote = ref('');
+const editedStartTime = ref('');
+const editedEndTime = ref('');
+const savingNote = ref(false);
+
+const formatSelectedDate = computed(() => {
+  if (!props.date) return '';
+  const date = new Date(props.date);
+  const localeCode = locale.value;
+  return date.toLocaleDateString(localeCode, {
+    weekday: 'long',
+    day: 'numeric',
+    month: 'long',
+    year: 'numeric',
+  });
+});
+
+function isFullDayTime(startTime?: string, endTime?: string): boolean {
+  if (!startTime || !endTime) return false;
+  const start = startTime.substring(0, 5);
+  const end = endTime.substring(0, 5);
+  return start === '00:00' && end === '23:59';
+}
+
+function formatTimeRange(startTime?: string, endTime?: string): string {
+  if (isFullDayTime(startTime, endTime)) {
+    return t('availability.allDay', 'All day');
+  }
+  return `${startTime ?? '00:00'}-${endTime ?? '23:59'}`;
+}
+
+async function loadParticipantDetails() {
+  loadingDetails.value = true;
+
+  try {
+    const details = await availabilitiesApi.getDateSummary(props.calendarToken, props.date);
+    participantDetails.value = details;
+  } catch (err) {
+    console.error('Failed to load participant details:', err);
+    participantDetails.value = null;
+  } finally {
+    loadingDetails.value = false;
+
+    await nextTick();
+    adjustTooltipPosition();
+  }
+}
+
+function adjustTooltipPosition() {
+  if (!tooltipRef.value) return;
+
+  const tooltip = tooltipRef.value;
+  const rect = tooltip.getBoundingClientRect();
+  const offset = 10;
+
+  let { x, y } = popupPosition.value;
+
+  const viewportWidth = window.innerWidth;
+  const viewportHeight = window.innerHeight;
+
+  if (x + rect.width > viewportWidth - offset) {
+    x = viewportWidth - rect.width - offset;
+  }
+
+  if (y + rect.height > viewportHeight - offset) {
+    y = viewportHeight - rect.height - offset;
+  }
+
+  if (x < offset) {
+    x = offset;
+  }
+
+  if (y < offset) {
+    y = offset;
+  }
+
+  if (x !== popupPosition.value.x || y !== popupPosition.value.y) {
+    popupPosition.value = { x, y };
+  }
+}
+
+function startEdit(currentNote: string, startTime?: string, endTime?: string) {
+  editedNote.value = currentNote;
+  editedStartTime.value = startTime || '';
+  editedEndTime.value = endTime || '';
+  editingNote.value = true;
+}
+
+function cancelEdit() {
+  editingNote.value = false;
+  editedNote.value = '';
+  editedStartTime.value = '';
+  editedEndTime.value = '';
+}
+
+async function saveNote() {
+  if (!props.calendarToken || !props.currentParticipantId || !props.date) {
+    return;
+  }
+
+  savingNote.value = true;
+
+  try {
+    await availabilitiesApi.update(
+      props.calendarToken,
+      props.currentParticipantId,
+      props.date,
+      {
+        note: editedNote.value || undefined,
+        start_time: editedStartTime.value || undefined,
+        end_time: editedEndTime.value || undefined,
+      }
+    );
+
+    await loadParticipantDetails();
+
+    editingNote.value = false;
+    editedNote.value = '';
+    editedStartTime.value = '';
+    editedEndTime.value = '';
+
+    emit('availability-updated');
+  } catch (err) {
+    console.error('Failed to update availability:', err);
+  } finally {
+    savingNote.value = false;
+  }
+}
+
+// Outside-click / scroll / Escape handlers
+const handleClickOutside = (event: Event) => {
+  if (tooltipRef.value && !tooltipRef.value.contains(event.target as Node)) {
+    emit('close');
+  }
+};
+
+const handleScroll = () => {
+  emit('close');
+};
+
+const handleEscape = (event: KeyboardEvent) => {
+  if (event.key === 'Escape') {
+    emit('close');
+  }
+};
+
+let attachTimer: number | null = null;
+
+onMounted(async () => {
+  // Initial anchored position (below the row, clamped to viewport width)
+  popupPosition.value = {
+    x: Math.min(props.anchorRect.left + 16, window.innerWidth - 400),
+    y: props.anchorRect.bottom + 8,
+  };
+
+  await loadParticipantDetails();
+
+  // Delay attaching so the opening pointer event doesn't immediately close
+  attachTimer = window.setTimeout(() => {
+    document.addEventListener('click', handleClickOutside);
+    document.addEventListener('touchstart', handleClickOutside);
+    window.addEventListener('scroll', handleScroll, true);
+    document.addEventListener('keydown', handleEscape);
+  }, 100);
+});
+
+onUnmounted(() => {
+  if (attachTimer !== null) {
+    window.clearTimeout(attachTimer);
+  }
+  document.removeEventListener('click', handleClickOutside);
+  document.removeEventListener('touchstart', handleClickOutside);
+  window.removeEventListener('scroll', handleScroll, true);
+  document.removeEventListener('keydown', handleEscape);
+});
+
+// Reload when the date prop changes (e.g., user long-presses a different row)
+watch(
+  () => props.date,
+  async (newDate, oldDate) => {
+    if (newDate && newDate !== oldDate) {
+      editingNote.value = false;
+      await loadParticipantDetails();
+    }
+  }
+);
+</script>

--- a/frontend/src/components/WeeklyCalendarGrid.vue
+++ b/frontend/src/components/WeeklyCalendarGrid.vue
@@ -26,9 +26,20 @@
         </button>
       </div>
 
-      <h3 class="text-base md:text-lg font-semibold text-gray-900 dark:text-white text-center px-2">
-        {{ weekRangeText }}
-      </h3>
+      <div class="flex flex-col items-center gap-1">
+        <h3 class="text-base md:text-lg font-semibold text-gray-900 dark:text-white text-center px-2">
+          {{ weekRangeText }}
+        </h3>
+        <select
+          v-if="showNavigation"
+          value="classic"
+          class="text-xs md:text-sm px-2 py-1 rounded border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 text-gray-700 dark:text-gray-300 focus:outline-none focus:ring-2 focus:ring-primary-500"
+          @change="handleViewStyleSelect"
+        >
+          <option value="classic">{{ t('calendar.viewClassic') }}</option>
+          <option value="list">{{ t('calendar.listView') }}</option>
+        </select>
+      </div>
 
       <div class="flex justify-end">
         <button
@@ -559,6 +570,11 @@ import { availabilitiesApi } from '@/api/availabilities';
 import type { Availability, DateAvailabilitySummary } from '@/types';
 import TimeSelect from '@/components/TimeSelect.vue';
 import { useDateValidation, clearHolidaysCache } from '@/composables/useDateValidation';
+import {
+  formatDateISO,
+  formatWeekday,
+  formatDayMonthShort,
+} from '@/utils/dateFormatting';
 
 const { t, locale } = useI18n();
 const toastStore = useToastStore();
@@ -647,6 +663,7 @@ interface Emits {
     settings: { startHour?: number; endHour?: number; slotDuration?: number }
   ): void;
   (e: 'availability-updated'): void;
+  (e: 'view-style-change', style: 'classic' | 'list'): void;
 }
 
 const emit = defineEmits<Emits>();
@@ -831,9 +848,9 @@ const weekDays = computed(() => {
     const date = new Date(start);
     date.setDate(start.getDate() + i);
 
-    const dateString = formatDateForAPI(date);
-    const dayName = formatDayName(date);
-    const dateFormatted = formatDateShort(date);
+    const dateString = formatDateISO(date);
+    const dayName = formatWeekday(date, locale.value, 'short');
+    const dateFormatted = formatDayMonthShort(date, locale.value);
 
     days.push({
       date,
@@ -1373,7 +1390,7 @@ const weekRangeText = computed(() => {
 
   if (!start || !end) return '';
 
-  return `${formatDateShort(start)} - ${formatDateShort(end)}`;
+  return `${formatDayMonthShort(start, locale.value)} - ${formatDayMonthShort(end, locale.value)}`;
 });
 
 // Check if a date is in the past
@@ -1510,7 +1527,7 @@ function isTimeSlotAllowed(date: Date, time: string): boolean {
 
 // Check if a date is enabled (day-level check, without time consideration)
 function isDateEnabled(date: Date): boolean {
-  const dateString = formatDateForAPI(date);
+  const dateString = formatDateISO(date);
 
   // Disable past dates
   if (isPastDate(date)) return false;
@@ -2433,6 +2450,16 @@ function addMinutes(time: string, minutes: number): string {
   return `${String(newHours).padStart(2, '0')}:${String(newMins).padStart(2, '0')}`;
 }
 
+// Handle view style selection (list is rendered by parent)
+function handleViewStyleSelect(event: Event) {
+  const value = (event.target as HTMLSelectElement).value;
+  if (value === 'list') {
+    // Reset the select back to 'classic' (list is rendered by parent, not this grid)
+    (event.target as HTMLSelectElement).value = 'classic';
+    emit('view-style-change', 'list');
+  }
+}
+
 // Navigation
 function previousWeek() {
   const newStart = new Date(currentWeekStartDate.value);
@@ -2446,27 +2473,6 @@ function nextWeek() {
   newStart.setDate(newStart.getDate() + 7);
   currentWeekStartDate.value = newStart;
   emit('week-change', newStart);
-}
-
-// Formatting helpers
-function formatDateForAPI(date: Date): string {
-  const year = date.getFullYear();
-  const month = String(date.getMonth() + 1).padStart(2, '0');
-  const day = String(date.getDate()).padStart(2, '0');
-  return `${year}-${month}-${day}`;
-}
-
-function formatDayName(date: Date): string {
-  const localeCode = locale.value;
-  return new Intl.DateTimeFormat(localeCode, { weekday: 'short' }).format(date);
-}
-
-function formatDateShort(date: Date): string {
-  const localeCode = locale.value;
-  return new Intl.DateTimeFormat(localeCode, {
-    day: 'numeric',
-    month: 'short',
-  }).format(date);
 }
 
 // Watch for prop changes

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -354,7 +354,9 @@
     "nextWeek": "Next week",
     "thresholdMet": "Event (threshold met)",
     "viewClassic": "Classic",
-    "viewCompact": "Compact"
+    "viewCompact": "Compact",
+    "listView": "List",
+    "noActionableDays": "No available days in this period"
   },
   "weekdays": {
     "short": {

--- a/frontend/src/locales/fr.json
+++ b/frontend/src/locales/fr.json
@@ -357,7 +357,9 @@
     "nextWeek": "Semaine suivante",
     "thresholdMet": "Événement (seuil atteint)",
     "viewClassic": "Classique",
-    "viewCompact": "Compact"
+    "viewCompact": "Compact",
+    "listView": "Liste",
+    "noActionableDays": "Aucun jour disponible dans cette période"
   },
   "weekdays": {
     "short": {

--- a/frontend/src/stores/calendarHistory.ts
+++ b/frontend/src/stores/calendarHistory.ts
@@ -19,6 +19,7 @@ export interface CalendarHistoryItem {
   startHour?: number;
   endHour?: number;
   slotDuration?: number;
+  viewStyle?: 'classic' | 'list';
 }
 
 const STORAGE_KEY = 'whento_visited_calendars';
@@ -91,6 +92,7 @@ export const useCalendarHistoryStore = defineStore('calendarHistory', () => {
         ...(existing?.startHour !== undefined && { startHour: existing.startHour }),
         ...(existing?.endHour !== undefined && { endHour: existing.endHour }),
         ...(existing?.slotDuration !== undefined && { slotDuration: existing.slotDuration }),
+        ...(existing?.viewStyle !== undefined && { viewStyle: existing.viewStyle }),
         // Update participantId if provided, otherwise preserve existing
         ...(participantId !== undefined
           ? { participantId }
@@ -161,6 +163,7 @@ export const useCalendarHistoryStore = defineStore('calendarHistory', () => {
       startHour?: number;
       endHour?: number;
       slotDuration?: number;
+      viewStyle?: 'classic' | 'list';
     }
   ) {
     const calendar = calendars.value.find(c => c.token === token);
@@ -174,6 +177,7 @@ export const useCalendarHistoryStore = defineStore('calendarHistory', () => {
       if (settings.startHour !== undefined) calendar.startHour = settings.startHour;
       if (settings.endHour !== undefined) calendar.endHour = settings.endHour;
       if (settings.slotDuration !== undefined) calendar.slotDuration = settings.slotDuration;
+      if (settings.viewStyle !== undefined) calendar.viewStyle = settings.viewStyle;
       saveVisitedCalendars(calendars.value);
     }
   }
@@ -188,6 +192,7 @@ export const useCalendarHistoryStore = defineStore('calendarHistory', () => {
       startHour: calendar.startHour,
       endHour: calendar.endHour,
       slotDuration: calendar.slotDuration,
+      viewStyle: calendar.viewStyle,
     };
   }
 

--- a/frontend/src/utils/dateFormatting.ts
+++ b/frontend/src/utils/dateFormatting.ts
@@ -1,0 +1,50 @@
+/*
+ * WhenTo - Collaborative event calendar for self-hosted environments
+ * Copyright (C) 2025 WhenTo Contributors
+ * Licensed under the Business Source License 1.1
+ * See LICENSE file for details
+ */
+
+/**
+ * Format a Date as an ISO date string (YYYY-MM-DD) using local time.
+ * Used when building API payloads or map keys keyed by calendar date.
+ */
+export function formatDateISO(date: Date): string {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const day = String(date.getDate()).padStart(2, '0');
+  return `${year}-${month}-${day}`;
+}
+
+/**
+ * Format the weekday name for the given date in the given locale.
+ * `style` controls the width ('long' for "Monday", 'short' for "Mon").
+ */
+export function formatWeekday(
+  date: Date,
+  locale: string,
+  style: 'long' | 'short' = 'long'
+): string {
+  return new Intl.DateTimeFormat(locale, { weekday: style }).format(date);
+}
+
+/**
+ * Day + short month (no year), e.g. "5 Apr".
+ */
+export function formatDayMonthShort(date: Date, locale: string): string {
+  return new Intl.DateTimeFormat(locale, {
+    day: 'numeric',
+    month: 'short',
+  }).format(date);
+}
+
+/**
+ * Day + full month + year, e.g. "5 April 2026".
+ */
+export function formatFullDate(date: Date, locale: string): string {
+  return new Intl.DateTimeFormat(locale, {
+    day: 'numeric',
+    month: 'long',
+    year: 'numeric',
+  }).format(date);
+}

--- a/frontend/src/views/ParticipantView.vue
+++ b/frontend/src/views/ParticipantView.vue
@@ -301,6 +301,7 @@
                     </option>
                   </select>
                 </div>
+
               </div>
             </div>
 
@@ -315,8 +316,35 @@
             </p>
           </div>
 
-          <!-- Calendar grids - Display months vertically (month view) -->
-          <div v-if="displayMode === 'month'" class="space-y-6">
+          <!-- List view (applies to both month and week display modes) -->
+          <CalendarListView
+            v-if="viewStyle === 'list'"
+            :display-mode="displayMode"
+            :months-to-display="monthsToDisplay"
+            :weeks-to-display="weeksToDisplay"
+            :availabilities="availabilities"
+            :recurrences="recurrences"
+            :participant-counts="participantCounts"
+            :threshold="calendar?.threshold || 1"
+            :allowed-weekdays="calendar?.allowed_weekdays"
+            :timezone="calendar?.timezone"
+            :holidays-policy="calendar?.holidays_policy"
+            :allow-holiday-eves="calendar?.allow_holiday_eves"
+            :start-date="calendarStartDate"
+            :end-date="calendarEndDate"
+            :displayed-year="displayedYear"
+            :displayed-month="displayedMonth"
+            :current-week-start-date="currentWeekStartDate"
+            :current-participant-id="participantId"
+            :highlighted-dates="selectedParticipantsCommonDates"
+            @day-click="handleCalendarDayClick"
+            @month-change="handleMonthChange"
+            @week-change="handleWeekChange"
+            @view-style-change="handleViewStyleChange"
+          />
+
+          <!-- Calendar grids - Display months vertically (month view, classic style) -->
+          <div v-else-if="displayMode === 'month'" class="space-y-6">
             <CalendarGrid
               v-for="(monthConfig, index) in monthsToDisplay"
               :key="`${monthConfig.key}-${calendar?.id}`"
@@ -331,16 +359,8 @@
               :timezone="calendar?.timezone"
               :holidays-policy="calendar?.holidays_policy"
               :allow-holiday-eves="calendar?.allow_holiday_eves"
-              :start-date="
-                calendar?.start_date
-                  ? new Date(calendar.start_date).toISOString().split('T')[0]
-                  : undefined
-              "
-              :end-date="
-                calendar?.end_date
-                  ? new Date(calendar.end_date).toISOString().split('T')[0]
-                  : undefined
-              "
+              :start-date="calendarStartDate"
+              :end-date="calendarEndDate"
               :calendar-token="token"
               :current-participant-id="participantId"
               :current-participant-name="participant?.name || ''"
@@ -350,10 +370,11 @@
               @days-deselect="handleCalendarDaysDeselect"
               @add-exception="handleCalendarAddException"
               @month-change="handleMonthChange"
+              @view-style-change="handleViewStyleChange"
             />
           </div>
 
-          <!-- Weekly grid - Display weeks (week view) -->
+          <!-- Weekly grid - Display weeks (week view, classic style) -->
           <div v-else class="space-y-6">
             <WeeklyCalendarGrid
               v-for="(weekConfig, index) in weeksToDisplay"
@@ -378,16 +399,8 @@
               :holiday-max-time="(calendar as any)?.holiday_max_time"
               :holiday-eve-min-time="(calendar as any)?.holiday_eve_min_time"
               :holiday-eve-max-time="(calendar as any)?.holiday_eve_max_time"
-              :start-date="
-                calendar?.start_date
-                  ? new Date(calendar.start_date).toISOString().split('T')[0]
-                  : undefined
-              "
-              :end-date="
-                calendar?.end_date
-                  ? new Date(calendar.end_date).toISOString().split('T')[0]
-                  : undefined
-              "
+              :start-date="calendarStartDate"
+              :end-date="calendarEndDate"
               :calendar-token="token"
               :current-participant-id="participantId"
               :current-participant-name="participant?.name || ''"
@@ -402,6 +415,7 @@
               @week-change="handleWeekChange"
               @settings-change="handleWeeklySettingsChange"
               @availability-updated="handleAvailabilityUpdated"
+              @view-style-change="handleViewStyleChange"
             />
           </div>
         </div>
@@ -1232,12 +1246,14 @@ import { useCalendarHistoryStore } from '@/stores/calendarHistory';
 import { useToastStore } from '@/stores/toast';
 import { availabilitiesApi } from '@/api/availabilities';
 import CalendarGrid from '@/components/CalendarGrid.vue';
+import CalendarListView from '@/components/CalendarListView.vue';
 import WeeklyCalendarGrid, {
   type AvailabilityOperation,
 } from '@/components/WeeklyCalendarGrid.vue';
 import TimeSelect from '@/components/TimeSelect.vue';
 import CollapsibleSection from '@/components/CollapsibleSection.vue';
 import { clearHolidaysCache } from '@/composables/useDateValidation';
+import { formatDateISO } from '@/utils/dateFormatting';
 import { addParticipantEmail, resendVerificationEmail } from '@/api/notify';
 import type {
   Availability,
@@ -1279,6 +1295,14 @@ const currentWeekStartDate = ref<Date>(new Date());
 
 // Display mode: 'month' or 'week'
 const displayMode = ref<'month' | 'week'>('month');
+
+// View style: 'classic' (grid) or 'list' (vertical card list)
+// Default to 'list' on mobile (screen width < 768px), 'classic' on desktop
+const getDefaultViewStyle = (): 'classic' | 'list' => {
+  if (typeof window === 'undefined') return 'classic';
+  return window.innerWidth < 768 ? 'list' : 'classic';
+};
+const viewStyle = ref<'classic' | 'list'>(getDefaultViewStyle());
 
 // Number of periods (months or weeks) to display (1-4 for weeks, 1-12 for months)
 const numberOfPeriods = ref(1);
@@ -1365,6 +1389,18 @@ const availabilities = computed((): Availability[] => {
     })
   );
 });
+
+// Calendar date range as formatted strings (shared across grid components)
+const calendarStartDate = computed(() =>
+  calendar.value?.start_date
+    ? new Date(calendar.value.start_date).toISOString().split('T')[0]
+    : undefined
+);
+const calendarEndDate = computed(() =>
+  calendar.value?.end_date
+    ? new Date(calendar.value.end_date).toISOString().split('T')[0]
+    : undefined
+);
 
 // Generate an array of month configurations to display
 const monthsToDisplay = computed(() => {
@@ -1767,6 +1803,9 @@ async function loadCalendar() {
         if (savedSettings.slotDuration !== undefined) {
           slotDuration.value = savedSettings.slotDuration;
         }
+        if (savedSettings.viewStyle !== undefined) {
+          viewStyle.value = savedSettings.viewStyle;
+        }
       }
     }
 
@@ -1828,8 +1867,8 @@ async function loadParticipantCounts(year?: number, month?: number) {
       endDate = new Date(targetYear, targetMonth + numberOfPeriods.value, 0); // Last day of last displayed month
     }
 
-    const startStr = formatDateForAPI(startDate);
-    const endStr = formatDateForAPI(endDate);
+    const startStr = formatDateISO(startDate);
+    const endStr = formatDateISO(endDate);
 
     const summaries = await availabilitiesApi.getRangeSummary(token.value, startStr, endStr);
 
@@ -1849,13 +1888,6 @@ async function loadParticipantCounts(year?: number, month?: number) {
     console.error('Failed to load participant counts:', err);
     participantCounts.value = {};
   }
-}
-
-function formatDateForAPI(date: Date): string {
-  const year = date.getFullYear();
-  const month = String(date.getMonth() + 1).padStart(2, '0');
-  const day = String(date.getDate()).padStart(2, '0');
-  return `${year}-${month}-${day}`;
 }
 
 async function handleDeleteAvailability(date: string) {
@@ -2583,6 +2615,24 @@ watch(numberOfPeriods, async newCount => {
     await loadParticipantCounts(displayedYear.value, displayedMonth.value);
   }
 });
+
+watch(viewStyle, newStyle => {
+  if (calendar.value) {
+    historyStore.updateDisplaySettings(token.value, { viewStyle: newStyle });
+  }
+});
+
+function handleViewStyleChange(style: 'classic' | 'compact' | 'list') {
+  if (style === 'list') {
+    viewStyle.value = 'list';
+  } else {
+    viewStyle.value = 'classic';
+    // When switching back to classic/compact in month mode, update CalendarGrid's localStorage
+    if (displayMode.value === 'month' && typeof window !== 'undefined') {
+      localStorage.setItem('calendar-view-mode', style);
+    }
+  }
+}
 
 // Watch for route changes to reload the calendar when navigating between calendars
 // The immediate flag ensures this runs on initial mount

--- a/frontend/src/views/ParticipantView.vue
+++ b/frontend/src/views/ParticipantView.vue
@@ -336,11 +336,14 @@
             :displayed-month="displayedMonth"
             :current-week-start-date="currentWeekStartDate"
             :current-participant-id="participantId"
+            :current-participant-name="participant?.name || ''"
+            :calendar-token="token"
             :highlighted-dates="selectedParticipantsCommonDates"
             @day-click="handleCalendarDayClick"
             @month-change="handleMonthChange"
             @week-change="handleWeekChange"
             @view-style-change="handleViewStyleChange"
+            @availability-updated="handleAvailabilityUpdated"
           />
 
           <!-- Calendar grids - Display months vertically (month view, classic style) -->


### PR DESCRIPTION
## Summary
- New "List" view for the participant calendar, showing actionable days as a compact list
- Style selectable alongside the existing classic/compact grid views
- Choice persisted per calendar via the `calendarHistory` store
- Date formatting helpers extracted to `frontend/src/utils/dateFormatting.ts`
- EN/FR i18n entries added

## Test plan
- [x] `make build` passes
- [x] Open a participant calendar and switch between Classic / Compact / List styles
- [x] Reload the page and confirm the last chosen style is restored
- [x] Verify rendering in both EN and FR locales
- [x] Check responsive behavior of the list on narrow viewports