### PR TITLE
chore(config): env var hygiene and URL validation at startup

### DIFF
--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -1,4 +1,12 @@
-version: '3.8'
+# VS Code Dev Container stack.
+# The backend runs INSIDE the `devcontainer` service via `go run`, so it
+# reaches postgres/redis through the docker bridge network (hostnames
+# `postgres`/`redis`). Host port mappings on 5432/6379 are kept so the
+# developer can also connect from the host (psql, redis-cli, etc.).
+#
+# Credentials default to `whento`/`whento`/`whento` (same defaults as the Go
+# config), so no .env file is required to open the devcontainer. Override
+# via .env if you need different values.
 
 services:
   devcontainer:
@@ -12,16 +20,13 @@ services:
     ports:
       - "8080:8080"   # Application (backend in prod, frontend in dev)
     environment:
-      # Database
-      - DATABASE_URL=postgres://whento_user:whento_password@postgres:5432/whento_db?sslmode=disable
-      # Redis
-      - REDIS_URL=redis://redis:6379
-      # Go configuration
+      # DEVCONTAINER=1 makes the Go config default to host=postgres / host=redis
+      # and build DATABASE_URL / REDIS_URL automatically, so we don't hardcode
+      # them here.
+      - DEVCONTAINER=1
       - GOPATH=/home/vscode/go
       - GOCACHE=/home/vscode/go/cache
       - GOMODCACHE=/home/vscode/go/pkg/mod
-      # Dev settings
-      - DEVCONTAINER=1
       - GO_ENV=development
       - LOG_LEVEL=debug
     depends_on:
@@ -33,15 +38,15 @@ services:
   postgres:
     image: postgres:16-alpine
     environment:
-      POSTGRES_DB: whento_db
-      POSTGRES_USER: whento_user
-      POSTGRES_PASSWORD: whento_password
+      - POSTGRES_DB=${DB_NAME:-whento}
+      - POSTGRES_USER=${DB_USER:-whento}
+      - POSTGRES_PASSWORD=${DB_PASSWORD:-whento}
     volumes:
       - postgres-data:/var/lib/postgresql/data
     ports:
       - "5432:5432"
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U whento_user -d whento_db"]
+      test: ["CMD-SHELL", "pg_isready -U ${DB_USER:-whento} -d ${DB_NAME:-whento}"]
       interval: 5s
       timeout: 5s
       retries: 5

--- a/.env.example
+++ b/.env.example
@@ -17,31 +17,54 @@ LOG_LEVEL=debug
 
 # ------------------------------------------------------------------------------
 # Database (PostgreSQL)
-# Provide DATABASE_URL OR the individual DB_* variables. DATABASE_URL has priority.
+#
+# Two ways to configure the database, depending on how you deploy WhenTo:
+#
+# A) docker-compose (the docker-compose.yml shipped with this repo)
+#    The DB_* variables below are REQUIRED. They are consumed both by the
+#    postgres service (POSTGRES_USER/PASSWORD/DB) and by the app service,
+#    which builds DATABASE_URL from them. A DATABASE_URL set here is IGNORED
+#    by the compose file in this mode.
+#
+# B) Standalone / binary deployment (no compose, or your own compose)
+#    Set DATABASE_URL directly (preferred). The DB_* variables are then only
+#    used as a fallback if DATABASE_URL is not set.
 # ------------------------------------------------------------------------------
-# Option 1 - Full URL (recommended for production)
-# DATABASE_URL=postgres://db_user:your_secure_password@localhost:5432/whento?sslmode=disable
-
-# Option 2 - Individual variables (used if DATABASE_URL is not set)
-DB_HOST=localhost
-DB_PORT=5432
+# Required for docker-compose deployments:
 DB_NAME=whento
 DB_USER=whento
 DB_PASSWORD=your_secure_password_here
+# Used only in standalone / binary deployments as fallback when DATABASE_URL
+# is unset (the official compose hardcodes host=postgres, port=5432,
+# sslmode=disable and does not expose postgres on the host):
+DB_HOST=localhost
+DB_PORT=5432
 # DB_SSLMODE=disable
+
+# For standalone / binary deployments only (ignored by the official compose):
+# DATABASE_URL=postgres://db_user:your_secure_password@localhost:5432/whento?sslmode=disable
 
 # ------------------------------------------------------------------------------
 # Redis
-# Provide REDIS_URL OR the individual REDIS_* variables.
+#
+# Same logic as the database:
+# A) docker-compose: REDIS_PASSWORD is REQUIRED (used by the redis service via
+#    --requirepass, and by the app to build REDIS_URL). A REDIS_URL set here is
+#    IGNORED in this mode.
+# B) Standalone / binary: set REDIS_URL directly (preferred); the REDIS_*
+#    variables are only used as a fallback.
 # ------------------------------------------------------------------------------
-# Option 1 - Full URL (recommended for production)
-# REDIS_URL=redis://:your_redis_password@localhost:6379/0
-
-# Option 2 - Individual variables
+# Required for docker-compose deployments:
+REDIS_PASSWORD=your_redis_password_here
+# Used only in standalone / binary deployments as fallback when REDIS_URL is
+# unset (the official compose hardcodes host=redis, port=6379 and does not
+# expose redis on the host):
 REDIS_HOST=localhost
 REDIS_PORT=6379
-REDIS_PASSWORD=your_redis_password_here
 # REDIS_DB=0
+
+# For standalone / binary deployments only (ignored by the official compose):
+# REDIS_URL=redis://:your_redis_password@localhost:6379/0
 
 # ------------------------------------------------------------------------------
 # JWT - Keys are auto-generated on first container start

--- a/.env.example
+++ b/.env.example
@@ -1,60 +1,112 @@
-# Database
-DB_HOST=localhost
-DB_PORT=5432
-DB_NAME=whento
-DB_USER=whento
-DB_PASSWORD=your_secure_password_here
+# ==============================================================================
+# WhenTo - Environment variables (development / cloud compose stack)
+# Copy this file to .env and adapt the values before first launch.
+# ==============================================================================
 
