### PR TITLE
fix(tooling): stop the backend too when dev-fullstack exits

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -80,8 +80,22 @@ dev-fullstack: ensure-dist-placeholder
 	@echo ""
 	@echo "Access the app at http://localhost:8080"
 	@echo ""
-	@trap 'kill 0' SIGINT; \
-	PORT=5173 go run -tags $(BUILD_TYPE) ./cmd/ & \
+	@# Three things had to be right for Ctrl+C to stop both halves, and none was:
+	@#  - `SIGINT` is not a valid trap name in POSIX sh. Recipes run under /bin/sh,
+	@#    which is dash on Debian and Ubuntu, so the old trap printed
+	@#    "trap: SIGINT: bad trap" and never installed. It has to be `INT`.
+	@#  - A background command in a non-interactive shell inherits SIGINT ignored,
+	@#    so Ctrl+C could never stop the backend even when it reached it. Only the
+	@#    foreground frontend died — exactly the reported symptom. SIGTERM is not
+	@#    ignored, which is what `pkill -TERM` and `kill` send.
+	@#  - `go run` is two processes: itself, and the compiled binary it execs, which
+	@#    is the one holding :5173. Killing only the parent orphans the server and
+	@#    leaves the port taken. `pkill -P` reaches the child first.
+	@# EXIT is trapped as well as INT, so quitting Vite with `q` — a normal exit that
+	@# sends no signal at all — cleans up too.
+	@PORT=5173 go run -tags $(BUILD_TYPE) ./cmd/ & \
+	BACKEND=$$!; \
+	trap 'pkill -TERM -P $$BACKEND 2>/dev/null; kill $$BACKEND 2>/dev/null' EXIT INT TERM; \
 	cd frontend && npm run dev:$(BUILD_TYPE)
 
 dev-backend: ensure-dist-placeholder


### PR DESCRIPTION
## Why

`make dev-fullstack` starts the frontend and the backend. Ctrl+C, or `q` in Vite, stops
only the frontend — the backend keeps running and keeps `:5173`, so the next
`make dev-fullstack` silently talks to the *previous* server.

Three separate causes, each sufficient on its own. All three are demonstrated below
rather than reasoned about.

## What

### 1. The trap never installed

```make
@trap 'kill 0' SIGINT; \
```

`SIGINT` is not a valid trap name in POSIX sh. Recipes run under `/bin/sh`, which is
**dash** on Debian and Ubuntu:

```
$ sh -c 'trap "echo caught" SIGINT'
trap: SIGINT: bad trap          # <- and dash carries on
$ sh -c 'trap "echo caught" INT'
sh: installed ok
```

bash accepts both spellings, which is exactly why the line looks correct. The error was
printed among the startup banner and never noticed, and `kill 0` has never run.

### 2. Even installed, it could not have worked for Ctrl+C

A command started in the background from a **non-interactive** shell inherits SIGINT
ignored. The terminal sends SIGINT to the whole foreground process group on Ctrl+C, so
the backend discards it while the foreground frontend dies from it — precisely the
asymmetry reported.

Measured, on a spare port:

| Signal to the process group | `go run` | the server binary | `:5199` | graceful shutdown |
| --- | --- | --- | --- | --- |
| `SIGINT` | survives | survives | held | not logged |
| `SIGTERM` | dies | dies | released | logged |

`kill 0` sends SIGTERM, so the *intent* was right — it simply never ran.

### 3. `go run` is two processes

```
53928  go    go run -tags selfhosted ./cmd/
53985  cmd   /home/vscode/go/cache/.../cmd     <- this one holds :5173
```

`go run` compiles and then execs the binary as a child. Killing the parent orphans the
server, which is also why `pkill -f 'go run'` does not free the port.

### The fix

```make
@PORT=5173 go run -tags $(BUILD_TYPE) ./cmd/ & \
BACKEND=$!; \
trap 'pkill -TERM -P $BACKEND 2>/dev/null; kill $BACKEND 2>/dev/null' EXIT INT TERM; \
cd frontend && npm run dev:$(BUILD_TYPE)
```

- `INT`, not `SIGINT`, so it installs under dash
- SIGTERM, which is not ignored for background jobs
- `pkill -P` first, to reach the binary `go run` spawned, then the parent
- **`EXIT` as well as the signals** — quitting Vite with `q` is a normal exit that sends
  no signal at all, so no signal trap could ever have covered it
- only the backend's own process tree is signalled, so `make` still exits 0 rather than
  reporting `Terminated` (which `kill 0` would cause, since it also hits make)

## Verification

Against the real target, on both paths:

| Path | Survivors | `:5173` | `:8080` |
| --- | --- | --- | --- |
| SIGINT to `make` (Ctrl+C) | none | released | released |
| Frontend ends on its own (`q`) | none | released | released |

## Note

`keys` appears in the Makefile's `.PHONY` list but **no `keys:` target exists** —
`make keys` fails with "No rule to make target". Left alone here; the entry point is
`./scripts/generate-keys.sh`, which is what the devcontainer and CI both call. Worth
either adding the target or dropping the stale `.PHONY` entry, separately.
