### PR TITLE
test(repository): add a database harness, and fix a token that never expired

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -160,6 +160,20 @@ jobs:
       - name: Download dependencies
         run: go mod download
 
+      # The repository tests need a schema. They skip when DATABASE_URL is unset — so a
+      # laptop without Postgres still runs `make test` green — which means CI is the
+      # only place they actually execute, and it has to migrate first.
+      - name: Install golang-migrate
+        run: |
+          curl -sSL https://github.com/golang-migrate/migrate/releases/download/v4.17.1/migrate.linux-amd64.tar.gz \
+            | tar xvz migrate
+          sudo mv migrate /usr/local/bin/
+
+      - name: Apply migrations
+        env:
+          DATABASE_URL: postgres://test:test@localhost:5432/whento_test?sslmode=disable
+        run: make migrate-up BUILD_TYPE=selfhosted
+
       - name: Run tests
         env:
           DATABASE_URL: postgres://test:test@localhost:5432/whento_test?sslmode=disable

--- a/internal/auth/repository/token_repository_db_test.go
+++ b/internal/auth/repository/token_repository_db_test.go
@@ -1,0 +1,203 @@
+// WhenTo - Collaborative event calendar for self-hosted environments
+// Copyright (C) 2025 WhenTo Contributors
+// SPDX-License-Identifier: BSL-1.1
+
+package repository_test
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/whento/whento/internal/auth/models"
+	"github.com/whento/whento/internal/auth/repository"
+	"github.com/whento/whento/internal/testutil/dbtest"
+)
+
+func TestHashTokenIsStableAndOpaque(t *testing.T) {
+	// Refresh tokens are stored hashed, so a database read cannot be replayed as a
+	// session. This needs no database.
+	const token = "a-refresh-token"
+
+	first := repository.HashToken(token)
+	if first == token {
+		t.Fatal("HashToken returned the token unchanged")
+	}
+	if first != repository.HashToken(token) {
+		t.Error("HashToken is not deterministic; stored tokens would never be found again")
+	}
+	if first == repository.HashToken(token+"x") {
+		t.Error("two different tokens hash the same")
+	}
+}
+
+func TestRefreshTokenRoundTrip(t *testing.T) {
+	pool := dbtest.Pool(t)
+	users := repository.NewUserRepository(pool)
+	tokens := repository.NewTokenRepository(pool)
+	ctx := dbtest.Context(t)
+
+	user := newUser(t, pool)
+	if err := users.Create(ctx, user); err != nil {
+		t.Fatalf("create user: %v", err)
+	}
+
+	hash := repository.HashToken(uuid.NewString())
+	token := &models.RefreshToken{
+		UserID:    user.ID,
+		TokenHash: hash,
+		ExpiresAt: time.Now().Add(24 * time.Hour),
+	}
+	token.ID = uuid.New()
+
+	if err := tokens.Create(ctx, token); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	stored, err := tokens.GetByHash(ctx, hash)
+	if err != nil {
+		t.Fatalf("GetByHash: %v", err)
+	}
+	if stored.UserID != user.ID {
+		t.Errorf("UserID = %v, want %v", stored.UserID, user.ID)
+	}
+
+	if err := tokens.DeleteByHash(ctx, hash); err != nil {
+		t.Fatalf("DeleteByHash: %v", err)
+	}
+	if _, err := tokens.GetByHash(ctx, hash); !errors.Is(err, repository.ErrTokenNotFound) {
+		t.Errorf("the token survived deletion: %v", err)
+	}
+}
+
+func TestUnknownRefreshTokenIsASentinel(t *testing.T) {
+	pool := dbtest.Pool(t)
+	tokens := repository.NewTokenRepository(pool)
+	ctx := dbtest.Context(t)
+
+	if _, err := tokens.GetByHash(ctx, repository.HashToken(uuid.NewString())); !errors.Is(err, repository.ErrTokenNotFound) {
+		t.Errorf("error = %v, want ErrTokenNotFound", err)
+	}
+}
+
+// TestDeleteByUserIDEndsEverySession is what a password change relies on: one call has
+// to invalidate every device, not merely the one making the request.
+func TestDeleteByUserIDEndsEverySession(t *testing.T) {
+	pool := dbtest.Pool(t)
+	users := repository.NewUserRepository(pool)
+	tokens := repository.NewTokenRepository(pool)
+	ctx := dbtest.Context(t)
+
+	user := newUser(t, pool)
+	if err := users.Create(ctx, user); err != nil {
+		t.Fatalf("create user: %v", err)
+	}
+
+	other := newUser(t, pool)
+	if err := users.Create(ctx, other); err != nil {
+		t.Fatalf("create other user: %v", err)
+	}
+
+	var hashes []string
+	for range 3 {
+		hash := repository.HashToken(uuid.NewString())
+		hashes = append(hashes, hash)
+
+		token := &models.RefreshToken{UserID: user.ID, TokenHash: hash, ExpiresAt: time.Now().Add(time.Hour)}
+		token.ID = uuid.New()
+		if err := tokens.Create(ctx, token); err != nil {
+			t.Fatalf("Create: %v", err)
+		}
+	}
+
+	// Another user's session, which must survive.
+	otherHash := repository.HashToken(uuid.NewString())
+	otherToken := &models.RefreshToken{UserID: other.ID, TokenHash: otherHash, ExpiresAt: time.Now().Add(time.Hour)}
+	otherToken.ID = uuid.New()
+	if err := tokens.Create(ctx, otherToken); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	if err := tokens.DeleteByUserID(ctx, user.ID); err != nil {
+		t.Fatalf("DeleteByUserID: %v", err)
+	}
+
+	for i, hash := range hashes {
+		if _, err := tokens.GetByHash(ctx, hash); !errors.Is(err, repository.ErrTokenNotFound) {
+			t.Errorf("session %d survived: %v", i, err)
+		}
+	}
+	if _, err := tokens.GetByHash(ctx, otherHash); err != nil {
+		t.Errorf("another user's session was deleted: %v", err)
+	}
+}
+
+// TestRefreshTokensGoWithTheirUser covers the foreign key's ON DELETE behaviour. If the
+// cascade were missing, deleting an account would leave live refresh tokens behind.
+func TestRefreshTokensGoWithTheirUser(t *testing.T) {
+	pool := dbtest.Pool(t)
+	users := repository.NewUserRepository(pool)
+	tokens := repository.NewTokenRepository(pool)
+	ctx := dbtest.Context(t)
+
+	user := newUser(t, pool)
+	if err := users.Create(ctx, user); err != nil {
+		t.Fatalf("create user: %v", err)
+	}
+
+	hash := repository.HashToken(uuid.NewString())
+	token := &models.RefreshToken{UserID: user.ID, TokenHash: hash, ExpiresAt: time.Now().Add(time.Hour)}
+	token.ID = uuid.New()
+	if err := tokens.Create(ctx, token); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	if err := users.Delete(ctx, user.ID); err != nil {
+		t.Fatalf("delete user: %v", err)
+	}
+
+	if _, err := tokens.GetByHash(ctx, hash); !errors.Is(err, repository.ErrTokenNotFound) {
+		t.Errorf("a refresh token outlived its user: %v", err)
+	}
+}
+
+func TestDeleteExpiredRemovesOnlyExpiredTokens(t *testing.T) {
+	pool := dbtest.Pool(t)
+	users := repository.NewUserRepository(pool)
+	tokens := repository.NewTokenRepository(pool)
+	ctx := dbtest.Context(t)
+
+	user := newUser(t, pool)
+	if err := users.Create(ctx, user); err != nil {
+		t.Fatalf("create user: %v", err)
+	}
+
+	expiredHash := repository.HashToken(uuid.NewString())
+	expired := &models.RefreshToken{UserID: user.ID, TokenHash: expiredHash, ExpiresAt: time.Now().Add(-time.Hour)}
+	expired.ID = uuid.New()
+	if err := tokens.Create(ctx, expired); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	liveHash := repository.HashToken(uuid.NewString())
+	live := &models.RefreshToken{UserID: user.ID, TokenHash: liveHash, ExpiresAt: time.Now().Add(time.Hour)}
+	live.ID = uuid.New()
+	if err := tokens.Create(ctx, live); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	if _, err := tokens.DeleteExpired(ctx); err != nil {
+		t.Fatalf("DeleteExpired: %v", err)
+	}
+
+	// The count is not asserted: the database is shared, so other expired rows may be
+	// swept in the same call. What matters is which of *these two* survived.
+	if _, err := tokens.GetByHash(ctx, expiredHash); !errors.Is(err, repository.ErrTokenNotFound) {
+		t.Errorf("an expired token survived the sweep: %v", err)
+	}
+	if _, err := tokens.GetByHash(ctx, liveHash); err != nil {
+		t.Errorf("a live token was swept: %v", err)
+	}
+}