-# Redis
-REDIS_HOST=localhost
-REDIS_PORT=6379
-REDIS_PASSWORD=your_redis_password_here
-
-# JWT - Keys are auto-generated on first container start
-JWT_PRIVATE_KEY_PATH=keys/private.pem
-JWT_PUBLIC_KEY_PATH=keys/public.pem
-JWT_ACCESS_EXPIRY=15m
-JWT_REFRESH_EXPIRY=168h
-
-# Auth / Registration Control
-# Allow new user registrations (after first admin user)
-ALLOWED_REGISTER=true
-# Comma-separated list of allowed email patterns (supports wildcards)
-# Examples:
-#   * = all emails allowed
-#   *@example.com = all emails from example.com domain
-#   user@* = specific user from any domain
-#   admin@example.com,*@company.org = specific email OR all from company.org
-ALLOWED_EMAILS=*
-
+# ------------------------------------------------------------------------------
 # Application
+# ------------------------------------------------------------------------------
 PORT=8080
 APP_ENV=development
 APP_URL=http://localhost:8080
 LOG_LEVEL=debug
 
-# Development: Set PORT=5173 when running with frontend dev server
-# Frontend will be on :8080 and proxy /api requests to backend on :5173
+# Development note: when running the Vite dev server for the frontend,
+# set PORT=5173 for the backend. The frontend then runs on :8080 and
+# proxies /api requests to the backend on :5173.
 
-# Rate Limiting
-RATE_LIMIT_ENABLED=true
+# ------------------------------------------------------------------------------
+# Database (PostgreSQL)
+# Provide DATABASE_URL OR the individual DB_* variables. DATABASE_URL has priority.
+# ------------------------------------------------------------------------------
+# Option 1 - Full URL (recommended for production)
+# DATABASE_URL=postgres://db_user:your_secure_password@localhost:5432/whento?sslmode=disable
 
+# Option 2 - Individual variables (used if DATABASE_URL is not set)
+DB_HOST=localhost
+DB_PORT=5432
+DB_NAME=whento
+DB_USER=whento
+DB_PASSWORD=your_secure_password_here
+# DB_SSLMODE=disable
+
+# ------------------------------------------------------------------------------
+# Redis
+# Provide REDIS_URL OR the individual REDIS_* variables.
+# ------------------------------------------------------------------------------
+# Option 1 - Full URL (recommended for production)
+# REDIS_URL=redis://:your_redis_password@localhost:6379/0
+
+# Option 2 - Individual variables
+REDIS_HOST=localhost
+REDIS_PORT=6379
+REDIS_PASSWORD=your_redis_password_here
+# REDIS_DB=0
+
+# ------------------------------------------------------------------------------
+# JWT - Keys are auto-generated on first container start
+# ------------------------------------------------------------------------------
+JWT_PRIVATE_KEY_PATH=keys/private.pem
+JWT_PUBLIC_KEY_PATH=keys/public.pem
+JWT_ACCESS_EXPIRY=15m
+JWT_REFRESH_EXPIRY=168h
+# JWT_ISSUER=whento
+
+# ------------------------------------------------------------------------------
+# Registration & access control
+# ------------------------------------------------------------------------------
+# Allow new user registrations (after first admin user)
+ALLOWED_REGISTER=true
+# Comma-separated list of allowed email patterns (supports wildcards)
+# Examples:
+#   * = all emails allowed (default)
+#   *@example.com = all emails from example.com domain
+#   user@* = specific user from any domain
+#   admin@example.com,*@company.org = specific email OR all from company.org
+ALLOWED_EMAILS=*
+
+# ------------------------------------------------------------------------------
+# Email / SMTP (required for email verification and notifications)
+# ------------------------------------------------------------------------------
+SMTP_HOST=smtp.example.com
+SMTP_PORT=587
+SMTP_USERNAME=your-email@example.com
+SMTP_PASSWORD=your-smtp-password
+# Sender address - must match the SMTP account
+SMTP_FROM=contact@example.com
+SMTP_FROM_NAME=WhenTo
+# TLS is determined automatically by port:
+#   port 465 -> implicit TLS
+#   port 587 (or other) -> STARTTLS
+# There is no separate TLS toggle variable.
+
+# Email verification required before creating calendars
+EMAIL_VERIFICATION_ENABLED=false
+# EMAIL_VERIFICATION_EXPIRY=24h
+
+# Token expirations
+# PASSWORD_RESET_EXPIRY=1h
+# MAGIC_LINK_EXPIRY=1h
+
+# ------------------------------------------------------------------------------
 # Security
+# ------------------------------------------------------------------------------
+BCRYPT_COST=12
 # Comma-separated list of allowed CORS origins (default: APP_URL)
 CORS_ORIGINS=http://localhost:8080
 # Comma-separated list of trusted reverse proxy IPs or CIDR ranges (leave empty if no proxy)
 # Only these IPs are allowed to set X-Forwarded-For / X-Real-IP headers
 # Examples: 10.0.0.1, 172.17.0.0/16, 2001:db8::/32
 TRUSTED_PROXIES=
+# Disable robots.txt (for private/non-public instances)
+# DISABLE_ROBOTS=false
 
-# SMTP Configuration (for email notifications)
-SMTP_HOST=smtp.example.com
-SMTP_PORT=587
-SMTP_USERNAME=your-email@example.com
-SMTP_PASSWORD=your-smtp-password
-SMTP_FROM=noreply@whento.be
-SMTP_TLS=true
-SMTP_FROM_NAME=WhenTo Apps
+# ------------------------------------------------------------------------------
+# Rate Limiting
+# ------------------------------------------------------------------------------
+RATE_LIMIT_ENABLED=true
 
-# Docker Configuration
+# ------------------------------------------------------------------------------
+# Docker build argument (not consumed at runtime)
+# ------------------------------------------------------------------------------
 VERSION=latest

