### PR TITLE
chore(tooling): format staged files on commit via a pre-commit hook

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -12,7 +12,8 @@ RUN mkdir -p /home/vscode/go/pkg /home/vscode/go/bin /home/vscode/go/src \
 USER vscode
 RUN go install github.com/air-verse/air@v1.67.1 \
     && go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2 \
-    && go install github.com/swaggo/swag/cmd/swag@v1.16.6
+    && go install github.com/swaggo/swag/cmd/swag@v1.16.6 \
+    && go install golang.org/x/tools/cmd/goimports@v0.48.0
 
 # Install golang-migrate with PostgreSQL support (requires tags)
 USER root

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -28,6 +28,11 @@ if ! command -v swag &> /dev/null; then
     go install github.com/swaggo/swag/cmd/swag@v1.16.6
 fi
 
+if ! command -v goimports &> /dev/null; then
+    echo "  → Installing goimports..."
+    go install golang.org/x/tools/cmd/goimports@v0.48.0
+fi
+
 # Initialize Go workspace if necessary
 cd /workspace
 if [ ! -f "go.work" ]; then
@@ -50,6 +55,10 @@ if [ -f "frontend/package.json" ]; then
     echo "📦 Installing frontend dependencies..."
     (cd frontend && npm install)
 fi
+
+# Enable the repo git hooks (formats staged files on commit)
+echo "🪝 Enabling git hooks..."
+make hooks
 
 # Run migrations
 echo "🗄️ Running migrations..."
@@ -80,6 +89,6 @@ echo "📋 Useful commands:"
 echo "  • make dev          - Run all services in watch mode"
 echo "  • make test         - Run tests"
 echo "  • make migrate-up   - Apply migrations"