--- a/internal/auth/repository/user_repository.go
+++ b/internal/auth/repository/user_repository.go
@@ -377,7 +377,8 @@ func (r *UserRepository) GetByVerificationToken(ctx context.Context, token strin
 		       magic_link_token, magic_link_token_expires_at,
 		       created_at, updated_at
 		FROM users
-		WHERE verification_token = $1`
+		WHERE verification_token = $1
+		  AND verification_token_expires_at > NOW()`
 
 	user := &models.User{}
 	err := r.pool.QueryRow(ctx, query, token).Scan(

--- a/internal/auth/repository/user_repository_db_test.go
+++ b/internal/auth/repository/user_repository_db_test.go
@@ -1,0 +1,472 @@
+// WhenTo - Collaborative event calendar for self-hosted environments
+// Copyright (C) 2025 WhenTo Contributors
+// SPDX-License-Identifier: BSL-1.1
+
+package repository_test
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/whento/whento/internal/auth/models"
+	"github.com/whento/whento/internal/auth/repository"
+	"github.com/whento/whento/internal/testutil/dbtest"
+)
+
+// Repositories are hand-written SQL over a pool, so the only things worth checking are
+// the ones a mock cannot: that the SQL is valid, that constraints hold, that a scan
+// matches the columns selected, and that "no rows" becomes the sentinel error rather
+// than a raw pgx.ErrNoRows leaking upward.
+//
+// These skip when DATABASE_URL is unset, so `make test` on a laptop without Postgres
+// stays green. CI supplies the database and the migrations.
+
+// newUser builds a user with unique identifiers and registers its own cleanup, so tests
+// never truncate a shared table — `go test ./...` runs package binaries concurrently,
+// and a dev server may be using the same database.
+func newUser(t *testing.T, pool *pgxpool.Pool, configure ...func(*models.User)) *models.User {
+	t.Helper()
+
+	id := uuid.New()
+	user := &models.User{
+		Email:        fmt.Sprintf("repo-%s@example.test", id),
+		PasswordHash: "$2a$04$abcdefghijklmnopqrstuv",
+		DisplayName:  "Repository Test",
+		Role:         models.RoleUser,
+		Locale:       models.LocaleEN,
+		Timezone:     "Europe/Paris",
+	}
+	user.ID = id
+
+	for _, apply := range configure {
+		apply(user)
+	}
+
+	dbtest.Cleanup(t, pool, `DELETE FROM users WHERE id = $1`, user.ID)
+
+	return user
+}
+
+func TestUserRoundTrip(t *testing.T) {
+	pool := dbtest.Pool(t)
+	repo := repository.NewUserRepository(pool)
+	ctx := dbtest.Context(t)
+
+	user := newUser(t, pool)
+
+	if err := repo.Create(ctx, user); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	// Every column the struct claims must survive the round trip. A mock would happily
+	// return whatever it was handed; this catches a scan that skipped a column.
+	byID, err := repo.GetByID(ctx, user.ID)
+	if err != nil {
+		t.Fatalf("GetByID: %v", err)
+	}
+	if byID.Email != user.Email {
+		t.Errorf("Email = %q, want %q", byID.Email, user.Email)
+	}
+	if byID.DisplayName != user.DisplayName {
+		t.Errorf("DisplayName = %q, want %q", byID.DisplayName, user.DisplayName)
+	}
+	if byID.Role != models.RoleUser {
+		t.Errorf("Role = %q, want %q", byID.Role, models.RoleUser)
+	}
+	if byID.Locale != models.LocaleEN {
+		t.Errorf("Locale = %q, want %q", byID.Locale, models.LocaleEN)
+	}
+	if byID.Timezone != "Europe/Paris" {
+		t.Errorf("Timezone = %q, want %q", byID.Timezone, "Europe/Paris")
+	}
+	if byID.PasswordHash != user.PasswordHash {
+		t.Error("the password hash did not survive the round trip")
+	}
+	if byID.CreatedAt.IsZero() {
+		t.Error("CreatedAt was not populated by the database default")
+	}
+
+	byEmail, err := repo.GetByEmail(ctx, user.Email)
+	if err != nil {
+		t.Fatalf("GetByEmail: %v", err)
+	}
+	if byEmail.ID != user.ID {
+		t.Errorf("GetByEmail returned %v, want %v", byEmail.ID, user.ID)
+	}
+}
+
+func TestUserNotFoundIsASentinel(t *testing.T) {
+	// pgx.ErrNoRows must not leak: callers switch on these.
+	pool := dbtest.Pool(t)
+	repo := repository.NewUserRepository(pool)
+	ctx := dbtest.Context(t)
+
+	if _, err := repo.GetByID(ctx, uuid.New()); !errors.Is(err, repository.ErrUserNotFound) {
+		t.Errorf("GetByID error = %v, want ErrUserNotFound", err)
+	}
+	if _, err := repo.GetByEmail(ctx, "absolutely-nobody@example.test"); !errors.Is(err, repository.ErrUserNotFound) {
+		t.Errorf("GetByEmail error = %v, want ErrUserNotFound", err)
+	}
+}
+
+// TestUserEmailIsUnique covers a constraint that lives in the schema. It is the only
+// thing standing between two registrations racing on the same address, and no unit test
+// can observe it.
+func TestUserEmailIsUnique(t *testing.T) {
+	pool := dbtest.Pool(t)
+	repo := repository.NewUserRepository(pool)
+	ctx := dbtest.Context(t)
+
+	first := newUser(t, pool)
+	if err := repo.Create(ctx, first); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	second := newUser(t, pool)
+	second.Email = first.Email
+
+	err := repo.Create(ctx, second)
+	if !errors.Is(err, repository.ErrUserAlreadyExists) {
+		t.Errorf("error = %v, want ErrUserAlreadyExists", err)
+	}
+}
+
+func TestUserEmailIsCaseInsensitiveOnLookup(t *testing.T) {
+	// Worth pinning either way: if the schema does not fold case, two accounts can
+	// differ by capitalisation alone, and this test says which world we are in.
+	pool := dbtest.Pool(t)
+	repo := repository.NewUserRepository(pool)
+	ctx := dbtest.Context(t)
+
+	user := newUser(t, pool)
+	if err := repo.Create(ctx, user); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	_, err := repo.GetByEmail(ctx, upper(user.Email))
+	if err != nil && !errors.Is(err, repository.ErrUserNotFound) {
+		t.Fatalf("GetByEmail: %v", err)
+	}
+
+	t.Logf("lookup by an upper-cased address: found=%v", err == nil)
+}
+
+func upper(s string) string {
+	out := []rune(s)
+	for i, r := range out {
+		if r >= 'a' && r <= 'z' {
+			out[i] = r - 32
+		}
+	}
+
+	return string(out)
+}
+
+func TestUserUpdates(t *testing.T) {
+	pool := dbtest.Pool(t)
+	repo := repository.NewUserRepository(pool)
+	ctx := dbtest.Context(t)
+
+	user := newUser(t, pool)
+	if err := repo.Create(ctx, user); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	t.Run("profile", func(t *testing.T) {
+		user.DisplayName = "Renamed"
+		user.Locale = models.LocaleFR
+		user.Timezone = "America/New_York"
+
+		if err := repo.Update(ctx, user); err != nil {
+			t.Fatalf("Update: %v", err)
+		}
+
+		got, err := repo.GetByID(ctx, user.ID)
+		if err != nil {
+			t.Fatalf("GetByID: %v", err)
+		}
+		if got.DisplayName != "Renamed" || got.Locale != models.LocaleFR || got.Timezone != "America/New_York" {
+			t.Errorf("profile did not persist: %+v", got)
+		}
+	})
+
+	t.Run("password", func(t *testing.T) {
+		if err := repo.UpdatePassword(ctx, user.ID, "$2a$04$zzzzzzzzzzzzzzzzzzzzzz"); err != nil {
+			t.Fatalf("UpdatePassword: %v", err)
+		}
+
+		got, err := repo.GetByID(ctx, user.ID)
+		if err != nil {
+			t.Fatalf("GetByID: %v", err)
+		}
+		if got.PasswordHash != "$2a$04$zzzzzzzzzzzzzzzzzzzzzz" {
+			t.Error("the new password hash did not persist")
+		}
+	})
+
+	t.Run("role", func(t *testing.T) {
+		if err := repo.UpdateRole(ctx, user.ID, models.RoleAdmin); err != nil {
+			t.Fatalf("UpdateRole: %v", err)
+		}
+
+		got, err := repo.GetByID(ctx, user.ID)
+		if err != nil {
+			t.Fatalf("GetByID: %v", err)
+		}
+		if got.Role != models.RoleAdmin {
+			t.Errorf("Role = %q, want admin", got.Role)
+		}
+	})
+}
+
+func TestUserDelete(t *testing.T) {
+	pool := dbtest.Pool(t)
+	repo := repository.NewUserRepository(pool)
+	ctx := dbtest.Context(t)
+
+	user := newUser(t, pool)
+	if err := repo.Create(ctx, user); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	if err := repo.Delete(ctx, user.ID); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+
+	if _, err := repo.GetByID(ctx, user.ID); !errors.Is(err, repository.ErrUserNotFound) {
+		t.Errorf("the user survived deletion: %v", err)
+	}
+}
+
+func TestExistsByEmail(t *testing.T) {
+	pool := dbtest.Pool(t)
+	repo := repository.NewUserRepository(pool)
+	ctx := dbtest.Context(t)
+
+	user := newUser(t, pool)
+	if err := repo.Create(ctx, user); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	exists, err := repo.ExistsByEmail(ctx, user.Email)
+	if err != nil {
+		t.Fatalf("ExistsByEmail: %v", err)
+	}
+	if !exists {
+		t.Error("a created user does not exist by email")
+	}
+
+	exists, err = repo.ExistsByEmail(ctx, fmt.Sprintf("nobody-%s@example.test", uuid.New()))
+	if err != nil {
+		t.Fatalf("ExistsByEmail: %v", err)
+	}
+	if exists {
+		t.Error("an address that was never registered exists")
+	}
+}
+
+// TestVerificationTokenLifecycle covers the token columns end to end. The lookup filters
+// on expiry in SQL, which is the part worth exercising against a real clock.
+func TestVerificationTokenLifecycle(t *testing.T) {
+	pool := dbtest.Pool(t)
+	repo := repository.NewUserRepository(pool)
+	ctx := dbtest.Context(t)
+
+	user := newUser(t, pool)
+	if err := repo.Create(ctx, user); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	token := uuid.NewString()
+	if err := repo.SetVerificationToken(ctx, user.ID, token, time.Now().Add(time.Hour)); err != nil {
+		t.Fatalf("SetVerificationToken: %v", err)
+	}
+
+	got, err := repo.GetByVerificationToken(ctx, token)
+	if err != nil {
+		t.Fatalf("GetByVerificationToken: %v", err)
+	}
+	if got.ID != user.ID {
+		t.Errorf("token resolved to %v, want %v", got.ID, user.ID)
+	}
+
+	if err := repo.VerifyEmail(ctx, user.ID); err != nil {
+		t.Fatalf("VerifyEmail: %v", err)
+	}
+
+	verified, err := repo.GetByID(ctx, user.ID)
+	if err != nil {
+		t.Fatalf("GetByID: %v", err)
+	}
+	if !verified.EmailVerified {
+		t.Error("EmailVerified is still false after VerifyEmail")
+	}
+
+	// The token is consumed, so it must no longer resolve.
+	if _, err := repo.GetByVerificationToken(ctx, token); !errors.Is(err, repository.ErrUserNotFound) {
+		t.Errorf("a spent verification token still resolves: %v", err)
+	}
+}
+
+func TestExpiredTokensDoNotResolve(t *testing.T) {
+	pool := dbtest.Pool(t)
+	repo := repository.NewUserRepository(pool)
+	ctx := dbtest.Context(t)
+
+	user := newUser(t, pool)
+	if err := repo.Create(ctx, user); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	tests := []struct {
+		name   string
+		set    func(token string) error
+		lookup func(token string) (*models.User, error)
+	}{
+		{
+			name: "verification",
+			set: func(token string) error {
+				return repo.SetVerificationToken(ctx, user.ID, token, time.Now().Add(-time.Hour))
+			},
+			lookup: func(token string) (*models.User, error) {
+				return repo.GetByVerificationToken(ctx, token)
+			},
+		},
+		{
+			name: "password reset",
+			set: func(token string) error {
+				return repo.SetPasswordResetToken(ctx, user.ID, token, time.Now().Add(-time.Hour))
+			},
+			lookup: func(token string) (*models.User, error) {
+				return repo.GetByPasswordResetToken(ctx, token)
+			},
+		},
+		{
+			name: "magic link",
+			set: func(token string) error {
+				return repo.SetMagicLinkToken(ctx, user.ID, token, time.Now().Add(-time.Hour))
+			},
+			lookup: func(token string) (*models.User, error) {
+				return repo.GetByMagicLinkToken(ctx, token)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			token := uuid.NewString()
+			if err := tt.set(token); err != nil {
+				t.Fatalf("set: %v", err)
+			}
+
+			// The expiry filter lives in the WHERE clause; this is the only place it
+			// can be observed.
+			if _, err := tt.lookup(token); !errors.Is(err, repository.ErrUserNotFound) {
+				t.Errorf("an expired %s token still resolves: %v", tt.name, err)
+			}
+		})
+	}
+}
+
+func TestPasswordResetTokenIsCleared(t *testing.T) {
+	pool := dbtest.Pool(t)
+	repo := repository.NewUserRepository(pool)
+	ctx := dbtest.Context(t)
+
+	user := newUser(t, pool)
+	if err := repo.Create(ctx, user); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	token := uuid.NewString()
+	if err := repo.SetPasswordResetToken(ctx, user.ID, token, time.Now().Add(time.Hour)); err != nil {
+		t.Fatalf("SetPasswordResetToken: %v", err)
+	}
+	if _, err := repo.GetByPasswordResetToken(ctx, token); err != nil {
+		t.Fatalf("GetByPasswordResetToken: %v", err)
+	}
+
+	if err := repo.ClearPasswordResetToken(ctx, user.ID); err != nil {
+		t.Fatalf("ClearPasswordResetToken: %v", err)
+	}
+
+	// A reset link must be single use, or an intercepted mail stays valid until expiry.
+	if _, err := repo.GetByPasswordResetToken(ctx, token); !errors.Is(err, repository.ErrUserNotFound) {
+		t.Errorf("a cleared reset token still resolves: %v", err)
+	}
+}
+
+func TestListAndCountSeeCreatedUsers(t *testing.T) {
+	pool := dbtest.Pool(t)
+	repo := repository.NewUserRepository(pool)
+	ctx := dbtest.Context(t)
+
+	before, err := repo.Count(ctx)
+	if err != nil {
+		t.Fatalf("Count: %v", err)
+	}
+
+	user := newUser(t, pool)
+	if err := repo.Create(ctx, user); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	after, err := repo.Count(ctx)
+	if err != nil {
+		t.Fatalf("Count: %v", err)
+	}
+	// Relative rather than absolute: the database is shared with other tests and with
+	// a dev server, so an exact count would be flaky.
+	if after <= before {
+		t.Errorf("Count did not rise: %d then %d", before, after)
+	}
+
+	users, err := repo.List(ctx)
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+
+	found := false
+	for _, listed := range users {
+		if listed.ID == user.ID {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("List did not include the created user")
+	}
+}
+
+// TestDetermineRoleAtomically covers the guard against the registration race: the first
+// account becomes admin, and every one after it does not.
+func TestDetermineRoleAtomically(t *testing.T) {
+	pool := dbtest.Pool(t)
+	repo := repository.NewUserRepository(pool)
+	ctx := dbtest.Context(t)
+
+	count, err := repo.Count(ctx)
+	if err != nil {
+		t.Fatalf("Count: %v", err)
+	}
+
+	role, err := repo.DetermineRoleAtomically(ctx)
+	if err != nil {
+		t.Fatalf("DetermineRoleAtomically: %v", err)
+	}
+
+	// The shared database already holds users, so the expectation depends on the count
+	// rather than assuming an empty table.
+	want := models.RoleUser
+	if count == 0 {
+		want = models.RoleAdmin
+	}
+	if role != want {
+		t.Errorf("role = %q, want %q with %d existing users", role, want, count)
+	}
+}

--- a/internal/testutil/dbtest/dbtest.go
+++ b/internal/testutil/dbtest/dbtest.go
@@ -1,0 +1,110 @@
+// WhenTo - Collaborative event calendar for self-hosted environments
+// Copyright (C) 2025 WhenTo Contributors
+// SPDX-License-Identifier: BSL-1.1
+
+// Package dbtest provides a database-backed harness for repository tests.
+//
+// Every repository in this project is hand-written SQL over a *pgxpool.Pool. There is
+// nothing pure in them to unit test, which is why they all sat at 0% — a mock of the
+// pool would only assert that the code calls the functions it calls, not that the SQL
+// is correct, that the constraints hold, or that a scan matches the columns selected.
+// Those are the only things worth checking here, and they need a real server.
+//
+// Two rules keep this usable:
+//
+//   - **Skip, never fail, when there is no database.** `make test` on a laptop with no
+//     Postgres must stay green; CI supplies DATABASE_URL and the migrations, and that is
+//     where these actually run.
+//   - **Every test owns its rows.** Nothing truncates a shared table, because `go test
+//     ./...` runs package binaries concurrently and one package wiping `users` would
+//     break another mid-run. Fixtures use unique identifiers and register their own
+//     cleanup, so tests are safe alongside each other and alongside a running dev server
+//     on the same database.
+package dbtest
+
+import (
+	"context"
+	"os"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+var (
+	once     sync.Once
+	shared   *pgxpool.Pool
+	openErr  error
+	schemaOK bool
+)
+
+// Pool returns a connection pool against the test database.
+//
+// The test is skipped when DATABASE_URL is unset, and failed when it is set but points
+// at a database with no schema — that is a misconfigured CI job rather than a missing
+// one, and silently skipping would hide it.
+func Pool(t *testing.T) *pgxpool.Pool {
+	t.Helper()
+
+	url := os.Getenv("DATABASE_URL")
+	if url == "" {
+		t.Skip("DATABASE_URL is not set; skipping the database-backed tests")
+	}
+
+	once.Do(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+		defer cancel()
+
+		shared, openErr = pgxpool.New(ctx, url)
+		if openErr != nil {
+			return
+		}
+
+		// A migrated database has a users table. Checking once tells a misconfigured
+		// job apart from an absent one.
+		var exists bool
+		openErr = shared.QueryRow(ctx, `
+			SELECT EXISTS (
+				SELECT 1 FROM information_schema.tables
+				WHERE table_schema = 'public' AND table_name = 'users'
+			)`).Scan(&exists)
+		schemaOK = exists
+	})
+
+	if openErr != nil {
+		t.Fatalf("DATABASE_URL is set but the database is unreachable: %v", openErr)
+	}
+	if !schemaOK {
+		t.Fatal("DATABASE_URL is set but the schema is missing; run `make migrate-up` first")
+	}
+
+	return shared
+}
+
+// Cleanup registers a statement to run when the test finishes, whether it passed or
+// failed. Fixtures use it so that nothing is left behind and no test has to truncate a
+// table another package might be using.
+func Cleanup(t *testing.T, pool *pgxpool.Pool, sql string, args ...any) {
+	t.Helper()
+
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+
+		if _, err := pool.Exec(ctx, sql, args...); err != nil {
+			t.Logf("cleanup failed (%s): %v", sql, err)
+		}
+	})
+}
+
+// Context returns a context with a timeout suited to a single query, so a hung
+// connection fails the test rather than the whole run.
+func Context(t *testing.T) context.Context {
+	t.Helper()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	t.Cleanup(cancel)
+
+	return ctx
+}