--- a/README.md
+++ b/README.md
@@ -200,44 +200,112 @@ All Self-hosted licenses are **perpetual** (lifetime) with optional support rene
 
 ```bash
 # Application
-APP_ENV=production
-APP_URL=https://your-domain.com  # Used to generate links in emails
-PORT=8080
-LOG_LEVEL=info
+APP_ENV=production                # Default: development
+APP_URL=https://your-domain.com   # Used to generate links in emails
+PORT=8080                         # Default: 8080
+LOG_LEVEL=info                    # Default: info (debug, info, warn, error)
 
-# Database
+# Database — use DATABASE_URL (preferred) OR individual DB_* variables
 DATABASE_URL=postgres://user:pass@host:5432/db?sslmode=disable
+# Alternative granular variables (used if DATABASE_URL is not set):
+# DB_HOST=localhost
+# DB_PORT=5432
+# DB_NAME=whento
+# DB_USER=whento
+# DB_PASSWORD=yourpassword
+# DB_SSLMODE=disable
 
-# Redis
+# Redis — use REDIS_URL (preferred) OR individual REDIS_* variables
 REDIS_URL=redis://:password@host:6379
+# Alternative granular variables (used if REDIS_URL is not set):
+# REDIS_HOST=localhost
+# REDIS_PORT=6379
+# REDIS_PASSWORD=
+# REDIS_DB=0
 
-# JWT (auto-generated on first run)
+# JWT — keys are auto-generated on first run if they do not exist
 JWT_PRIVATE_KEY_PATH=/app/keys/private.pem
 JWT_PUBLIC_KEY_PATH=/app/keys/public.pem
-JWT_ACCESS_EXPIRY=15m
-JWT_REFRESH_EXPIRY=168h
+JWT_ACCESS_EXPIRY=15m             # Default: 15m
+JWT_REFRESH_EXPIRY=168h           # Default: 168h (7 days)
+# JWT_ISSUER=whento               # Default: whento
 
-# SMTP (required for email verification and notifications)
+# SMTP (required for email verification, password reset, and notifications)
 SMTP_HOST=mail.example.com
-SMTP_PORT=587               # Default: 587
+SMTP_PORT=587                     # Default: 587. Use 465 for implicit TLS, 587 for STARTTLS
 SMTP_USERNAME=user@example.com
 SMTP_PASSWORD=yourpassword
-SMTP_TLS=true               # Default: true
-EMAIL_FROM_ADDRESS=whento@example.com
-EMAIL_FROM_NAME=WhenTo      # Default: WhenTo
+SMTP_FROM=whento@example.com      # Default: contact@whento.be
+SMTP_FROM_NAME=WhenTo             # Default: Contact WhenTo
+# Note: TLS mode is determined automatically by the port — there is no
+#       separate TLS toggle variable.
 
-# Registration
-EMAIL_VERIFICATION_ENABLED=true
-ALLOWED_REGISTER=true
-ALLOWED_EMAILS=             # Comma-separated patterns (e.g., *@company.com). Default: * (all)
+# Registration & email verification
+EMAIL_VERIFICATION_ENABLED=true   # Default: false
+# EMAIL_VERIFICATION_EXPIRY=24h
+# PASSWORD_RESET_EXPIRY=1h
+# MAGIC_LINK_EXPIRY=1h
+ALLOWED_REGISTER=true             # Default: true
+ALLOWED_EMAILS=*                  # Comma-separated patterns (e.g., *@company.com). Default: * (all)
 
 # Rate Limiting
-RATE_LIMIT_ENABLED=true
+RATE_LIMIT_ENABLED=true           # Default: true
 
 # Security
-BCRYPT_COST=12
-CORS_ORIGINS=https://your-domain.com  # Comma-separated allowed CORS origins (default: APP_URL)
-TRUSTED_PROXIES=                       # Comma-separated trusted reverse proxy IPs (e.g., 127.0.0.1,10.0.0.1)
+BCRYPT_COST=12                                # Default: 12
+CORS_ORIGINS=https://your-domain.com          # Comma-separated allowed CORS origins (default: APP_URL)
+TRUSTED_PROXIES=                              # Comma-separated trusted reverse proxy IPs/CIDRs (e.g., 127.0.0.1,10.0.0.0/8)
+# DISABLE_ROBOTS=false                        # Disable robots.txt (default: false)
+
+# WebAuthn / Passkeys (optional — defaults are derived from APP_URL)
+# WEBAUTHN_RP_NAME=WhenTo
+# WEBAUTHN_RP_ID=your-domain.com
+# WEBAUTHN_RP_ORIGIN=https://your-domain.com
+# WEBAUTHN_TIMEOUT=60s
+
+# TOTP / 2FA (optional)
+# TOTP_ISSUER=WhenTo
+# TOTP_PERIOD=30
+# TOTP_DIGITS=6
+```
+
+#### Self-Hosted Only (build tag `selfhosted`)
+
+```bash
+# License — leave empty for Community tier (30 calendars).
+# JSON license key; auto-activates at startup if the DB has no license yet.
+# Can also be activated via the Admin UI.
+LICENSE_KEY=
+
+# Public key used to verify license signatures.
+# Leave empty to use the built-in WhenTo public key (recommended).
+# LICENSE_PUBLIC_KEY=
+```
+
+#### Cloud Only (build tag `cloud`)
+
+```bash
+# Stripe — subscription billing
+STRIPE_SECRET_KEY=sk_live_...
+STRIPE_WEBHOOK_SUBSCRIPTION_SECRET=whsec_...
+STRIPE_PRICE_PRO=price_...        # Stripe Price ID for the Pro plan
+STRIPE_PRICE_POWER=price_...      # Stripe Price ID for the Power plan
+
+# Stripe — license shop (one-time payments)
+STRIPE_PRICE_PRO_LICENSE=price_...
+STRIPE_PRICE_ENTERPRISE_LICENSE=price_...
+STRIPE_WEBHOOK_LICENCE_SECRET=whsec_...
+STRIPE_WEBHOOK_PRICE_SECRET=whsec_...    # Optional: product/price update webhooks
+
+# Ed25519 private key (base64) used to sign self-hosted licenses sold through the shop
+LICENSE_PRIVATE_KEY_BASE64=
+```
+
+#### Frontend (Build-Time Only)
+
+```bash
+# Set at build time (npm run build), not at runtime
+VITE_BUILD_TYPE=selfhosted        # 'selfhosted' or 'cloud'. Default: selfhosted
 ```
 
 ---
@@ -299,7 +367,7 @@ version: "3.8"
 
 services:
   whento:
-    image: ghcr.io/When-To/whento:latest
+    image: ghcr.io/when-to/whento:latest
     ports:
       - "8080:8080"
     environment:
@@ -307,12 +375,11 @@ services:
       - REDIS_URL=redis://:password@redis:6379
       - APP_URL=https://your-domain.com  # Used to generate links in emails
       - SMTP_HOST=mail.example.com
-      - SMTP_PORT=587
+      - SMTP_PORT=587                    # 465 = implicit TLS, 587 = STARTTLS
       - SMTP_USERNAME=user@example.com
       - SMTP_PASSWORD=yourpassword
-      - SMTP_TLS=true
-      - EMAIL_FROM_ADDRESS=whento@example.com
-      - EMAIL_FROM_NAME=WhenTo
+      - SMTP_FROM=whento@example.com
+      - SMTP_FROM_NAME=WhenTo
     depends_on:
       - postgres
       - redis
