### PR TITLE
fix(e2e): stop the participant suite failing on a month boundary

### DIFF
--- a/frontend/e2e-backend/fixtures/seed.ts
+++ b/frontend/e2e-backend/fixtures/seed.ts
@@ -46,15 +46,44 @@ function iso(date: Date): string {
 }
 
 /**
- * The Monday of the week after next.
+ * The furthest offset from the anchor that any test reads out of the DOM.
  *
- * Far enough ahead that nothing in the fixture is in the past — the calendar refuses
- * edits to past dates — and never so far that it leaves the range the view loads.
+ * `day(11)` is asserted with expectNotMarked, which counts zero matches — so a cell that
+ * is simply not rendered would make it pass for the wrong reason. Range queries reach
+ * further (`day(20)`, `day(400)`) but go straight to the API and never touch the grid.
+ */
+const RENDERED_SPAN_DAYS = 11;
+
+/**
+ * A Monday whose following two weeks all fall inside one calendar month.
+ *
+ * The starting point is the Monday of the week after next: far enough ahead that nothing
+ * in the fixture is in the past, since the calendar refuses edits to past dates.
+ *
+ * The single-month constraint is what the month grid imposes. It renders one month at a
+ * time, and a date in the next month is present only as trailing overflow — a cell that
+ * exists, carries the right `data-date`, and is inert. Clicking it waits sixty seconds
+ * for an element that will never become enabled.
+ *
+ * Anchoring alone is not enough, because the view always opens on today's month; the
+ * tests navigate to the anchor's month. But navigation alone is not enough either, since
+ * the drag test spans day(8) to day(10) and no single month shows all three once they
+ * straddle a boundary. Both halves are needed.
  */
 function upcomingMonday(): Date {
   const date = new Date();
   date.setHours(0, 0, 0, 0);
   date.setDate(date.getDate() + ((8 - date.getDay()) % 7) + 7);
+
+  // Step a week at a time until the whole rendered span fits in one month. A Monday
+  // early in a month always satisfies this, so at most a few steps are needed.
+  for (let step = 0; step < 6; step += 1) {
+    const last = new Date(date);
+    last.setDate(last.getDate() + RENDERED_SPAN_DAYS);
+    if (last.getMonth() === date.getMonth()) break;
+    date.setDate(date.getDate() + 7);
+  }
+
   return date;
 }
 

--- a/frontend/e2e-backend/participant.spec.ts
+++ b/frontend/e2e-backend/participant.spec.ts
@@ -17,12 +17,50 @@ import { fetchAvailabilities, fetchRangeSummary, seedCalendar } from './fixtures
  * the component believes.
  */
 