-echo "  • make lint         - Check code"
+echo "  • make format       - Format Go + frontend code"
 echo ""
 echo "Happy coding! 🎉"

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+#
+# Formats staged files and re-stages them, so commits always land formatted.
+# Activate with: make hooks   (sets core.hooksPath to .githooks)
+# Bypass with:   git commit --no-verify
+#
+set -euo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+cd "$REPO_ROOT"
+
+# Hooks triggered from an IDE don't inherit the interactive shell PATH.
+if command -v go > /dev/null 2>&1; then
+    export PATH="$(go env GOPATH)/bin:$PATH"
+fi
+
+GOIMPORTS_VERSION="v0.48.0"
+PRETTIER_BIN="frontend/node_modules/.bin/prettier"
+
+# Files staged for this commit.
+mapfile -t STAGED < <(git diff --cached --name-only --diff-filter=ACMR)
+[ ${#STAGED[@]} -eq 0 ] && exit 0
+
+# Files with unstaged changes on top of what's staged (git add -p). Formatting
+# those would re-stage work that was deliberately left out of this commit.
+mapfile -t UNSTAGED < <(git diff --name-only --diff-filter=ACMR)
+
+is_partially_staged() {
+    local file="$1" other
+    for other in ${UNSTAGED[@]+"${UNSTAGED[@]}"}; do
+        [ "$other" = "$file" ] && return 0
+    done
+    return 1
+}
+
+GO_FILES=()
+FRONTEND_FILES=()
+SKIPPED=()
+
+for file in "${STAGED[@]}"; do
+    # Deleted in the worktree between staging and committing.
+    [ -f "$file" ] || continue
+
+    case "$file" in
+        .go-cache/*|vendor/*|frontend/node_modules/*|frontend/dist/*) continue ;;
+    esac
+
+    case "$file" in
+        *.go)                                          kind="go" ;;
+        frontend/*.vue|frontend/*.ts|frontend/*.js|frontend/*.css|frontend/*.json) kind="frontend" ;;
+        *) continue ;;
+    esac
+
+    if is_partially_staged "$file"; then
+        SKIPPED+=("$file")
+        continue
+    fi
+
+    if [ "$kind" = "go" ]; then
+        GO_FILES+=("$file")
+    else
+        FRONTEND_FILES+=("$file")
+    fi
+done
+
+FORMATTED=()
+
+if [ ${#GO_FILES[@]} -gt 0 ]; then
+    if ! command -v goimports > /dev/null 2>&1; then
+        echo "✗ goimports not installed."
+        echo "  Install with: go install golang.org/x/tools/cmd/goimports@${GOIMPORTS_VERSION}"
+        exit 1
+    fi
+    goimports -w -local github.com/whento "${GO_FILES[@]}"
+    FORMATTED+=("${GO_FILES[@]}")
+fi
+
+if [ ${#FRONTEND_FILES[@]} -gt 0 ]; then
+    if [ ! -x "$PRETTIER_BIN" ]; then
+        echo "✗ prettier not installed."
+        echo "  Install with: cd frontend && npm install"
+        exit 1
+    fi
+    # prettier resolves .prettierrc.json relative to each file, but run from
+    # frontend/ so paths match the ones used by 'npm run format'.
+    (cd frontend && "./node_modules/.bin/prettier" --write --log-level warn \
+        "${FRONTEND_FILES[@]#frontend/}")
+    FORMATTED+=("${FRONTEND_FILES[@]}")
+fi
+
+if [ ${#FORMATTED[@]} -gt 0 ]; then
+    git add -- "${FORMATTED[@]}"
+    echo "✓ Formatted ${#FORMATTED[@]} staged file(s)"
+fi
+
+if [ ${#SKIPPED[@]} -gt 0 ]; then
+    echo "⚠ Skipped (partially staged, format manually):"
+    printf '    %s\n' "${SKIPPED[@]}"
+fi
+
+exit 0

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -20,18 +20,34 @@ Thank you for your interest in contributing to WhenTo!
 
 1. **Fork** the repository
 2. **Create a branch** from `main`: `git checkout -b feature/your-feature`
-3. **Make your changes** following the code style guidelines
-4. **Test your changes**: `make test`
-5. **Commit** with clear messages
-6. **Push** to your fork
-7. **Open a Pull Request** against `main`
+3. **Enable the git hooks** (once per clone): `make hooks`
+4. **Make your changes** following the code style guidelines
+5. **Test your changes**: `make test`
+6. **Commit** with clear messages
+7. **Push** to your fork
+8. **Open a Pull Request** against `main`
+
+### Git Hooks
+
+Run `make hooks` once after cloning (done automatically in the devcontainer). It
+points `core.hooksPath` at the versioned `.githooks/` directory.
+
+The `pre-commit` hook formats the files staged for the commit and re-stages them,
+so commits always land formatted:
+
+- Go files → `goimports -w -local github.com/whento`
+- Frontend files → `prettier --write`
+
+Files that are only partially staged (`git add -p`) are skipped with a warning,
+to avoid pulling unstaged work into the commit. Use `git commit --no-verify` to
+bypass the hook.
 
 ### Code Style
 
 #### Go
 
 - Follow standard Go conventions
-- Use `gofmt` for formatting
+- Format with `make format-go` (goimports with `-local github.com/whento`), not plain `gofmt`
 - Add tests for new functionality
 - Use meaningful variable names
 
@@ -39,7 +55,9 @@ Thank you for your interest in contributing to WhenTo!
 
 - Follow existing component patterns
 - Use TypeScript strict mode
-- Run `npm run lint` before committing
+- Format with `make format-frontend` (prettier) and run `npm run lint` before committing
+
+`make format` runs both; `make format-check` verifies without modifying.
 
 ### Commit Messages
 

--- a/.gitignore
+++ b/.gitignore
@@ -63,6 +63,9 @@
 # Dev Container
 !.devcontainer/
 
+# Git hooks (enabled with `make hooks`)
+!.githooks/
+
 # ============================================
 # Recursive Rules for Included Directories
 # ============================================

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,10 @@
-.PHONY: dev dev-fullstack dev-backend dev-frontend dev-db dev-app test build clean migrate-up migrate-down migrate-reset migrate-status sync docker-build docker-build-versioned docker-build-multiarch docker-test-build docker-up docker-down docker-logs docker-ps swagger swagger-generate swagger-clean docs-serve docs-validate build-licensegen keys help format format-check
+.PHONY: dev dev-fullstack dev-backend dev-frontend dev-db dev-app test build clean migrate-up migrate-down migrate-reset migrate-status sync docker-build docker-build-versioned docker-build-multiarch docker-test-build docker-up docker-down docker-logs docker-ps swagger swagger-generate swagger-clean docs-serve docs-validate build-licensegen keys help hooks format format-go format-frontend format-check format-check-go format-check-frontend
 
 # BUILD_TYPE can be 'cloud' or 'selfhosted' (default: selfhosted)
 BUILD_TYPE ?= selfhosted
+
+# Pinned dev tools (keep in sync with .devcontainer/ and .githooks/pre-commit)
+GOIMPORTS_VERSION := v0.48.0
 
 # Load environment variables from .env file if it exists
 -include .env
@@ -41,8 +44,11 @@ help:
 	@echo "  make swagger-clean    - Remove generated Swagger files"
 	@echo "  make docs-serve       - Info on accessing embedded Swagger UI"
 	@echo "  make build-licensegen - Build license generator tool (for e-commerce)"
-	@echo "  make format           - Format all Go files with goimports"
-	@echo "  make format-check     - Check Go file formatting without modifying"
+	@echo "  make hooks            - Enable the repo git hooks (format on commit)"
+	@echo "  make format           - Format Go (goimports) + frontend (prettier) files"
+	@echo "  make format-go        - Format Go files only"
+	@echo "  make format-frontend  - Format frontend files only"
+	@echo "  make format-check     - Check formatting without modifying"
 
 # Development
 ensure-dist-placeholder:
@@ -117,25 +123,45 @@ clean:
 	rm -rf bin/
 	docker compose -f docker-compose.dev.yml down -v
 
+# Git hooks
+# core.hooksPath is local config, so every clone must run this once.
+hooks:
+	@git config core.hooksPath .githooks
+	@chmod +x .githooks/pre-commit
+	@echo "✓ Git hooks enabled (.githooks) - staged files are formatted on commit"
+
 # Formatting
-format:
+format: format-go format-frontend
+
+format-check: format-check-go format-check-frontend
+
+format-go:
 	@echo "Formatting Go files with goimports..."
-	@which goimports > /dev/null || (echo "Error: goimports not installed. Install with: go install golang.org/x/tools/cmd/goimports@latest" && exit 1)
-	@goimports -w -local github.com/whento $$(find . -type f -name '*.go' -not -path './.go-cache/*' -not -path './vendor/*')
+	@which goimports > /dev/null || (echo "Error: goimports not installed. Install with: go install golang.org/x/tools/cmd/goimports@$(GOIMPORTS_VERSION)" && exit 1)
+	@goimports -w -local github.com/whento $$(find . -type f -name '*.go' -not -path './.go-cache/*' -not -path './vendor/*' -not -path './.claude/*')
 	@echo "✓ All Go files formatted"
 
-format-check:
+format-check-go:
 	@echo "Checking Go file formatting..."
-	@which goimports > /dev/null || (echo "Error: goimports not installed. Install with: go install golang.org/x/tools/cmd/goimports@latest" && exit 1)
-	@UNFORMATTED=$$(goimports -l -local github.com/whento $$(find . -type f -name '*.go' -not -path './.go-cache/*' -not -path './vendor/*')); \
+	@which goimports > /dev/null || (echo "Error: goimports not installed. Install with: go install golang.org/x/tools/cmd/goimports@$(GOIMPORTS_VERSION)" && exit 1)
+	@UNFORMATTED=$$(goimports -l -local github.com/whento $$(find . -type f -name '*.go' -not -path './.go-cache/*' -not -path './vendor/*' -not -path './.claude/*')); \
 	if [ -n "$$UNFORMATTED" ]; then \
 		echo "The following files need formatting:"; \
 		echo "$$UNFORMATTED"; \
 		echo ""; \
-		echo "Run 'make format' to fix formatting"; \
+		echo "Run 'make format-go' to fix formatting"; \
 		exit 1; \
 	fi
 	@echo "✓ All Go files are properly formatted"
+
+format-frontend:
+	@echo "Formatting frontend files with prettier..."
+	@cd frontend && npm run format
+	@echo "✓ All frontend files formatted"
+
+format-check-frontend:
+	@echo "Checking frontend file formatting..."
+	@cd frontend && npm run format:check
 
 # Go workspace sync (fixes "is not in your go.mod" errors in VS Code)
 sync:

--- a/README.md
+++ b/README.md
@@ -456,7 +456,18 @@ npm run dev         # Vite dev server
 npm run build       # Production build
 npm run type-check  # TypeScript checking
 npm run lint        # ESLint
+npm run format      # Prettier (same as `make format-frontend`)
 ```
+
+### Formatting
+
+```bash
+make hooks         # Enable the pre-commit hook (once per clone)
+make format        # Format Go (goimports) + frontend (prettier)
+make format-check  # Check formatting without modifying
+```
+
+The `pre-commit` hook formats staged files automatically — see [CONTRIBUTING.md](.github/CONTRIBUTING.md).
 
 ---
 


### PR DESCRIPTION
## Why

Formatting was honour-system only: `make format` existed for Go, `npm run format` for the frontend, and nothing ran either one — no hook, no CI check. The tree drifted (see #55, which cleans it up).

This PR adds the hook that keeps it from drifting again, and wires the frontend formatter into the Makefile so both sides are reachable from one command.

## What

**`.githooks/pre-commit`** — formats the files **staged** for the commit and re-stages them, so commits land formatted rather than being rejected:

- `*.go` → `goimports -w -local github.com/whento`
- `frontend/**.{vue,ts,js,css,json}` → the local `frontend/node_modules/.bin/prettier` (not `npx`, which can hit the network)
- files that are only **partially staged** (`git add -p`) are skipped with a warning — reformatting and re-staging them would pull unstaged work into the commit
- a missing formatter exits 1 with the exact install command, rather than silently letting unformatted code through
- `git commit --no-verify` bypasses it

**`make hooks`** — points `core.hooksPath` at the versioned `.githooks/` directory. It's local config, so every clone runs it once; the devcontainer's `post-create.sh` now does it automatically. `.gitignore` uses a whitelist approach, so `!.githooks/` had to be added.

**Makefile** — `format` / `format-check` now cover Go **and** frontend, split into `format-go` / `format-frontend` / `format-check-go` / `format-check-frontend`. The frontend targets just call the existing `npm run format` / `format:check`.

**goimports pinned to v0.48.0** (matching `golang.org/x/tools` in `go.mod`) in the Dockerfile and `post-create.sh`. It was the only dev tool left unpinned after #51, and absent from a fresh devcontainer entirely — `make format` was broken there.

**Docs** — CONTRIBUTING gained a "Git Hooks" section, and its "use `gofmt`" advice is corrected to goimports with `-local github.com/whento` (the two disagree on import grouping). README gained a Formatting section. `post-create.sh` advertised a `make lint` target that doesn't exist; it now points at `make format`.

Also excludes `.claude/` from the Go file scan — `make format` was descending into gitignored agent worktrees and rewriting files there.

## Verification

Hook exercised on each path:

| Case | Result |
| --- | --- |
| Staged `.go` with scrambled imports | formatted, `-local` grouping correct, re-staged |
| Staged `.ts` / `.vue` | prettier-formatted, re-staged |
| Partially staged file | skipped with warning, unstaged part untouched |
| Only `.md` staged | no-op, exit 0 |
| `goimports` off `PATH` | exit 1 with the install command |

This commit itself was made with the hook active.

## Note

`make format-check` fails on this branch until #55 lands — that PR is the formatting pass, this one is only the tooling.