@@ -346,7 +413,7 @@ volumes:
 # Self-hosted build (default)
 make build
 # or
-go build -tags selfhosted -o bin/whento ./cmd/main.go
+go build -tags selfhosted -o bin/whento ./cmd/
 ```
 
 ### Reverse Proxy

--- a/README.md
+++ b/README.md
@@ -205,23 +205,31 @@ APP_URL=https://your-domain.com   # Used to generate links in emails
 PORT=8080                         # Default: 8080
 LOG_LEVEL=info                    # Default: info (debug, info, warn, error)
 
-# Database — use DATABASE_URL (preferred) OR individual DB_* variables
-DATABASE_URL=postgres://user:pass@host:5432/db?sslmode=disable
-# Alternative granular variables (used if DATABASE_URL is not set):
-# DB_HOST=localhost
-# DB_PORT=5432
-# DB_NAME=whento
-# DB_USER=whento
-# DB_PASSWORD=yourpassword
-# DB_SSLMODE=disable
+# Database
+# - For the docker-compose.yml shipped with this repo: set the DB_* variables
+#   below (DB_NAME/DB_USER/DB_PASSWORD are REQUIRED — they are consumed by
+#   both the postgres service and the app service). DATABASE_URL is ignored
+#   in that mode.
+# - For standalone / binary deployments: set DATABASE_URL directly (preferred);
+#   DB_* are then only used as a fallback if DATABASE_URL is unset.
+DB_NAME=whento
+DB_USER=whento
+DB_PASSWORD=yourpassword
+# DB_HOST=localhost                 # Standalone/binary only (compose hardcodes "postgres")
+# DB_PORT=5432                      # Standalone/binary only (compose hardcodes 5432, not exposed)
+# DB_SSLMODE=disable                # Standalone/binary only (compose hardcodes "disable")
+# DATABASE_URL=postgres://user:pass@host:5432/db?sslmode=disable   # Standalone only
 
-# Redis — use REDIS_URL (preferred) OR individual REDIS_* variables
-REDIS_URL=redis://:password@host:6379
-# Alternative granular variables (used if REDIS_URL is not set):
-# REDIS_HOST=localhost
-# REDIS_PORT=6379
-# REDIS_PASSWORD=
-# REDIS_DB=0
+# Redis — same logic as the database
+# - docker-compose: REDIS_PASSWORD is REQUIRED (used by both the redis service
+#   and the app). REDIS_URL is ignored.
+# - Standalone / binary: set REDIS_URL directly (preferred); REDIS_* are
+#   fallback only.
+REDIS_PASSWORD=yourpassword
+# REDIS_HOST=localhost              # Standalone/binary only (compose hardcodes "redis")
+# REDIS_PORT=6379                   # Standalone/binary only (compose hardcodes 6379, not exposed)
+# REDIS_DB=0                        # Standalone/binary only
+# REDIS_URL=redis://:password@host:6379                            # Standalone only
 
 # JWT — keys are auto-generated on first run if they do not exist
 JWT_PRIVATE_KEY_PATH=/app/keys/private.pem
@@ -362,50 +370,37 @@ whento/
 
 ### Docker Compose (Recommended)
 
-```yaml
-version: "3.8"
+The repository ships a ready-to-use [`docker-compose.yml`](docker-compose.yml). It defines the `app`, `postgres`, and `redis` services and builds `DATABASE_URL` / `REDIS_URL` for the app from the variables you set in `.env`.
 
-services:
-  whento:
-    image: ghcr.io/when-to/whento:latest
-    ports:
-      - "8080:8080"
-    environment:
-      - DATABASE_URL=postgres://whento:password@postgres:5432/whento
-      - REDIS_URL=redis://:password@redis:6379
-      - APP_URL=https://your-domain.com  # Used to generate links in emails
-      - SMTP_HOST=mail.example.com
-      - SMTP_PORT=587                    # 465 = implicit TLS, 587 = STARTTLS
-      - SMTP_USERNAME=user@example.com
-      - SMTP_PASSWORD=yourpassword
-      - SMTP_FROM=whento@example.com
-      - SMTP_FROM_NAME=WhenTo
-    depends_on:
-      - postgres
-      - redis
-    volumes:
-      - jwt_keys:/app/keys
-
-  postgres:
-    image: postgres:16-alpine
-    environment:
-      POSTGRES_DB: whento
-      POSTGRES_USER: whento
-      POSTGRES_PASSWORD: password
-    volumes:
-      - postgres_data:/var/lib/postgresql/data
-
-  redis:
-    image: redis:7-alpine
-    command: redis-server --requirepass password
-    volumes:
-      - redis_data:/data
-
-volumes:
-  postgres_data:
-  redis_data:
-  jwt_keys:
+```bash
+cp .env.example .env
+# Edit .env — at minimum set:
+#   DB_PASSWORD, REDIS_PASSWORD, APP_URL, and SMTP_* if you want email
+docker compose up -d
 ```
+
+Minimum required variables in `.env` when using this compose file:
+
+```bash
+# Database — consumed by both the postgres service and the app
+DB_PASSWORD=your_secure_password
+# DB_NAME, DB_USER default to "whento" if unset
+
+# Redis — consumed by both the redis service and the app
+REDIS_PASSWORD=your_redis_password
+
+# Application
+APP_URL=https://your-domain.com
+
+# SMTP (required for email verification and notifications)
+SMTP_HOST=mail.example.com
+SMTP_PORT=587
+SMTP_USERNAME=user@example.com
+SMTP_PASSWORD=yourpassword
+SMTP_FROM=whento@example.com
+```
+
+> **Note:** with this compose file, `DATABASE_URL` and `REDIS_URL` are constructed automatically from `DB_*` / `REDIS_PASSWORD`. Setting them directly in `.env` has no effect here — they only apply to standalone / binary deployments.
 
 ### Building from Source
 

--- a/build/cloud/.env.example
+++ b/build/cloud/.env.example
@@ -1,43 +1,32 @@
 # ==============================================================================
-# WhenTo Self-hosted - Environment variables
+# WhenTo Cloud - Environment variables (SaaS build, build tag: cloud)
 # Copyright (C) 2025 WhenTo Contributors
 #
-# Copy this file to .env in the same directory as docker-compose.yml,
-# then customize the values before first launch.
+# Copy this file to .env in the same directory as docker-compose.yml.
+# This file documents the Cloud-specific variables; common variables
+# (database, Redis, SMTP, JWT, security) are identical to the root .env.example.
 # ==============================================================================
 
 # ------------------------------------------------------------------------------
 # Application
 # ------------------------------------------------------------------------------
