### PR TITLE
chore(toolchain): pin Go dev tools and bump Node 20 -> 24

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -10,15 +10,15 @@ RUN mkdir -p /home/vscode/go/pkg /home/vscode/go/bin /home/vscode/go/src \
 
 # Install Go tools as vscode user to avoid permission issues
 USER vscode
-RUN go install github.com/air-verse/air@latest \
-    && go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest \
-    && go install github.com/swaggo/swag/cmd/swag@latest
+RUN go install github.com/air-verse/air@v1.67.1 \
+    && go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2 \
+    && go install github.com/swaggo/swag/cmd/swag@v1.16.6
 
 # Install golang-migrate with PostgreSQL support (requires tags)
 USER root
 RUN apt-get update && apt-get install -y gcc musl-dev && rm -rf /var/lib/apt/lists/*
 USER vscode
-RUN go install -tags 'postgres' github.com/golang-migrate/migrate/v4/cmd/migrate@latest
+RUN go install -tags 'postgres' github.com/golang-migrate/migrate/v4/cmd/migrate@v4.19.1
 
 # Switch back to root to install system tools
 USER root

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -7,7 +7,7 @@
     "ghcr.io/devcontainers/features/git:1": {},
     "ghcr.io/devcontainers/features/github-cli:1": {},
     "ghcr.io/devcontainers/features/node:1": {
-      "version": "20"
+      "version": "24"
     }
   },
   "customizations": {

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -10,22 +10,22 @@ export PATH="/home/vscode/go/bin:$PATH"
 echo "🔧 Checking Go tools..."
 if ! command -v migrate &> /dev/null; then
     echo "  → Installing migrate..."
-    go install -tags 'postgres' github.com/golang-migrate/migrate/v4/cmd/migrate@latest
+    go install -tags 'postgres' github.com/golang-migrate/migrate/v4/cmd/migrate@v4.19.1
 fi
 
 if ! command -v air &> /dev/null; then
     echo "  → Installing air..."
-    go install github.com/air-verse/air@latest
+    go install github.com/air-verse/air@v1.67.1
 fi
 
 if ! command -v golangci-lint &> /dev/null; then
     echo "  → Installing golangci-lint..."
-    go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest
+    go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2
 fi
 
 if ! command -v swag &> /dev/null; then
     echo "  → Installing swag..."
-    go install github.com/swaggo/swag/cmd/swag@latest
+    go install github.com/swaggo/swag/cmd/swag@v1.16.6
 fi
 
 # Initialize Go workspace if necessary

--- a/.github/workflows/build-cloud.yml
+++ b/.github/workflows/build-cloud.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '24'
           cache: 'npm'
           cache-dependency-path: frontend/package-lock.json
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '24'
           cache: 'npm'
           cache-dependency-path: frontend/package-lock.json
 
@@ -52,7 +52,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '24'
           cache: 'npm'
           cache-dependency-path: frontend/package-lock.json
 

--- a/.github/workflows/release-selfhosted.yml
+++ b/.github/workflows/release-selfhosted.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '24'
           cache: 'npm'
           cache-dependency-path: frontend/package-lock.json
 

--- a/.github/workflows/update-dependencies.yml
+++ b/.github/workflows/update-dependencies.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '24'
 
       - name: Setup Go
         uses: actions/setup-go@v5

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: BSL-1.1
 
 # Frontend build stage
-FROM node:20-alpine AS frontend-builder
+FROM node:24-alpine AS frontend-builder
 
 WORKDIR /frontend
 


### PR DESCRIPTION
## Description

Two toolchain fixes for the dev environment, CI and the release image. No application code is touched (8 files, +15 / -15).

**Pin Go tool versions instead of `@latest`** (`89877bd`)

`air`, `golangci-lint`, `swag` and `migrate` were installed from `@latest` in both the devcontainer `Dockerfile` and `post-create.sh`, making image builds non-reproducible: two rebuilds of the same commit could land on different tool versions, and a breaking upstream release could break the dev environment with no local change. `golangci-lint` also moved to the `/v2` module path, which `@latest` on the old path silently kept resolving to a stale v1.

| Tool | Pinned to |
| --- | --- |
| air | `v1.67.1` |
| golangci-lint | `v2.12.2` (now `/v2/cmd/golangci-lint`) |
| swag | `v1.16.6` |
| migrate | `v4.19.1` |

**Bump Node 20 -> 24 everywhere** (`6cfb934`)

`npm install` warned `EBADENGINE`: `vue-i18n` 11 requires Node >= 22 while the devcontainer, the CI workflows and the Docker `frontend-builder` stage all ran Node 20. Only `vue-i18n` is actually incompatible today (vite, eslint, vitest and jsdom accept 20.19+), but leaving dev, CI and the release image on an unsupported runtime only widens the gap.

Node 24 rather than the strict minimum 22: it is the active LTS, so this avoids another bump when 22 goes end-of-life in April 2027. Applied to `devcontainer.json`, `ci.yml` (both jobs), `build-cloud.yml`, `release-selfhosted.yml`, `update-dependencies.yml` and the root `Dockerfile`.

## Type of Change

- [ ] Bug fix (non-breaking change fixing an issue)
- [ ] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature causing existing functionality to change)
- [ ] Documentation update
- [x] Refactoring (no functional changes)

## Related Issue

<!-- none -->

## Testing

- [ ] Unit tests added/updated
- [x] Manual testing performed
- [ ] Tested with self-hosted build (`go build -tags selfhosted`)

- All four pinned versions resolve on the Go module proxy (`go list -m` on each), including the new `golangci-lint/v2` path.
- `npm install --dry-run` in `frontend/` under Node 24 / npm 11 emits no `EBADENGINE` warning.
- Note: this devcontainer was built before the pinning commit (it still carries `swag v1.16.4`), so the pins themselves are exercised by a devcontainer rebuild, not by the current container. CI on this PR is what validates the Node 24 bump across the build, lint and swagger jobs plus the `node:24-alpine` Docker stage.

## Checklist

- [x] My code follows the project's code style
- [x] I have performed a self-review
- [ ] I have added tests that prove my fix/feature works
- [ ] New and existing tests pass locally
- [ ] I have updated documentation if needed

## Follow-up (not in this PR)

- `ci.yml:86` and `build-cloud.yml:64` still run `go install .../swag@latest`. The pinning commit was deliberately scoped to the devcontainer; CI would benefit from the same pin.
- `build-cloud.yml:61` sets `go-version: '1.23'` while `ci.yml:83` sets `'1.25'`. Pre-existing inconsistency, unrelated to this branch.