-/** Wait for the view to be interactive rather than merely mounted. */
-async function openCalendar(page: Page, url: string) {
+/**
+ * Wait for the view to be interactive rather than merely mounted, and bring the
+ * fixture's month into view.
+ *
+ * Pass `anchor` whenever the test reads cells out of the grid. The month view opens on
+ * today's month and renders one month at a time, so a fixture anchored in the next month
+ * is present only as trailing overflow: cells that exist and carry the right `data-date`
+ * but are inert. Clicking one waits for an element that never becomes enabled, and an
+ * expectNotMarked assertion against one passes for the wrong reason.
+ */
+async function openCalendar(page: Page, url: string, anchor?: string) {
   await page.goto(url, { waitUntil: 'domcontentloaded' });
   await page.waitForSelector('#displayMode', { timeout: 30_000 });
   // The grid renders from the range summary, so wait for a real cell.
   await page.waitForSelector('.cal-cell[data-date]');
+
+  if (anchor) await showMonthOf(page, anchor);
+}
+
+/**
+ * Step the month grid forward until `date` is a cell of the month itself.
+ *
+ * `:not([data-status="outside"])` is the whole question: overflow cells match on date
+ * alone. The fixture keeps its rendered span inside one month, so bringing the anchor
+ * into view brings every date the tests touch with it.
+ */
+async function showMonthOf(page: Page, date: string) {
+  const live = page.locator(`.cal-cell[data-date="${date}"]:not([data-status="outside"])`);
+
+  for (let step = 0; step < 12; step += 1) {
+    if ((await live.count()) > 0) return;
+
+    const shown = await page
+      .locator('.cal-month .cal-cell[data-date]')
+      .first()
+      .getAttribute('data-date');
+    await page.getByTestId('month-next').click();
+    // The grid reloads from a fresh range summary; wait for it rather than racing it.
+    await expect
+      .poll(() => page.locator('.cal-month .cal-cell[data-date]').first().getAttribute('data-date'))
+      .not.toBe(shown);
+  }
+
+  throw new Error(`${date} never came into view after twelve months of stepping forward`);
 }
 
 function cell(page: Page, date: string) {
@@ -47,7 +85,7 @@ async function expectNotMarked(page: Page, date: string, marker: string) {
 test.describe('adding and removing availability', () => {
   test('a click adds an availability and it survives a reload', async ({ page, baseURL }) => {
     const seed = await seedCalendar();
-    await openCalendar(page, seed.participantUrl(baseURL!, 'Ada'));
+    await openCalendar(page, seed.participantUrl(baseURL!, 'Ada'), seed.monday);
 
     // Tuesday of the following week: allowed, empty, and in the future.
     const target = seed.day(8);
@@ -67,12 +105,16 @@ test.describe('adding and removing availability', () => {
 
     await page.reload({ waitUntil: 'domcontentloaded' });
     await page.waitForSelector('.cal-cell[data-date]');
+    // The displayed month is not persisted the way the display mode is, so a reload
+    // lands back on today's — which is the point of the assertion below, but it means
+    // navigating again first.
+    await showMonthOf(page, seed.monday);
     await expectMarked(page, target, 'data-own');
   });
 
   test('a second click removes it again', async ({ page, baseURL }) => {
     const seed = await seedCalendar();
-    await openCalendar(page, seed.participantUrl(baseURL!, 'Ada'));
+    await openCalendar(page, seed.participantUrl(baseURL!, 'Ada'), seed.monday);
 
     const target = seed.day(8);
 
@@ -93,7 +135,7 @@ test.describe('adding and removing availability', () => {
 
   test('a closed day cannot be answered', async ({ page, baseURL }) => {
     const seed = await seedCalendar();
-    await openCalendar(page, seed.participantUrl(baseURL!, 'Ada'));
+    await openCalendar(page, seed.participantUrl(baseURL!, 'Ada'), seed.monday);
 
     // Wednesday is not in allowed_weekdays.
     const wednesday = seed.day(2);
@@ -117,7 +159,7 @@ test.describe('dragging across days', () => {
     // The regression this suite exists to catch end to end: a drag that crosses a
     // disabled cell must still cover everything on both sides of it.
     const seed = await seedCalendar();
-    await openCalendar(page, seed.participantUrl(baseURL!, 'Ada'));
+    await openCalendar(page, seed.participantUrl(baseURL!, 'Ada'), seed.monday);
 
     const from = seed.day(8); // Tuesday, open
     const across = seed.day(9); // Wednesday, closed
@@ -161,7 +203,7 @@ test.describe('recurrences', () => {
     baseURL,
   }) => {
     const seed = await seedCalendar();
-    await openCalendar(page, seed.participantUrl(baseURL!, 'Ada'));
+    await openCalendar(page, seed.participantUrl(baseURL!, 'Ada'), seed.monday);
 
     const friday = seed.day(4);
     await expectMarked(page, friday, 'data-recurring');
@@ -182,7 +224,7 @@ test.describe('recurrences', () => {
 
   test('an excepted occurrence is absent', async ({ page, baseURL }) => {
     const seed = await seedCalendar();
-    await openCalendar(page, seed.participantUrl(baseURL!, 'Ada'));
+    await openCalendar(page, seed.participantUrl(baseURL!, 'Ada'), seed.monday);
 
     const excepted = seed.day(11);
     await expectNotMarked(page, excepted, 'data-recurring');
@@ -196,7 +238,7 @@ test.describe('recurrences', () => {
     baseURL,
   }) => {
     const seed = await seedCalendar();
-    await openCalendar(page, seed.participantUrl(baseURL!, 'Ada'));
+    await openCalendar(page, seed.participantUrl(baseURL!, 'Ada'), seed.monday);
 
     const friday = seed.day(4);
     await expectMarked(page, friday, 'data-recurring');
@@ -224,7 +266,7 @@ test.describe('what the grid reports', () => {
     baseURL,
   }) => {
     const seed = await seedCalendar();
-    await openCalendar(page, seed.participantUrl(baseURL!, 'Ada'));
+    await openCalendar(page, seed.participantUrl(baseURL!, 'Ada'), seed.monday);
 
     // Monday has two participants overlapping, against a threshold of two.
     await expectMarked(page, seed.monday, 'data-threshold');
@@ -239,7 +281,7 @@ test.describe('what the grid reports', () => {
     // weekday. On this calendar that is 08:00-20:00, so "all day" means "all of the
     // hours this calendar is open", not "midnight to midnight".
     const seed = await seedCalendar();
-    await openCalendar(page, seed.participantUrl(baseURL!, 'Grace'));
+    await openCalendar(page, seed.participantUrl(baseURL!, 'Grace'), seed.monday);
 
     const untimed = seed.day(3);
     await expectMarked(page, untimed, 'data-own');
@@ -290,7 +332,7 @@ test.describe('the server is the authority', () => {
     // UNIQUE(participant_id, date) lives in the database. A mocked backend would never
     // reject anything, so this constraint has no other way of being exercised.
     const seed = await seedCalendar();
-    await openCalendar(page, seed.participantUrl(baseURL!, 'Ada'));
+    await openCalendar(page, seed.participantUrl(baseURL!, 'Ada'), seed.monday);
 
     const target = seed.day(8);
     await cell(page, target).click();
@@ -329,7 +371,7 @@ test.describe('the server is the authority', () => {
 test.describe('display settings persist', () => {
   test('the chosen view survives a reload', async ({ page, baseURL }) => {
     const seed = await seedCalendar();
-    await openCalendar(page, seed.participantUrl(baseURL!, 'Ada'));
+    await openCalendar(page, seed.participantUrl(baseURL!, 'Ada'), seed.monday);
 
     await page.selectOption('#displayMode', 'week');
     await expect(page.locator('.cal-week')).toBeVisible();

--- a/frontend/src/components/calendar/CalendarMonthView.vue
+++ b/frontend/src/components/calendar/CalendarMonthView.vue
@@ -173,6 +173,7 @@ defineExpose({ selectableDays });
       <button
         type="button"
         class="btn btn-ghost px-2 py-1"
+        data-testid="month-prev"
         :aria-label="t('calendar.previousMonth')"
         @click="goToPreviousMonth"
       >
@@ -182,6 +183,7 @@ defineExpose({ selectableDays });
       <button
         type="button"
         class="btn btn-ghost px-2 py-1"
+        data-testid="month-next"
         :aria-label="t('calendar.nextMonth')"
         @click="goToNextMonth"
       >


### PR DESCRIPTION
Four tests in `participant.spec.ts` fail whenever the fixture's anchor lands in the last week of a month — roughly **one week in four**. They failed on #74, and, on the same day and with none of that branch's commits, on a `workflow_dispatch` run of `main`: [run 31526638699](https://github.com/When-To/whento/actions/runs/31526638699), same four tests.

## What happens

The fixture anchors on *"the Monday of the week after next"*:

```
CI du 10 août (lundi) -> ancre 17 août -> day(8) = 25 août       -> même mois, vert
CI du 11 août (mardi) -> ancre 24 août -> day(8) = 1ᵉʳ septembre -> échec
```

The month grid renders one month at a time and `ParticipantView` always opens on today's (`displayedMonth` is initialised from `now`). So the cell for 1 September is present only as trailing overflow — it carries the right `data-date`, and `dayModel.ts` gives it `data-status="outside"`, which `CalendarDayCell` renders `aria-disabled`:

```
locator resolved to <div class="cal-cell" aria-disabled="true" data-status="outside" data-date="2026-09-01">
  - element is not enabled
  - retrying click action  (×118)
```

Playwright finds the element and waits sixty seconds for it to become enabled.

## Why both halves are needed

**Anchoring inside a single month is not enough.** The view opens on today's month, and a late anchor cannot fit twelve days into what is left of it — the anchor has to move to the *next* month, which the view is not showing. So the tests navigate, through a `month-next` button that now carries a `data-testid`. The accessible name would have been the obvious handle, but it is translated and the locale follows the browser; `data-testid` is already how `frontend/e2e/calendar.spec.ts` selects the legend.

**Navigating is not enough either.** The drag test spans `day(8)` to `day(10)`, and no single month shows all three once they straddle a boundary. So the anchor advances by whole weeks until the rendered span fits in one month.

The span is **11 days, not 13**: `day(11)` is asserted with `expectNotMarked`, which counts zero matches — an unrendered cell would have made it pass for the wrong reason. Range queries reach `day(20)` and `day(400)` but go straight to the API and never touch the grid.

## Verification

Run against a real backend and database **on the date that reproduces it**, so the before/after is not hypothetical:

| | |
| --- | ---: |
| before, unmodified `main` | 4 failed, 12 passed |
| after | **16 passed** |

The anchor invariant was then checked over **800 consecutive days**: always a Monday, never in the past, at most 27 days ahead, and the rendered span never crosses a month — zero violations. Navigation turns out to be needed on **68%** of days, so it is the common case rather than an edge one.

Also green: `make format-check`, `npm run lint`, 351 unit tests, and the 56 preview-based browser tests (the component change is a single added attribute, but it is shared with that suite).

## Note for reviewers

If you run this locally, restart the Vite dev server after checking out. The component change is an added attribute and HMR served a stale module for me until the server was restarted — which cost a confusing run where `getByTestId` found nothing.