-APP_URL=https://your-domain.com
+APP_URL=https://your-cloud-domain.com
 APP_ENV=production
 LOG_LEVEL=info
 # PORT=8080
 
 # ------------------------------------------------------------------------------
-# Database (PostgreSQL)
-# The password set here is consumed by docker-compose.yml to build DATABASE_URL
-# and to initialize the postgres container.
+# Database (PostgreSQL) - prefer DATABASE_URL in production
 # ------------------------------------------------------------------------------
-POSTGRES_PASSWORD=change_this_strong_password
-
-# DATABASE_URL is built automatically from POSTGRES_PASSWORD by docker-compose.
-# Override only if you point WhenTo at an external database.
-# DATABASE_URL=postgres://whento:change_this_strong_password@postgres:5432/whento?sslmode=disable
+DATABASE_URL=postgres://whento:change_this_strong_password@postgres:5432/whento?sslmode=disable
 
 # ------------------------------------------------------------------------------
 # Redis
-# The password set here is consumed by docker-compose.yml.
 # ------------------------------------------------------------------------------
-REDIS_PASSWORD=change_this_strong_redis_password
-
-# REDIS_URL is built automatically from REDIS_PASSWORD by docker-compose.
-# Override only if you point WhenTo at an external Redis.
-# REDIS_URL=redis://:change_this_strong_redis_password@redis:6379
+REDIS_URL=redis://:change_this_strong_redis_password@redis:6379/0
 
 # ------------------------------------------------------------------------------
 # JWT - Keys are auto-generated on first container start
-# Do not change these paths unless you mount your own keys.
 # ------------------------------------------------------------------------------
 JWT_PRIVATE_KEY_PATH=/app/keys/private.pem
 JWT_PUBLIC_KEY_PATH=/app/keys/public.pem
@@ -45,55 +34,57 @@ JWT_ACCESS_EXPIRY=15m
 JWT_REFRESH_EXPIRY=168h
 
 # ------------------------------------------------------------------------------
-# Email / SMTP (required for email verification and notifications)
-# Leave SMTP_HOST empty to disable outgoing email.
+# Email / SMTP (required)
 # ------------------------------------------------------------------------------
 SMTP_HOST=smtp.example.com
 SMTP_PORT=587
 SMTP_USERNAME=your-email@example.com
 SMTP_PASSWORD=your-smtp-password
-# Sender address - must match the SMTP account
 SMTP_FROM=contact@example.com
 SMTP_FROM_NAME=WhenTo
-# TLS is determined automatically by port:
-#   port 465 -> implicit TLS
-#   port 587 (or other) -> STARTTLS
+# TLS is determined automatically by port (465 = implicit TLS, 587 = STARTTLS).
 
-# Email verification required before creating calendars (recommended for public instances)
 EMAIL_VERIFICATION_ENABLED=true
 
 # ------------------------------------------------------------------------------
 # Registration & access control
 # ------------------------------------------------------------------------------
 ALLOWED_REGISTER=true
-# Allowed email patterns (comma-separated, wildcards supported).
-# Leave as * to accept any address, or restrict (e.g. *@mycompany.com).
 ALLOWED_EMAILS=*
 
 # ------------------------------------------------------------------------------
 # Security
 # ------------------------------------------------------------------------------
 BCRYPT_COST=12
-# Comma-separated list of allowed CORS origins (default: value of APP_URL)
-CORS_ORIGINS=https://your-domain.com
-# Trusted reverse proxy IPs or CIDR ranges (e.g. Traefik, Caddy, Nginx)
-# Examples: 10.0.0.1, 172.17.0.0/16
+CORS_ORIGINS=https://your-cloud-domain.com
 TRUSTED_PROXIES=
-
-# ------------------------------------------------------------------------------
-# Rate Limiting
-# ------------------------------------------------------------------------------
 RATE_LIMIT_ENABLED=true
 
-# ------------------------------------------------------------------------------
-# Self-hosted license (optional - leave empty for Community tier)
-# Community  : 30 calendars (free)
-# Pro        : 300 calendars (100 EUR one-time)
-# Enterprise : unlimited     (250 EUR one-time)
-# Can also be activated via the Admin UI after install.
-# ------------------------------------------------------------------------------
-LICENSE_KEY=
+# ==============================================================================
+# Cloud-only variables (build tag: cloud)
+# ==============================================================================
 
-# Public key used to verify license signatures.
-# Leave empty to use the built-in WhenTo public key (recommended).
-# LICENSE_PUBLIC_KEY=
+# ------------------------------------------------------------------------------
+# Stripe - Subscriptions
+# ------------------------------------------------------------------------------
+STRIPE_SECRET_KEY=sk_live_xxx
+STRIPE_WEBHOOK_SUBSCRIPTION_SECRET=whsec_xxx
+# Stripe Price IDs for the recurring subscription plans
+STRIPE_PRICE_PRO=price_xxx
+STRIPE_PRICE_POWER=price_xxx
+
+# ------------------------------------------------------------------------------
+# Stripe - License shop (one-time payments)
+# ------------------------------------------------------------------------------
+STRIPE_PRICE_PRO_LICENSE=price_xxx
+STRIPE_PRICE_ENTERPRISE_LICENSE=price_xxx
+STRIPE_WEBHOOK_LICENCE_SECRET=whsec_xxx
+# Optional: webhook secret for product/price update events
+STRIPE_WEBHOOK_PRICE_SECRET=whsec_xxx
+
+# ------------------------------------------------------------------------------
+# License signing key
+# Ed25519 private key (base64-encoded) used to sign self-hosted licenses
+# sold through the shop. Generate with `cmd/licensegen`.
+# ------------------------------------------------------------------------------
+LICENSE_PRIVATE_KEY_BASE64=

--- a/build/selfhosted/docker-compose.yml
+++ b/build/selfhosted/docker-compose.yml
@@ -10,8 +10,9 @@ services:
     ports:
       - "8080:8080"
     environment:
-      # Build type
-      - BUILD_TYPE=selfhosted
+      # Application
+      - APP_ENV=${APP_ENV:-production}
+      - LOG_LEVEL=${LOG_LEVEL:-info}
 
       # Database
       - DATABASE_URL=postgres://whento:${POSTGRES_PASSWORD:-changeme}@postgres:5432/whento?sslmode=disable
