### PR TITLE
fix: settle the three behaviours the tests had only documented

### DIFF
--- a/frontend/e2e-backend/fixtures/seed.ts
+++ b/frontend/e2e-backend/fixtures/seed.ts
@@ -193,9 +193,9 @@ export async function fetchAvailabilities(
 /**
  * Read the range summary, which is what the calendar views render from.
  *
- * The array coercion is load-bearing: a range with nothing in it serialises as
- * `"data": null`, not `[]`. ParticipantView compensates with its own `Array.isArray`
- * guard for the same reason.
+ * The array coercion is now belt and braces: the server returns [] for an empty range.
+ * It used to serialise as `"data": null`, which is why this and ParticipantView both
+ * carry a guard.
  */
 export async function fetchRangeSummary(
   publicToken: string,

--- a/frontend/src/composables/calendar/useCalendarGridNav.test.ts
+++ b/frontend/src/composables/calendar/useCalendarGridNav.test.ts
@@ -275,21 +275,34 @@ describe('useCalendarGridNav', () => {
     });
 
     /**
-     * Home and End divide by a hard-coded 7 rather than by the layout's horizontal
-     * step. In the wide grid that is the row, which is right. In the compact grid a
-     * "row" is a column and the step is 7, so the same arithmetic no longer describes
-     * the visual row — Home lands on whatever index happens to share a residue.
-     *
-     * Pinned as documentation rather than fixed: correcting it means deciding what
-     * Home should mean in a transposed grid, which is a design question.
+     * Home and End used to subtract `index % 7` unconditionally, which describes a row
+     * only in the wide grid. The compact layout is transposed — a row gathers the
+     * indices sharing `index % 7`, spaced seven apart — so the old arithmetic jumped to
+     * an unrelated cell. Both are now derived from the same horizontal step the arrows
+     * use.
      */
-    it('use the same arithmetic in the compact layout, where it no longer means the row', () => {
+    it('follow the transposed row in the compact layout', () => {
       harness = setup({ compact: true });
 
+      // 35 cells, so a transposed row holds 5: 3, 10, 17, 24, 31.
       harness.nav.focus(17);
-      press(harness.nav, 'Home');
 
-      expect(harness.nav.focusedIndex.value).toBe(14);
+      press(harness.nav, 'Home');
+      expect(harness.nav.focusedIndex.value).toBe(3);
+
+      press(harness.nav, 'End');
+      expect(harness.nav.focusedIndex.value).toBe(31);
+    });
+
+    it('stay inside the grid when a transposed row is short', () => {
+      // 38 cells: the row through index 5 is 5, 12, 19, 26, 33 — index 40 does not
+      // exist, so End must stop at 33 rather than running past the end.
+      harness = setup({ compact: true, count: 38 });
+
+      harness.nav.focus(12);
+      press(harness.nav, 'End');
+
+      expect(harness.nav.focusedIndex.value).toBe(33);
     });
   });
 

--- a/frontend/src/composables/calendar/useCalendarGridNav.ts
+++ b/frontend/src/composables/calendar/useCalendarGridNav.ts
@@ -50,6 +50,9 @@ export interface GridNav {
 
 const COMPACT_QUERY = '(max-width: 48rem)';
 
+/** Columns in the wide grid, and rows in the transposed one. */
+const DAYS_PER_WEEK = 7;
+
 export function useCalendarGridNav(options: GridNavOptions): GridNav {
   const focusedIndex = ref(-1);
   const anchorIndex = ref<number | null>(null);
@@ -58,8 +61,8 @@ export function useCalendarGridNav(options: GridNavOptions): GridNav {
   // one day in the wide layout. Reading the media query keeps the arrows matching what
   // the user actually sees.
   const isCompact = useMediaQuery(options.compactQuery ?? COMPACT_QUERY);
-  const horizontalStep = computed(() => (isCompact.value ? 7 : 1));
-  const verticalStep = computed(() => (isCompact.value ? 1 : 7));
+  const horizontalStep = computed(() => (isCompact.value ? DAYS_PER_WEEK : 1));
+  const verticalStep = computed(() => (isCompact.value ? 1 : DAYS_PER_WEEK));
 
   const rangeIndices = computed<ReadonlySet<number>>(() => {
     if (anchorIndex.value === null || focusedIndex.value < 0) return new Set<number>();
@@ -71,6 +74,36 @@ export function useCalendarGridNav(options: GridNavOptions): GridNav {
     }
     return indices;
   });
+
+  /**
+   * How many cells a visual row holds.
+   *
+   * Seven in the wide grid — a week across. In the transposed compact layout a row is a
+   * weekday running down the months, so it holds one cell per week on screen.
+   */
+  const perRow = computed(() =>
+    isCompact.value ? Math.ceil(options.count.value / 7) : DAYS_PER_WEEK
+  );
+
+  /**
+   * The first and last index of the visual row containing `index`.
+   *
+   * Home and End used to subtract `index % 7` unconditionally, which describes the row
+   * only in the wide layout. Transposed, a row gathers the indices sharing `index % 7`
+   * — every Monday, say — spaced seven apart, so the old arithmetic jumped to an
+   * unrelated cell. Both layouts are derived from the same horizontal step the arrow
+   * keys already use, so the two cannot disagree again.
+   */
+  function rowBounds(index: number): { first: number; last: number } {
+    const step = horizontalStep.value;
+    const offset = isCompact.value ? Math.floor(index / DAYS_PER_WEEK) : index % DAYS_PER_WEEK;
+
+    const first = index - offset * step;
+    let last = first + step * (perRow.value - 1);
+    while (last >= options.count.value) last -= step;
+
+    return { first, last };
+  }
 
   /** First focusable index at or after `from`, walking in `direction`. */
   function seek(from: number, direction: number): number {
@@ -123,12 +156,16 @@ export function useCalendarGridNav(options: GridNavOptions): GridNav {
       case 'ArrowUp':
         move(-verticalStep.value, extend);
         break;
-      case 'Home':
-        focus(seek(focusedIndex.value - (focusedIndex.value % 7), 1));
+      case 'Home': {
+        const { first } = rowBounds(focusedIndex.value < 0 ? seek(0, 1) : focusedIndex.value);
+        focus(seek(first, 1));
         break;
-      case 'End':
-        focus(seek(focusedIndex.value - (focusedIndex.value % 7) + 6, -1));
+      }
+      case 'End': {
+        const { last } = rowBounds(focusedIndex.value < 0 ? seek(0, 1) : focusedIndex.value);
+        focus(seek(last, -1));
         break;
+      }
       case 'PageDown':
         options.shiftPeriod(1);
         break;

--- a/frontend/src/views/ParticipantView.vue
+++ b/frontend/src/views/ParticipantView.vue
@@ -1928,7 +1928,8 @@ async function loadParticipantCounts(year?: number, month?: number) {
     ]);
     ownAvailabilities.value = own?.availabilities ?? [];
 
-    // Ensure summaries is an array (handle null/undefined responses)
+    // The backend returns [] for an empty range now; this stays as cheap insurance
+    // against an older self-hosted server, which sent null and made .map() throw.
     const summariesArray = Array.isArray(summaries) ? summaries : [];
 
     // Store full summaries for weekly view

--- a/internal/availability/handlers/availability_handler_test.go
+++ b/internal/availability/handlers/availability_handler_test.go
@@ -302,17 +302,12 @@ func TestGetRangeSummaryResponseShape(t *testing.T) {
 	}
 }
 
-// TestGetRangeSummaryEmptySerialisesAsNull pins a wart rather than a virtue.
+// TestGetRangeSummaryEmptySerialisesAsArray covers what used to be a wart.
 //
-// GetRangeSummary accumulates into a nil slice, so a calendar with nothing in range
-// serialises as `null`, not `[]`. ParticipantView already compensates —
-// `Array.isArray(summaries) ? summaries : []`, commented "handle null/undefined
-// responses" — so nothing is broken today, but the guard exists because of this.
-//
-// Left as-is deliberately: changing it alters an API response shape, which is a
-// decision to take on its own terms rather than as a side effect of adding tests. If it
-// is ever changed, this test fails and points at the frontend guard that can then go.
-func TestGetRangeSummaryEmptySerialisesAsNull(t *testing.T) {
+// GetRangeSummary accumulated into a nil slice, so a calendar with nothing in range
+// serialised as `null` rather than `[]` — and any client calling .map() on the payload
+// threw. ParticipantView carried an Array.isArray guard purely to absorb it.
+func TestGetRangeSummaryEmptySerialisesAsArray(t *testing.T) {
 	calendar := &repository.Calendar{
 		ID:              uuid.New(),
 		AllowedWeekdays: []int{0, 1, 2, 3, 4, 5, 6},
@@ -341,11 +336,7 @@ func TestGetRangeSummaryEmptySerialisesAsNull(t *testing.T) {
 		t.Fatalf("decode response: %v", err)
 	}
 
-	if string(body.Data) != "null" {
-		t.Errorf(
-			"data = %s, want null — if this now serialises as [], the ParticipantView "+
-				"Array.isArray guard is no longer needed and this test should be updated",
-			body.Data,
-		)
+	if string(body.Data) != "[]" {
+		t.Errorf("data = %s, want []", body.Data)
 	}
 }

--- a/internal/availability/service/availability_service.go
+++ b/internal/availability/service/availability_service.go
@@ -844,7 +844,10 @@ func (s *AvailabilityService) GetRangeSummary(ctx context.Context, token, startD
 	}
 
 	// Build response (with min_duration_hours filter if configured)
-	var summaries []models.PublicDateAvailabilitySummary
+	// Initialised rather than left nil so an empty range serialises as [] and not null.
+	// The frontend carried an Array.isArray guard purely to absorb that, and any client
+	// calling .map() on the payload would have thrown.
+	summaries := make([]models.PublicDateAvailabilitySummary, 0, len(dateMap))
 	for date, participants := range dateMap {
 		// Apply min_duration_hours filter if configured
 		if calendarInfo.MinDurationHours > 0 {
@@ -1791,15 +1794,25 @@ func recurrencesOverlap(startDateA, endDateA, startDateB, endDateB string) bool 
 // Unlike getAllowedTimeRangeForDate, this doesn't check for holidays since recurrences
 // span multiple dates and holiday logic can't be consistently applied.
 func getAllowedTimeRangeForWeekday(dayOfWeek int, calendarInfo *repository.Calendar) repository.TimeRange {
+	// A weekday the calendar does not accept has no window at all. Returning an empty
+	// range here means "do not clamp", which is right: the weekday is rejected earlier,
+	// by validation, and a range invented for it would only obscure that.
+	if !datevalidation.IsWeekdayAllowed(dayOfWeek, calendarInfo.AllowedWeekdays) {
+		return repository.TimeRange{}
+	}
+
 	weekdayStr := fmt.Sprintf("%d", dayOfWeek)
 
-	// Check if this weekday has specific allowed hours configured
 	if tr, ok := calendarInfo.AllowedHours.Weekdays[weekdayStr]; ok {
 		return tr
 	}
 
-	// No specific hours configured for this day, return empty (no restrictions)
-	return repository.TimeRange{}
+	// An allowed weekday with no configured hours is open all day — the same answer
+	// getAllowedTimeRangeForDate gives. It used to return an empty range instead, so an
+	// untimed recurrence was stored with NULL times while an untimed one-off on the very
+	// same day became 00:00-23:59. Both render as "all day", which is why it went
+	// unnoticed, but the two were not the same row.
+	return repository.TimeRange{Start: "00:00", End: "23:59"}
 }
 
 // adjustTimesByAllowedHoursForWeekday adjusts times based on the calendar's allowed hours for a specific weekday.

--- a/internal/availability/service/time_rules_test.go
+++ b/internal/availability/service/time_rules_test.go
@@ -554,15 +554,13 @@ func TestGetAllowedTimeRangeForWeekday(t *testing.T) {
 		want    repository.TimeRange
 	}{
 		{name: "configured hours are returned", weekday: 2, want: repository.TimeRange{Start: "09:00", End: "17:00"}},
-		// Note the divergence from getAllowedTimeRangeForDate, which returns
-		// 00:00-23:59 for an allowed weekday carrying no hours. This function
-		// returns an empty range instead, and an empty range means "do not clamp".
-		// See TestWeekdayAndDatedWindowsDivergeWithoutHours for what that costs.
-		{name: "an unconfigured weekday yields an empty range, not a full day", weekday: 4, want: repository.TimeRange{}},
-		// It also never consults AllowedWeekdays: a weekday that the calendar
-		// forbids is indistinguishable here from one that simply has no hours.
-		{name: "a forbidden weekday is not distinguished", weekday: 3, want: repository.TimeRange{}},
-		{name: "sunday is zero", weekday: 0, want: repository.TimeRange{}},
+		// An allowed weekday with no configured hours is open all day — the same
+		// answer getAllowedTimeRangeForDate gives for it.
+		{name: "an allowed weekday with no hours is open all day", weekday: 4, want: repository.TimeRange{Start: "00:00", End: "23:59"}},
+		// A weekday the calendar rejects has no window: an empty range means "do not
+		// clamp", and inventing one would only obscure that validation refuses it.
+		{name: "a forbidden weekday yields no window", weekday: 3, want: repository.TimeRange{}},
+		{name: "sunday is zero, and also forbidden here", weekday: 0, want: repository.TimeRange{}},
 	}
 
 	for _, tt := range tests {
@@ -713,43 +711,59 @@ func TestCalculateDurationForDate(t *testing.T) {
 
 func ptr(s string) *string { return &s }
 
-// TestWeekdayAndDatedWindowsDivergeWithoutHours documents a real difference between the
-// two clamps, so that it is a known quantity rather than a surprise.
+// TestWeekdayAndDatedWindowsAgree covers a divergence that used to exist.
 //
-// For a weekday the calendar allows but for which no hours are configured, the dated
-// path treats the day as 00:00-23:59 and therefore fills in both bounds of an all-day
-// request. The weekday path — used for recurrences — returns an empty range, which
-// means "do not clamp", and leaves the request untouched.
-//
-// The practical effect: an all-day one-off is stored as 00:00-23:59, while an all-day
-// recurrence on the same weekday is stored with NULL times. Both render as "all day",
-// which is why this has gone unnoticed; it matters to anything comparing the two.
-func TestWeekdayAndDatedWindowsDivergeWithoutHours(t *testing.T) {
+// For a weekday the calendar allowed but left unconfigured, the dated path treated the
+// day as 00:00-23:59 while the weekday path — used for recurrences — returned an empty
+// range meaning "do not clamp". An all-day one-off was therefore stored as 00:00-23:59
+// while an all-day recurrence on the same weekday kept NULL times. Both render as "all
+// day", which is why it went unnoticed, but they were not the same row.
+func TestWeekdayAndDatedWindowsAgree(t *testing.T) {
 	// Thursday (4) is allowed, but only Tuesday (2) has configured hours.
 	calendar := calendarWith([]int{2, 4}, repository.AllowedHours{
 		Weekdays: map[string]repository.TimeRange{"2": {Start: "09:00", End: "17:00"}},
 	}, "ignore", false)
 
-	// 2026-03-19 is a Thursday, and not a holiday in France.
-	datedStart, datedEnd := adjustTimesByAllowedHours(mustDate(t, "2026-03-19"), nil, nil, calendar)
-	weekdayStart, weekdayEnd := adjustTimesByAllowedHoursForWeekday(4, nil, nil, calendar)
-
-	if deref(datedStart) != "00:00" || deref(datedEnd) != "23:59" {
-		t.Errorf("the dated clamp gave %s-%s, want 00:00-23:59", deref(datedStart), deref(datedEnd))
+	cases := []struct {
+		name    string
+		iso     string
+		weekday int
+	}{
+		// 2026-03-19 is a Thursday: allowed, no configured hours.
+		{name: "an allowed weekday with no configured hours", iso: "2026-03-19", weekday: 4},
+		// 2026-03-17 is a Tuesday: allowed, with hours.
+		{name: "an allowed weekday with configured hours", iso: "2026-03-17", weekday: 2},
 	}
-	if weekdayStart != nil || weekdayEnd != nil {
-		t.Errorf("the weekday clamp gave %s-%s, want both nil", deref(weekdayStart), deref(weekdayEnd))
+
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			datedStart, datedEnd := adjustTimesByAllowedHours(mustDate(t, tt.iso), nil, nil, calendar)
+			weekdayStart, weekdayEnd := adjustTimesByAllowedHoursForWeekday(tt.weekday, nil, nil, calendar)
+
+			if deref(datedStart) != deref(weekdayStart) || deref(datedEnd) != deref(weekdayEnd) {
+				t.Errorf(
+					"the dated and weekday clamps disagree: %s-%s vs %s-%s",
+					deref(datedStart), deref(datedEnd), deref(weekdayStart), deref(weekdayEnd),
+				)
+			}
+		})
 	}
 
-	// Where hours *are* configured, the two agree — which is what makes the case
-	// above a gap in the weekday path rather than a deliberate difference.
-	sameStart, sameEnd := adjustTimesByAllowedHours(mustDate(t, "2026-03-17"), nil, nil, calendar)
-	sameWeekdayStart, sameWeekdayEnd := adjustTimesByAllowedHoursForWeekday(2, nil, nil, calendar)
+	t.Run("an untimed request on an unconfigured weekday becomes a full day", func(t *testing.T) {
+		start, end := adjustTimesByAllowedHoursForWeekday(4, nil, nil, calendar)
 
-	if deref(sameStart) != deref(sameWeekdayStart) || deref(sameEnd) != deref(sameWeekdayEnd) {
-		t.Errorf(
-			"configured hours should agree, got %s-%s vs %s-%s",
-			deref(sameStart), deref(sameEnd), deref(sameWeekdayStart), deref(sameWeekdayEnd),
-		)
-	}
+		if deref(start) != "00:00" || deref(end) != "23:59" {
+			t.Errorf("got %s-%s, want 00:00-23:59", deref(start), deref(end))
+		}
+	})
+
+	t.Run("a weekday the calendar refuses is left unclamped", func(t *testing.T) {
+		// Wednesday (3) is not allowed. Validation rejects it before this matters;
+		// inventing a window here would only obscure that.
+		start, end := adjustTimesByAllowedHoursForWeekday(3, ptr("06:00"), ptr("23:00"), calendar)
+
+		if deref(start) != "06:00" || deref(end) != "23:00" {
+			t.Errorf("got %s-%s, want the request unchanged", deref(start), deref(end))
+		}
+	})
 }


### PR DESCRIPTION
Three behaviours were pinned by tests that asserted the wart rather than the virtue,
each deferred at the time because it needed a decision rather than a patch. Those tests
now assert the fix — which is what pinning them was for.

## The two time clamps agree

For a weekday the calendar **allowed but left unconfigured**, the dated path treated the
day as `00:00-23:59` while the weekday path used for recurrences returned an empty range,
meaning "do not clamp". So an all-day one-off was stored as `00:00-23:59` while an all-day
recurrence *on the same weekday* kept `NULL` times. Both render as "all day", which is why
it went unnoticed — but they were not the same row.

`getAllowedTimeRangeForWeekday` now consults `AllowedWeekdays` and answers `00:00-23:59`
for an allowed weekday with no hours, matching the dated path. A weekday the calendar
*refuses* still yields no window: validation rejects it earlier, and inventing a range
there would only obscure that.

`TestWeekdayAndDatedWindowsDivergeWithoutHours` becomes
`TestWeekdayAndDatedWindowsAgree`, and checks both a configured and an unconfigured
weekday.

## An empty range summary is `[]`, not `null`

It accumulated into a nil slice, so a quiet calendar came back as `null` and any client
calling `.map()` on the payload threw. `ParticipantView` carried an `Array.isArray` guard
purely to absorb it.

```
$ curl '.../range?start=2020-01-01&end=2020-01-07'
{"success":true,"data":[]}
```

The guard stays as insurance against an older self-hosted server, but its comment no
longer blames the current one.

## `Home` and `End` follow the visual row in both layouts

They subtracted `index % 7` unconditionally, which describes a row only in the wide grid.
The compact layout is **transposed** — a row gathers the indices sharing `index % 7`,
spaced seven apart — so the keys jumped to an unrelated cell.

Both layouts now derive from the same horizontal step the arrow keys already use, so the
two cannot disagree again, and a short trailing row no longer sends `End` past the end of
the grid. The test that documented the bad arithmetic is replaced by two that assert the
row, including the short-row case.

## Verification

| Check | Result |
| --- | --- |
| `make test` / `BUILD_TYPE=cloud` | 0 failures |
| `go build` both tags | pass |
| Vitest | 338 passed |
| Playwright harness | 56 passed |
| Playwright real backend | 13 passed |
| `make format-check`, `vue-tsc` | pass |

The `[]` change was confirmed against a running server, not just in a unit test.
