### PR TITLE
fix(docker): wait for DB with pg_isready, bump base images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ COPY frontend/ ./
 RUN npm run build
 
 # Go build stage
-FROM golang:1.25-alpine3.22 AS builder
+FROM golang:1.26-alpine3.23 AS builder
 
 WORKDIR /build
 
@@ -57,7 +57,7 @@ RUN go build \
     ./cmd/
 
 # Download migrate CLI (use BUILDPLATFORM to avoid QEMU issues)
-FROM --platform=$BUILDPLATFORM alpine:3.19 AS migrate-builder
+FROM --platform=$BUILDPLATFORM alpine:3.23 AS migrate-builder
 
 ARG TARGETARCH
 
@@ -68,7 +68,7 @@ RUN apk add --no-cache curl && \
     chmod +x /usr/local/bin/migrate
 
 # Runtime stage
-FROM alpine:3.19
+FROM alpine:3.23
 
 # Install runtime dependencies
 RUN apk add --no-cache ca-certificates tzdata openssl postgresql-client

--- a/Dockerfile
+++ b/Dockerfile
@@ -71,7 +71,7 @@ RUN apk add --no-cache curl && \
 FROM alpine:3.19
 
 # Install runtime dependencies
-RUN apk add --no-cache ca-certificates tzdata openssl netcat-openbsd
+RUN apk add --no-cache ca-certificates tzdata openssl postgresql-client
 
 WORKDIR /app
 

--- a/build/cloud/Dockerfile
+++ b/build/cloud/Dockerfile
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
 
 # Build stage
-FROM golang:1.25-alpine3.22 AS builder
+FROM golang:1.26-alpine3.23 AS builder
 
 WORKDIR /build
 
@@ -34,7 +34,7 @@ RUN go build \
     ./cmd/
 
 # Download migrate CLI (use BUILDPLATFORM to avoid QEMU issues)
-FROM --platform=$BUILDPLATFORM alpine:3.19 AS migrate-builder
+FROM --platform=$BUILDPLATFORM alpine:3.23 AS migrate-builder
 
 ARG TARGETARCH
 
@@ -45,7 +45,7 @@ RUN apk add --no-cache curl && \
     chmod +x /usr/local/bin/migrate
 
 # Runtime stage
-FROM alpine:3.22
+FROM alpine:3.23
 
 # Install runtime dependencies
 RUN apk add --no-cache ca-certificates tzdata openssl postgresql-client

--- a/build/cloud/Dockerfile
+++ b/build/cloud/Dockerfile
@@ -48,7 +48,7 @@ RUN apk add --no-cache curl && \
 FROM alpine:3.22
 
 # Install runtime dependencies
-RUN apk add --no-cache ca-certificates tzdata openssl netcat-openbsd
+RUN apk add --no-cache ca-certificates tzdata openssl postgresql-client
 
 WORKDIR /app
 

--- a/build/selfhosted/Dockerfile
+++ b/build/selfhosted/Dockerfile
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
 
 # Build stage
-FROM golang:1.25-alpine3.22 AS builder
+FROM golang:1.26-alpine3.23 AS builder
 
 WORKDIR /build
 
@@ -34,7 +34,7 @@ RUN go build \
     ./cmd/
 
 # Download migrate CLI (use BUILDPLATFORM to avoid QEMU issues)
-FROM --platform=$BUILDPLATFORM alpine:3.19 AS migrate-builder
+FROM --platform=$BUILDPLATFORM alpine:3.23 AS migrate-builder
 
 ARG TARGETARCH
 
@@ -45,7 +45,7 @@ RUN apk add --no-cache curl && \
     chmod +x /usr/local/bin/migrate
 
 # Runtime stage
-FROM alpine:3.22
+FROM alpine:3.23
 
 LABEL org.opencontainers.image.title="WhenTo" \
     org.opencontainers.image.description="Self-hosted scheduling and calendar application" \

--- a/build/selfhosted/Dockerfile
+++ b/build/selfhosted/Dockerfile
@@ -48,12 +48,12 @@ RUN apk add --no-cache curl && \
 FROM alpine:3.22
 
 LABEL org.opencontainers.image.title="WhenTo" \