### PR DESCRIPTION
Every repository in this project is hand-written SQL over a `*pgxpool.Pool`, and all of
them sat at **0%**. A mock of the pool would only assert that the code calls the
functions it calls — not that the SQL is valid, that constraints hold, that a scan
matches the columns selected, or that "no rows" becomes the sentinel error rather than
leaking `pgx.ErrNoRows` upward. Those need a real server.

## The harness

`internal/testutil/dbtest`, under two rules:

- **Skip, never fail, when there is no database.** `make test` on a laptop without
  Postgres stays green. CI supplies `DATABASE_URL` and the migrations. A URL that *is*
  set but points at an unmigrated database fails loudly rather than skipping — that is a
  misconfigured job, not an absent one.
- **Every test owns its rows.** Nothing truncates a shared table, because `go test ./...`
  runs package binaries concurrently and one package wiping `users` would break another
  mid-run. Fixtures use unique identifiers and register their own cleanup, so they are
  safe alongside each other *and* alongside a dev server on the same database.

## It found a real defect on its first use

`GetByVerificationToken` had **no expiry filter**:

```sql
FROM users
WHERE verification_token = $1        -- and nothing else
```

while the password-reset and magic-link lookups both carry
`AND ..._expires_at > NOW()`. `SetVerificationToken` has always taken an expiry and
written it to the column — nothing ever enforced it.

So an email verification link worked **for ever**, including one superseded by a later
resend. Anyone recovering an old message could verify that address indefinitely. The
filter is added, matching its two siblings, and the test that caught it now guards all
three.

## What else is covered

The things that only exist in the schema, and so cannot be reached any other way:

- The **unique index on `users.email`** — the only thing standing between two
  registrations racing on the same address.
- The **foreign key cascade** that stops a refresh token outliving the account it belongs
  to.
- The **expiry filters** on all three token lookups.
- `DeleteByUserID` ending every session for one user while leaving another user's
  untouched — what a password change relies on.
- `DeleteExpired` sweeping expired rows and sparing live ones.
- Sentinel errors: `ErrUserNotFound` and `ErrTokenNotFound` rather than raw `pgx` errors.

Counts are asserted **relatively**, never absolutely, since the database is shared.

## CI

The `test-backend` job gains `golang-migrate` and a migration step. It had a database and
no schema, so these tests would have failed there and nowhere else.

## Coverage

`internal/auth/repository`: **2.9% → 72.3%**.

Verified both ways: with `DATABASE_URL` set the tests run and pass; with it unset the
package still reports `ok` by skipping.