@@ -29,10 +30,19 @@ services:
       - LICENSE_KEY=${LICENSE_KEY:-}
       - LICENSE_PUBLIC_KEY=${LICENSE_PUBLIC_KEY:-}
 
-      # Application
+      # Application URL & registration
       - APP_URL=${APP_URL:-http://localhost:8080}
       - ALLOWED_REGISTER=${ALLOWED_REGISTER:-true}
-      - ALLOWED_EMAILS=${ALLOWED_EMAILS:-}
+      - ALLOWED_EMAILS=${ALLOWED_EMAILS:-*}
+
+      # SMTP (TLS is implied by SMTP_PORT: 465 = implicit TLS, otherwise STARTTLS)
+      - SMTP_HOST=${SMTP_HOST:-}
+      - SMTP_PORT=${SMTP_PORT:-587}
+      - SMTP_USERNAME=${SMTP_USERNAME:-}
+      - SMTP_PASSWORD=${SMTP_PASSWORD:-}
+      - SMTP_FROM=${SMTP_FROM:-contact@whento.be}
+      - SMTP_FROM_NAME=${SMTP_FROM_NAME:-WhenTo}
+      - EMAIL_VERIFICATION_ENABLED=${EMAIL_VERIFICATION_ENABLED:-true}
 
       # Rate limiting
       - RATE_LIMIT_ENABLED=true

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -115,6 +115,12 @@ func main() {
 	log := logger.New(cfg.LogLevel, "json")
 	logger.SetDefault(log)
 
+	// Fail fast on malformed URL-shaped env vars (DATABASE_URL, REDIS_URL, APP_URL).
+	if err := cfg.Validate(); err != nil {
+		log.Error("Invalid configuration", "error", err)
+		os.Exit(1)
+	}
+
 	log.Info("Starting WhenTo Application", "port", cfg.Port, "env", cfg.AppEnv)
 
 	// Context for initialization

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,51 +1,9 @@
-version: "3.8"
+# Development stack: PostgreSQL + Redis only.
+# The backend runs on the host via `go run` (see `make dev-db` / `make dev-app`),
+# so postgres and redis must be reachable on localhost — their ports are
+# intentionally exposed here, unlike the production docker-compose.yml.
 
 services:
-  app:
-    build:
-      context: .
-      dockerfile: Dockerfile
-      args:
-        VERSION: ${VERSION:-latest}
-    container_name: whento-app
-    ports:
-      - "${APP_PORT:-8080}:8080"
-    environment:
-      # Application
-      - APP_ENV=${APP_ENV:-production}
-      - APP_URL=${APP_URL:-http://localhost:8080}
-      - PORT=8080
-      - LOG_LEVEL=${LOG_LEVEL:-info}
-
-      # Database
-      - DATABASE_URL=postgres://${DB_USER:-whento}:${DB_PASSWORD:?Database password required}@postgres:5432/${DB_NAME:-whento}?sslmode=disable
-
-      # Redis
-      - REDIS_URL=redis://:${REDIS_PASSWORD:?Redis password required}@redis:6379/0
-
-      # JWT - Keys are auto-generated on first start
-      - JWT_PRIVATE_KEY_PATH=/app/keys/private.pem
-      - JWT_PUBLIC_KEY_PATH=/app/keys/public.pem
-      - JWT_ACCESS_EXPIRY=${JWT_ACCESS_EXPIRY:-15m}
-      - JWT_REFRESH_EXPIRY=${JWT_REFRESH_EXPIRY:-168h}
-
-      # Rate Limiting
-      - RATE_LIMIT_ENABLED=${RATE_LIMIT_ENABLED:-true}
-    depends_on:
-      postgres:
-        condition: service_healthy
-      redis:
-        condition: service_healthy
-    restart: unless-stopped
-    networks:
-      - whento-network
-    healthcheck:
-      test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:8080/api/health"]
-      interval: 30s
-      timeout: 10s
-      retries: 3
-      start_period: 40s
-
   postgres:
     image: postgres:16-alpine
     container_name: whento-postgres

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -31,9 +31,6 @@ services:
 
       # Rate Limiting
       - RATE_LIMIT_ENABLED=${RATE_LIMIT_ENABLED:-true}
-
-      # Notifications
-      - NOTIFY_ENABLED=${NOTIFY_ENABLED:-false}
     depends_on:
       postgres:
         condition: service_healthy
@@ -43,7 +40,7 @@ services:
     networks:
       - whento-network
     healthcheck:
-      test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:8080/health"]
+      test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:8080/api/health"]
       interval: 30s
       timeout: 10s
       retries: 3

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,22 +30,18 @@ services:
       - CORS_ORIGINS=${CORS_ORIGINS:-${APP_URL:-http://localhost:8080}}
       - TRUSTED_PROXIES=${TRUSTED_PROXIES:-}
       
-      # SMTP
+      # SMTP (TLS is implied by SMTP_PORT: 465 = implicit TLS, otherwise STARTTLS)
       - SMTP_HOST=${SMTP_HOST}
       - SMTP_PORT=${SMTP_PORT:-587}
       - SMTP_USERNAME=${SMTP_USERNAME}
       - SMTP_PASSWORD=${SMTP_PASSWORD}
-      - SMTP_TLS=${SMTP_TLS:-true}
-      - EMAIL_FROM_ADDRESS=${EMAIL_FROM_ADDRESS}
-      - EMAIL_FROM_NAME=${EMAIL_FROM_NAME:-WhenTo}
+      - SMTP_FROM=${SMTP_FROM}
+      - SMTP_FROM_NAME=${SMTP_FROM_NAME:-WhenTo}
 
       # Registration
       - EMAIL_VERIFICATION_ENABLED=${EMAIL_VERIFICATION_ENABLED:-true}
       - ALLOWED_REGISTER=${ALLOWED_REGISTER:-true}
       - ALLOWED_EMAILS=${ALLOWED_EMAILS:-*}
-
-      # Notifications
-      - NOTIFY_ENABLED=${NOTIFY_ENABLED:-false}
     depends_on:
       postgres:
         condition: service_healthy
@@ -55,7 +51,7 @@ services:
     networks:
       - whento-network
     healthcheck:
-      test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:8080/health"]
+      test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:8080/api/health"]
       interval: 30s
       timeout: 10s
       retries: 3

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -66,8 +66,6 @@ services:
       - POSTGRES_PASSWORD=${DB_PASSWORD:?Database password required}
     volumes:
       - postgres_data:/var/lib/postgresql/data
-    ports:
-      - "${DB_PORT:-5432}:5432"
     restart: unless-stopped
     networks:
       - whento-network
@@ -85,8 +83,6 @@ services:
     command: redis-server --requirepass ${REDIS_PASSWORD:?Redis password required} --maxmemory 256mb --maxmemory-policy allkeys-lru
     volumes:
       - redis_data:/data
-    ports:
-      - "${REDIS_PORT:-6379}:6379"
     restart: unless-stopped
     networks:
       - whento-network

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -6,6 +6,7 @@ package config
 
 import (
 	"fmt"
+	"net/url"
 	"os"
 	"strconv"
 	"strings"
@@ -266,8 +267,10 @@ func buildDatabaseURL() string {
 	password := getEnv("DB_PASSWORD", "whento")
 	sslmode := getEnv("DB_SSLMODE", "disable")
 
-	return fmt.Sprintf("postgres://%s:%s@%s:%s/%s?sslmode=%s",
-		user, password, host, port, name, sslmode)
+	// url.UserPassword percent-encodes special characters in user/password so
+	// passwords containing '@', ':', '/', '?' do not break the URL.
+	return fmt.Sprintf("postgres://%s@%s:%s/%s?sslmode=%s",
+		url.UserPassword(user, password).String(), host, port, name, sslmode)
 }
 
 func buildRedisURL() string {
@@ -285,7 +288,9 @@ func buildRedisURL() string {
 	db := getEnv("REDIS_DB", "0")
 
 	if password != "" {
-		return fmt.Sprintf("redis://:%s@%s:%s/%s", password, host, port, db)
+		// url.UserPassword percent-encodes special characters in the password.
+		return fmt.Sprintf("redis://%s@%s:%s/%s",
+			url.UserPassword("", password).String(), host, port, db)
 	}
 	return fmt.Sprintf("redis://%s:%s/%s", host, port, db)
 }
@@ -329,6 +334,94 @@ func getEmailList(key string, defaultValue []string) []string {
 		return defaultValue
 	}
 	return result
+}
+
+// Validate checks that URL-shaped environment variables are well-formed.
+// It runs at startup so configuration errors surface before any side effect
+// (logger, JWT keys, DB connection). Error messages mask passwords.
+func (c *Config) Validate() error {
+	if err := validateDatabaseURL(c.DatabaseURL); err != nil {
+		return fmt.Errorf("invalid DATABASE_URL (or DB_* vars): %w", err)
+	}
+	if err := validateRedisURL(c.RedisURL); err != nil {
+		return fmt.Errorf("invalid REDIS_URL (or REDIS_* vars): %w", err)
+	}
+	if err := validateAppURL(c.AppURL); err != nil {
+		return fmt.Errorf("invalid APP_URL: %w", err)
+	}
+	return nil
+}
+
+func validateDatabaseURL(raw string) error {
+	if raw == "" {
+		return fmt.Errorf("value is empty")
+	}
+	u, err := url.Parse(raw)
+	if err != nil {
+		return fmt.Errorf("malformed URL %q: %w", MaskURL(raw), err)
+	}
+	if u.Scheme != "postgres" && u.Scheme != "postgresql" {
+		return fmt.Errorf("scheme must be postgres:// or postgresql:// (got %q in %q)", u.Scheme, MaskURL(raw))
+	}
+	if u.Host == "" {
+		return fmt.Errorf("missing host in %q (expected postgres://user:password@host:port/dbname)", MaskURL(raw))
+	}
+	return nil
+}
+
+func validateRedisURL(raw string) error {
+	if raw == "" {
+		return fmt.Errorf("value is empty")
+	}
+	u, err := url.Parse(raw)
+	if err != nil {
+		return fmt.Errorf("malformed URL %q: %w", MaskURL(raw), err)
+	}
+	if u.Scheme != "redis" && u.Scheme != "rediss" {
+		return fmt.Errorf("scheme must be redis:// or rediss:// (got %q in %q)", u.Scheme, MaskURL(raw))
+	}
+	if u.Host == "" {
+		return fmt.Errorf("missing host in %q (expected redis://[:password@]host:port[/db])", MaskURL(raw))
+	}
+	return nil
+}
+
+func validateAppURL(raw string) error {
+	if raw == "" {
+		return fmt.Errorf("value is empty")
+	}
+	u, err := url.Parse(raw)
+	if err != nil {
+		return fmt.Errorf("malformed URL %q: %w", raw, err)
+	}
+	if u.Scheme != "http" && u.Scheme != "https" {
+		return fmt.Errorf("scheme must be http:// or https:// (got %q)", u.Scheme)
+	}
+	if u.Host == "" {
+		return fmt.Errorf("missing host in %q", raw)
+	}
+	return nil
+}
+
+// MaskURL returns a copy of raw with the userinfo password replaced by ***.
+// Safe to embed in logs and error messages. Returns the input unchanged
+// if it cannot be parsed as a URL (best-effort masking).
+func MaskURL(raw string) string {
+	u, err := url.Parse(raw)
+	if err != nil || u.User == nil {
+		return raw
+	}
+	if _, hasPassword := u.User.Password(); !hasPassword {
+		return raw
+	}
+	// Build the userinfo manually so the placeholder is not percent-encoded
+	// (url.UserPassword would turn "***" into "%2A%2A%2A").
+	masked := *u
+	masked.User = nil
+	rest := masked.String()
+	prefix := u.Scheme + "://"
+	suffix := strings.TrimPrefix(rest, prefix)
+	return fmt.Sprintf("%s%s:***@%s", prefix, u.User.Username(), suffix)
 }
 
 // extractDomain extracts the domain from a URL for WebAuthn RP ID

--- a/internal/config/validate_test.go
+++ b/internal/config/validate_test.go
@@ -1,0 +1,124 @@
+// WhenTo - Collaborative event calendar for self-hosted environments
+// Copyright (C) 2025 WhenTo Contributors
+// SPDX-License-Identifier: BSL-1.1
+
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestValidateDatabaseURL(t *testing.T) {
+	tests := []struct {
+		name      string
+		in        string
+		wantError bool
+		errSubstr string
+	}{
+		{"valid postgres", "postgres://user:pass@host:5432/db?sslmode=disable", false, ""},
+		{"valid postgresql", "postgresql://user:pass@host:5432/db", false, ""},
+		{"empty", "", true, "empty"},
+		{"wrong scheme", "mysql://user:pass@host:5432/db", true, "postgres://"},
+		{"missing host", "postgres://user:pass@/db", true, "missing host"},
+		{"valid with encoded special char password", "postgres://user:p%40ss@host:5432/db", false, ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateDatabaseURL(tt.in)
+			if tt.wantError && err == nil {
+				t.Fatalf("expected error, got nil")
+			}
+			if !tt.wantError && err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if tt.wantError && tt.errSubstr != "" && !strings.Contains(err.Error(), tt.errSubstr) {
+				t.Fatalf("expected error to contain %q, got %q", tt.errSubstr, err.Error())
+			}
+		})
+	}
+}
+
+func TestValidateRedisURL(t *testing.T) {
+	tests := []struct {
+		name      string
+		in        string
+		wantError bool
+		errSubstr string
+	}{
+		{"valid redis", "redis://:pwd@host:6379/0", false, ""},
+		{"valid rediss (TLS)", "rediss://:pwd@host:6379", false, ""},
+		{"valid no password", "redis://host:6379", false, ""},
+		{"empty", "", true, "empty"},
+		{"wrong scheme", "http://host:6379", true, "redis://"},
+		{"missing host", "redis://", true, "missing host"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateRedisURL(tt.in)
+			if tt.wantError && err == nil {
+				t.Fatalf("expected error, got nil")
+			}
+			if !tt.wantError && err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if tt.wantError && tt.errSubstr != "" && !strings.Contains(err.Error(), tt.errSubstr) {
+				t.Fatalf("expected error to contain %q, got %q", tt.errSubstr, err.Error())
+			}
+		})
+	}
+}
+
+func TestMaskURL(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"postgres with password", "postgres://user:secret@host:5432/db", "postgres://user:***@host:5432/db"},
+		{"redis with password only", "redis://:secret@host:6379", "redis://:***@host:6379"},
+		{"no userinfo", "postgres://host:5432/db", "postgres://host:5432/db"},
+		{"username only (no password)", "postgres://user@host:5432/db", "postgres://user@host:5432/db"},
+		{"non-URL string preserved", "not a url at all", "not a url at all"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := MaskURL(tt.in); got != tt.want {
+				t.Fatalf("MaskURL(%q) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestBuildDatabaseURLEscapesPassword(t *testing.T) {
+	t.Setenv("DB_HOST", "host")
+	t.Setenv("DB_PORT", "5432")
+	t.Setenv("DB_NAME", "db")
+	t.Setenv("DB_USER", "user")
+	t.Setenv("DB_PASSWORD", "p@ss:w/ord?x")
+	t.Setenv("DB_SSLMODE", "disable")
+
+	got := buildDatabaseURL()
+	if err := validateDatabaseURL(got); err != nil {
+		t.Fatalf("built URL fails validation: %v (url=%s)", err, MaskURL(got))
+	}
+	// Spot-check that the literal special characters are not present unescaped.
+	if strings.Contains(got, "p@ss:w/ord?x") {
+		t.Fatalf("password was not escaped: %s", MaskURL(got))
+	}
+}
+
+func TestBuildRedisURLEscapesPassword(t *testing.T) {
+	t.Setenv("REDIS_HOST", "host")
+	t.Setenv("REDIS_PORT", "6379")
+	t.Setenv("REDIS_PASSWORD", "p@ss:w/ord?x")
+	t.Setenv("REDIS_DB", "0")
+
+	got := buildRedisURL()
+	if err := validateRedisURL(got); err != nil {
+		t.Fatalf("built URL fails validation: %v (url=%s)", err, MaskURL(got))
+	}
+	if strings.Contains(got, "p@ss:w/ord?x") {
+		t.Fatalf("password was not escaped: %s", MaskURL(got))
+	}
+}


### PR DESCRIPTION
## Summary

Two coherent changes, separable into the two commits on this branch:

1. **`docs(config)` — env var documentation aligned with code, dead vars dropped.** The `.env.example` files and compose files were drifting from what the Go config actually reads. Self-hosters were setting `SMTP_TLS`, `EMAIL_FROM_ADDRESS`, `EMAIL_FROM_NAME`, `NOTIFY_ENABLED`, `BUILD_TYPE` — none of which are consumed by the application — while missing `LICENSE_PUBLIC_KEY` and the actual `SMTP_FROM` / `SMTP_FROM_NAME` pair. The container healthcheck still pointed at `/health` (the route is `/api/health`). README now documents WebAuthn, TOTP, Stripe, and frontend build-time vars; a dedicated `build/cloud/.env.example` is added.

2. **`feat(config)` — fail fast on malformed URL-shaped env vars.** Today a typo in `DATABASE_URL`, `REDIS_URL` or `APP_URL` surfaces deep in the boot sequence (logger, JWT keys, DB pool), making the cause hard to spot. `Config.Validate()` now runs right after `Load()` and checks scheme, host, and non-emptiness. A `MaskURL()` helper makes sure error messages never leak the userinfo password. While I was there, `buildDatabaseURL` / `buildRedisURL` now use `url.UserPassword` so passwords containing `@`, `:`, `/`, `?` no longer break the URL.

## Why

The trigger was an audit of the README ↔ Dockerfile ↔ docker-compose ↔ `internal/config/config.go` matrix. Findings:
- `SMTP_TLS` was a ghost variable in `.env`/compose — code derives TLS from `SMTP_PORT`, README already said so.
- `LICENSE_PUBLIC_KEY` was passed by `build/selfhosted/docker-compose.yml` and read by the code, but undocumented anywhere.
- `EMAIL_FROM_ADDRESS` / `EMAIL_FROM_NAME` in compose did nothing — the code reads `SMTP_FROM` / `SMTP_FROM_NAME`.
- Healthcheck path mismatch (`/health` vs `/api/health`).

## Notable behavior change

Boot will now exit 1 with a clear error if `DATABASE_URL`, `REDIS_URL`, or `APP_URL` is unset/malformed instead of failing later with a less actionable error. Operators upgrading should make sure these three are well-formed before restart.

## Test plan

- [x] `make build` succeeds (verified locally)
- [x] `go test ./internal/config/...` — new `validate_test.go` covers the validators
- [x] `docker compose -f build/selfhosted/docker-compose.yml up` with a fresh `.env` copied from `build/selfhosted/.env.example` — container reaches healthy
- [ ] Sanity check: `curl http://localhost:8080/api/health` returns 200
- [ ] Boot fails fast with a clear error when `DATABASE_URL=garbage`
- [ ] Boot logs never expose the DB password (verify with `DATABASE_URL=postgres://u:secret@…` and a deliberate typo)