-      org.opencontainers.image.description="Self-hosted scheduling and calendar application" \
-      org.opencontainers.image.vendor="WhenTo Contributors" \
-      org.opencontainers.image.licenses="BSL-1.1"
+    org.opencontainers.image.description="Self-hosted scheduling and calendar application" \
+    org.opencontainers.image.vendor="WhenTo Contributors" \
+    org.opencontainers.image.licenses="BSL-1.1"
 
 # Install runtime dependencies
-RUN apk add --no-cache ca-certificates tzdata openssl netcat-openbsd
+RUN apk add --no-cache ca-certificates tzdata openssl postgresql-client
 
 WORKDIR /app
 

--- a/scripts/docker-entrypoint.sh
+++ b/scripts/docker-entrypoint.sh
@@ -79,30 +79,17 @@ generate_keys() {
 wait_for_db() {
     echo "[DB] Waiting for database to be ready..."
 
-    # Extract host and port from DATABASE_URL
-    # Format: postgres://user:pass@host:port/db?sslmode=disable
     if [ -z "$DATABASE_URL" ]; then
         echo "[DB] WARNING: DATABASE_URL not set, skipping database check"
         return 0
-    fi
-
-    # Parse host from DATABASE_URL
-    DB_HOST=$(echo "$DATABASE_URL" | sed -n 's/.*@\([^:]*\):.*/\1/p')
-    DB_PORT=$(echo "$DATABASE_URL" | sed -n 's/.*:\([0-9]*\)\/.*/\1/p')
-
-    if [ -z "$DB_HOST" ]; then
-        DB_HOST="localhost"
-    fi
-    if [ -z "$DB_PORT" ]; then
-        DB_PORT="5432"
     fi
 
     MAX_RETRIES=30
     RETRY_COUNT=0
 
     while [ $RETRY_COUNT -lt $MAX_RETRIES ]; do
-        if nc -z "$DB_HOST" "$DB_PORT" 2>/dev/null; then
-            echo "[DB] Database is ready at $DB_HOST:$DB_PORT"
+        if pg_isready -d "$DATABASE_URL" -q -t 2; then
+            echo "[DB] Database is ready"
             return 0
         fi
         RETRY_COUNT=$((RETRY_COUNT + 1))


### PR DESCRIPTION
## Description

`wait_for_db()` in `docker-entrypoint.sh` parsed `DATABASE_URL` by hand with `sed`. The regex silently broke for IPv6 hosts, URL-encoded socket paths, and other libpq URIs the app's `pgx` driver accepts, falling back to `localhost` and timing out with no useful log.

This PR:

1. **`scripts/docker-entrypoint.sh`** — replace the `sed` + `nc` probe with `pg_isready -d "$DATABASE_URL" -q -t 2`, which delegates URL parsing to libpq (same parser `pgx` uses). Same outer contract: 30 retries × 2 s, same log prefix, same exit semantics.
2. **`Dockerfile`, `build/cloud/Dockerfile`, `build/selfhosted/Dockerfile`** — swap `netcat-openbsd` for `postgresql-client` in the runtime stage (`nc` is no longer used; `pg_isready` is now needed).
3. **Base image bump to Go 1.26 / Alpine 3.23** across all stages. Alpine 3.19's `postgresql-client` did not ship `pg_isready` on PATH (caught during local testing — entrypoint failed with `pg_isready: not found`); 3.23's does.

## Type of Change

- [x] Bug fix (non-breaking change fixing an issue)
- [ ] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature causing existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Related Issue

Reported against \`ghcr.io/when-to/whento:latest\` — reproducible on Unraid and Docker Desktop Windows. The report also described an "empty network namespace" symptom that could not be reproduced from this code (no \`setcap\`/\`iptables\`/\`netns\`/cgo anywhere); only the fragile parser is addressed here.

## Testing

- [ ] Unit tests added/updated
- [x] Manual testing performed
- [ ] Tested with self-hosted build (\`go build -tags selfhosted\`)

Manual:
- \`docker build -t whento:fix-db-wait .\` then \`docker compose up app\` → \`[DB] Database is ready\` on first probe.
- Confirm \`pg_isready\` is present and \`nc\` is absent in the runtime image.
- Failure path (postgres stopped): 30 × 2 s retries, then \`ERROR: Database not available after 30 attempts\` and exit 1 — unchanged.

## Checklist

- [x] My code follows the project's code style
- [x] I have performed a self-review
- [ ] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [ ] I have updated documentation if needed