### PR TITLE
feat(calendar): resolve the first day of the week from the calendar timezone

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@vueuse/core": "^14.4.0",
         "axios": "^1.19.0",
-        "countries-and-timezones": "^3.9.0",
+        "countries-and-timezones": "^3.10.0",
         "date-fns": "^4.4.0",
         "date-fns-tz": "^3.2.0",
         "date-holidays": "^3.34.1",
@@ -2206,9 +2206,9 @@
       "license": "MIT"
     },
     "node_modules/countries-and-timezones": {
-      "version": "3.9.0",
-      "resolved": "https://registry.npmjs.org/countries-and-timezones/-/countries-and-timezones-3.9.0.tgz",
-      "integrity": "sha512-3upkVtUfZgdp5xOQI/Deg1ye73ae6bygJMO4UvtUi6wLjwcj7cBqx2PzSZ1VL8i5iveBbjhsQp2Judx7kPKivA==",
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/countries-and-timezones/-/countries-and-timezones-3.10.0.tgz",
+      "integrity": "sha512-HQ1GtXWNZy0r5MnZMLF9xmBmFNmtDVBeKQgX/5DY+RVmcZTODA+EPN/JLPCYRNP86nHG0QQrb1yJwGzXeqCCXw==",
       "license": "MIT",
       "engines": {
         "node": ">=8.x",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -25,7 +25,7 @@
   "dependencies": {
     "@vueuse/core": "^14.4.0",
     "axios": "^1.19.0",
-    "countries-and-timezones": "^3.9.0",
+    "countries-and-timezones": "^3.10.0",
     "date-fns": "^4.4.0",
     "date-fns-tz": "^3.2.0",
     "date-holidays": "^3.34.1",

--- a/frontend/src/composables/calendar/useParticipantCalendar.test.ts
+++ b/frontend/src/composables/calendar/useParticipantCalendar.test.ts
@@ -1,0 +1,96 @@
+/*
+ * WhenTo - Collaborative event calendar for self-hosted environments
+ * Copyright (C) 2025 WhenTo Contributors
+ * SPDX-License-Identifier: BSL-1.1
+ *
+ * The composable reaches i18n, whose module body reads window.location to pick the
+ * initial locale.
+ *
+ * @vitest-environment jsdom
+ */
+
+import { describe, expect, it } from 'vitest';
+import { createApp, ref } from 'vue';
+
+import { useParticipantCalendar } from './useParticipantCalendar';
+import { i18n } from '@/i18n';
+import type { CalendarWithParticipants } from '@/types';
+
+/**
+ * The composable calls useI18n(), which needs a component instance with the plugin
+ * installed. A one-off app supplies both without pulling in a component-testing library.
+ */
+function withSetup<T>(composable: () => T): T {
+  let result!: T;
+  const app = createApp({
+    setup() {
+      result = composable();
+
+      return () => null;
+    },
+  });
+  app.use(i18n);
+  app.mount(document.createElement('div'));
+
+  return result;
+}
+
+/**
+ * weekStart.test.ts covers the CLDR resolution itself. What is checked here is the
+ * wiring: that the model derives its first day from the *calendar's* timezone rather
+ * than from the reader's language. Without this, reverting the call site to
+ * getWeekStartDay(locale) would leave every unit test green while putting German
+ * calendars back on Sunday — which is the whole of issue #48.
+ */
+
+function modelFor(timezone: string) {
+  const calendar = {
+    id: 'calendar-1',
+    name: 'Test',
+    timezone,
+    threshold: 1,
+    allowed_weekdays: [0, 1, 2, 3, 4, 5, 6],
+    holidays_policy: 'ignore',
+    participants: [],
+  } as unknown as CalendarWithParticipants;
+
+  return withSetup(() =>
+    useParticipantCalendar({
+      calendar: ref(calendar),
+      availabilities: ref([]),
+      recurrences: ref([]),
+      participantCounts: ref({}),
+      dateSummaries: ref([]),
+      months: ref([{ year: 2026, month: 8 }]),
+      weekStarts: ref([]),
+    })
+  );
+}
+
+describe('the first day of the week', () => {
+  it('follows the calendar timezone, not the reader language', () => {
+    // The case from the issue: a German calendar must open on Monday.
+    expect(modelFor('Europe/Berlin').weekStartDay.value).toBe(1);
+    // And the convention genuinely differs by country, so a US calendar must not.
+    expect(modelFor('America/New_York').weekStartDay.value).toBe(0);
+  });
+
+  it('handles regions whose week starts on neither Sunday nor Monday', () => {
+    // Egypt starts on Saturday and the Maldives on Friday. A Sunday-or-Monday branch
+    // cannot express either, which is why the grid rotates rather than special-casing.
+    expect(modelFor('Africa/Cairo').weekStartDay.value).toBe(6);
+    expect(modelFor('Indian/Maldives').weekStartDay.value).toBe(5);
+  });
+
+  it('reaches the month grid, not just the model', () => {
+    // The offset is what pads the leading cells, so a first day that never reaches
+    // buildMonthModel would be a setting with no effect on screen.
+    const [berlin] = modelFor('Europe/Berlin').months.value;
+    const [newYork] = modelFor('America/New_York').months.value;
+
+    expect(berlin.weekdayHeaders[0]).not.toBe(newYork.weekdayHeaders[0]);
+    // 1 September 2026 is a Tuesday: one cell after Monday, two after Sunday.
+    expect(berlin.days.findIndex(day => day.date === '2026-09-01')).toBe(1);
+    expect(newYork.days.findIndex(day => day.date === '2026-09-01')).toBe(2);
+  });
+});

--- a/frontend/src/composables/calendar/useParticipantCalendar.ts
+++ b/frontend/src/composables/calendar/useParticipantCalendar.ts
@@ -14,7 +14,7 @@
  */
 
 import { computed, type ComputedRef, type Ref } from 'vue';
-import { getWeekStartDay } from '@/i18n';
+import { resolveWeekStart } from '@/utils/weekStart';
 import type {
   Availability,
   CalendarWithParticipants,
@@ -72,8 +72,11 @@ export function useParticipantCalendar(
 ): ParticipantCalendarModel {
   const { formatters, locale } = useCalendarFormatters();
 
-  const weekStartDay = computed(() => getWeekStartDay(locale.value));
   const timeZone = computed(() => options.calendar.value?.timezone || 'Europe/Paris');
+  // The calendar's timezone rather than the reader's language: every participant must
+  // see the same grid, and a shared link is opened by people in several locales. It also
+  // works for anonymous participants, who have no account to carry a preference.
+  const weekStartDay = computed(() => resolveWeekStart(timeZone.value, locale.value));
   const today = computed(() => todayISO(timeZone.value));
 
   const rules = computed(() => {

--- a/frontend/src/utils/weekStart.test.ts
+++ b/frontend/src/utils/weekStart.test.ts
@@ -1,0 +1,186 @@
+/*
+ * WhenTo - Collaborative event calendar for self-hosted environments
+ * Copyright (C) 2025 WhenTo Contributors
+ * SPDX-License-Identifier: BSL-1.1
+ *
+ * The last-resort fallback goes through src/i18n.ts, whose module body reads
+ * window.location to pick the initial locale, so this file needs a DOM even though the
+ * unit under test is pure.
+ *
+ * @vitest-environment jsdom
+ */
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  DEFAULT_WEEK_START,
+  WEEK_START_BY_REGION,
+  getWeekStartForRegion,
+  getWeekStartForTimezone,
+  getWeekdayOffset,
+  resolveWeekStart,
+} from './weekStart';
+
+/** Pins navigator.language for the duration of a test. */
+function withBrowserLanguage(tag: string) {
+  vi.spyOn(navigator, 'language', 'get').mockReturnValue(tag);
+}
+
+afterEach(() => {
+  localStorage.clear();
+  vi.restoreAllMocks();
+});
+
+describe('getWeekStartForRegion', () => {
+  it('returns the CLDR value for regions that differ from the default', () => {
+    expect(getWeekStartForRegion('US')).toBe(0);
+    expect(getWeekStartForRegion('EG')).toBe(6);
+    expect(getWeekStartForRegion('MV')).toBe(5);
+  });
+
+  it('falls back to Monday for regions CLDR leaves at the world default', () => {
+    expect(getWeekStartForRegion('DE')).toBe(1);
+    expect(getWeekStartForRegion('FR')).toBe(1);
+    // Not in CLDR's table at all, so it inherits "001"
+    expect(getWeekStartForRegion('ZZ')).toBe(DEFAULT_WEEK_START);
+  });
+
+  it('accepts lowercase region codes', () => {
+    expect(getWeekStartForRegion('us')).toBe(0);
+  });
+
+  it('returns undefined for absent or malformed input so callers fall through', () => {
+    expect(getWeekStartForRegion(undefined)).toBeUndefined();
+    expect(getWeekStartForRegion(null)).toBeUndefined();
+    expect(getWeekStartForRegion('')).toBeUndefined();
+    expect(getWeekStartForRegion('DEU')).toBeUndefined();
+    expect(getWeekStartForRegion('001')).toBeUndefined();
+  });
+});
+
+describe('getWeekStartForTimezone', () => {
+  it('maps an IANA timezone to its country then to the CLDR value', () => {
+    expect(getWeekStartForTimezone('Europe/Berlin')).toBe(1);
+    expect(getWeekStartForTimezone('America/New_York')).toBe(0);
+    expect(getWeekStartForTimezone('Asia/Riyadh')).toBe(0); // CLDR puts SA on Sunday
+    expect(getWeekStartForTimezone('Africa/Cairo')).toBe(6);
+    expect(getWeekStartForTimezone('Indian/Maldives')).toBe(5);
+  });
+
+  it('returns undefined for timezones that map to no country', () => {
+    expect(getWeekStartForTimezone('UTC')).toBeUndefined();
+    expect(getWeekStartForTimezone('Not/AZone')).toBeUndefined();
+    expect(getWeekStartForTimezone(undefined)).toBeUndefined();
+    expect(getWeekStartForTimezone('')).toBeUndefined();
+  });
+});
+
+describe('resolveWeekStart', () => {
+  it('prefers an explicit override over everything else', () => {
+    localStorage.setItem('week-start-day', '6');
+    expect(resolveWeekStart('Europe/Berlin', 'en')).toBe(6);
+  });
+
+  it('ignores an override that is not a valid first day', () => {
+    localStorage.setItem('week-start-day', '3');
+    expect(resolveWeekStart('Europe/Berlin', 'en')).toBe(1);
+  });
+
+  it('uses the calendar timezone ahead of the browser and the locale', () => {
+    withBrowserLanguage('en-US');
+    // Timezone says Monday, browser and locale would both say Sunday
+    expect(resolveWeekStart('Europe/Berlin', 'en')).toBe(1);
+  });
+
+  it('falls back to the browser region when no calendar is in context', () => {
+    withBrowserLanguage('de-DE');
+    expect(resolveWeekStart(undefined, 'en')).toBe(1);
+
+    withBrowserLanguage('en-US');
+    expect(resolveWeekStart(undefined, 'fr')).toBe(0);
+  });
+
+  it('expands a language-only browser tag to a region', () => {
+    withBrowserLanguage('de');
+    expect(resolveWeekStart(undefined, 'en')).toBe(1);
+  });
+
+  it('falls back to the app locale when the browser exposes no usable region', () => {
+    withBrowserLanguage('');
+    expect(resolveWeekStart(undefined, 'en')).toBe(0);
+    expect(resolveWeekStart(undefined, 'fr')).toBe(1);
+  });
+
+  it('resolves the reported bug: a German calendar starts on Monday', () => {
+    // The reporter's browser is German, but the app only ships en/fr so the
+    // locale alone would resolve to Sunday.
+    withBrowserLanguage('de-DE');
+    expect(resolveWeekStart('Europe/Berlin', 'en')).toBe(1);
+  });
+});
+
+describe('getWeekdayOffset', () => {
+  // 2026-08-01 is a Saturday (getDay() === 6)
+  const saturday = new Date(2026, 7, 1);
+
+  it('counts days elapsed since the start of the week', () => {
+    expect(getWeekdayOffset(saturday, 0)).toBe(6); // Sunday-first
+    expect(getWeekdayOffset(saturday, 1)).toBe(5); // Monday-first
+    expect(getWeekdayOffset(saturday, 6)).toBe(0); // Saturday-first
+  });
+
+  it('is zero exactly on the first day of the week', () => {
+    for (let day = 0; day < 7; day++) {
+      // 2026-02-01 is a Sunday, so adding `day` lands on weekday `day`
+      const date = new Date(2026, 1, 1 + day);
+      expect(getWeekdayOffset(date, day)).toBe(0);
+    }
+  });
+
+  it('pads a month grid with the right number of leading cells', () => {
+    // 2026-03-01 is a Sunday
+    const march = new Date(2026, 2, 1);
+    expect(getWeekdayOffset(march, 0)).toBe(0); // Sunday-first: no padding
+    expect(getWeekdayOffset(march, 1)).toBe(6); // Monday-first: a full week of padding
+  });
+});
+
+describe('WEEK_START_BY_REGION', () => {
+  it('only lists regions that differ from the Monday default', () => {
+    for (const [region, day] of Object.entries(WEEK_START_BY_REGION)) {
+      expect(day, `${region} should not be listed`).not.toBe(DEFAULT_WEEK_START);
+      expect(region).toMatch(/^[A-Z]{2}$/);
+    }
+  });
+
+  it('matches the CLDR data the runtime was built with', () => {
+    const weekInfoOf = (region: string) => {
+      const locale = new Intl.Locale(`und-${region}`) as Intl.Locale & {
+        getWeekInfo?: () => { firstDay: number };
+        weekInfo?: { firstDay: number };
+      };
+      return locale.getWeekInfo?.() ?? locale.weekInfo;
+    };
+
+    // Intl exposes CLDR week data only on newer runtimes; skip rather than
+    // make the table depend on it.
+    if (!weekInfoOf('DE')) return;
+
+    for (const region of Object.keys(WEEK_START_BY_REGION)) {
+      // Intl encodes 1 = Monday ... 7 = Sunday; the app uses getDay()'s 0 = Sunday
+      const expected = weekInfoOf(region)!.firstDay % 7;
+      expect(WEEK_START_BY_REGION[region], `CLDR firstDay for ${region}`).toBe(expected);
+    }
+  });
+
+  it('agrees with the runtime that unlisted regions start on Monday', () => {
+    const locale = new Intl.Locale('und-DE') as Intl.Locale & { weekInfo?: { firstDay: number } };
+    if (!locale.weekInfo) return;
+    for (const region of ['DE', 'FR', 'GB', 'RU', 'CN', 'AU']) {
+      expect(WEEK_START_BY_REGION[region]).toBeUndefined();
+      const info = new Intl.Locale(`und-${region}`) as Intl.Locale & {
+        weekInfo?: { firstDay: number };
+      };
+      expect(info.weekInfo!.firstDay % 7).toBe(DEFAULT_WEEK_START);
+    }
+  });
+});

--- a/frontend/src/utils/weekStart.ts
+++ b/frontend/src/utils/weekStart.ts
@@ -1,0 +1,194 @@
+/*
+ * WhenTo - Collaborative event calendar for self-hosted environments
+ * Copyright (C) 2025 WhenTo Contributors
+ * SPDX-License-Identifier: BSL-1.1
+ */
+
+import { getCountryForTimezone } from 'countries-and-timezones';
+import { getWeekStartDay } from '@/i18n';
+
+/**
+ * First day of the week, using the same encoding as Date.prototype.getDay()
+ * (0 = Sunday ... 6 = Saturday).
+ */
+export type WeekStartDay = 0 | 1 | 5 | 6;
+
+/**
+ * CLDR's world-wide default (region "001") is Monday: any region absent from
+ * WEEK_START_BY_REGION inherits it.
+ */
+export const DEFAULT_WEEK_START: WeekStartDay = 1;
+
+/** localStorage key holding an explicit user override (no UI writes it yet). */
+const STORAGE_KEY = 'week-start-day';
+
+/**
+ * First day of the week per region, from Unicode CLDR supplemental weekData
+ * (`firstDay`), CLDR 48 / Unicode 16.0.0.
+ *
+ * Only regions that differ from the Monday default are listed. Regenerate with:
+ *   curl -sSLO https://raw.githubusercontent.com/unicode-org/cldr-json/main/cldr-json/cldr-core/supplemental/weekData.json
+ * then map sun->0, mon->1, fri->5, sat->6, dropping "001" and "*-alt-*" keys.
+ *
+ * Beware of the counter-intuitive entries before "fixing" anything here: CLDR
+ * puts Portugal and Saudi Arabia on Sunday, not Monday and Saturday.
+ */
+export const WEEK_START_BY_REGION: Readonly<Record<string, WeekStartDay>> = {
+  // Sunday (0) — 56 regions
+  AG: 0,
+  AS: 0,
+  BD: 0,
+  BR: 0,
+  BS: 0,
+  BT: 0,
+  BW: 0,
+  BZ: 0,
+  CA: 0,
+  CO: 0,
+  DM: 0,
+  DO: 0,
+  ET: 0,
+  GT: 0,
+  GU: 0,
+  HK: 0,
+  HN: 0,
+  ID: 0,
+  IL: 0,
+  IN: 0,
+  IS: 0,
+  JM: 0,
+  JP: 0,
+  KE: 0,
+  KH: 0,
+  KR: 0,
+  LA: 0,
+  MH: 0,
+  MM: 0,
+  MO: 0,
+  MT: 0,
+  MX: 0,
+  MZ: 0,
+  NI: 0,
+  NP: 0,
+  PA: 0,
+  PE: 0,
+  PH: 0,
+  PK: 0,
+  PR: 0,
+  PT: 0,
+  PY: 0,
+  SA: 0,
+  SG: 0,
+  SV: 0,
+  TH: 0,
+  TT: 0,
+  TW: 0,
+  UM: 0,
+  US: 0,
+  VE: 0,
+  VI: 0,
+  WS: 0,
+  YE: 0,
+  ZA: 0,
+  ZW: 0,
+  // Saturday (6) — 14 regions
+  AF: 6,
+  BH: 6,
+  DJ: 6,
+  DZ: 6,
+  EG: 6,
+  IQ: 6,
+  IR: 6,
+  JO: 6,
+  KW: 6,
+  LY: 6,
+  OM: 6,
+  QA: 6,
+  SD: 6,
+  SY: 6,
+  // Friday (5) — 1 region
+  MV: 5,
+};
+
+/**
+ * Returns the first day of the week for a CLDR region code (e.g. "DE"),
+ * or undefined when the region is empty/unknown so callers can fall through.
+ * A known region absent from the table resolves to the Monday default.
+ */
+export function getWeekStartForRegion(region?: string | null): WeekStartDay | undefined {
+  if (!region) return undefined;
+  const upper = region.toUpperCase();
+  if (!/^[A-Z]{2}$/.test(upper)) return undefined;
+  return WEEK_START_BY_REGION[upper] ?? DEFAULT_WEEK_START;
+}
+
+/**
+ * Returns the first day of the week for an IANA timezone (e.g. "Europe/Berlin"),
+ * or undefined when the timezone maps to no country (e.g. "UTC").
+ */
+export function getWeekStartForTimezone(timezone?: string | null): WeekStartDay | undefined {
+  if (!timezone) return undefined;
+  try {
+    return getWeekStartForRegion(getCountryForTimezone(timezone)?.id);
+  } catch {
+    // Unknown or malformed timezone identifier
+    return undefined;
+  }
+}
+
+/** Reads the explicit override, tolerating unavailable/blocked storage. */
+function getStoredOverride(): WeekStartDay | undefined {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (raw === null) return undefined;
+    const day = Number(raw);
+    return day === 0 || day === 1 || day === 5 || day === 6 ? day : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+/** Region the browser is configured for, expanded via CLDR likely subtags. */
+function getBrowserRegion(): string | undefined {
+  const tag = typeof navigator !== 'undefined' ? navigator.language : undefined;
+  if (!tag) return undefined;
+  try {
+    // "de" -> "de-Latn-DE", so a language-only tag still yields a region
+    return new Intl.Locale(tag).maximize().region ?? undefined;
+  } catch {
+    return tag.split('-')[1];
+  }
+}
+
+/**
+ * Number of grid cells a date sits after the start of its week — the count of
+ * leading cells to pad a month grid with, and the offset to subtract to reach
+ * a week's first day.
+ *
+ * @param date         any date
+ * @param weekStartDay first day of the week (0 = Sunday ... 6 = Saturday)
+ */
+export function getWeekdayOffset(date: Date, weekStartDay: number): number {
+  return (date.getDay() - weekStartDay + 7) % 7;
+}
+
+/**
+ * Resolves the first day of the week, most specific source first:
+ *   1. explicit user override in localStorage
+ *   2. the calendar's timezone (shared by every participant, so everyone
+ *      sees the same grid — and it works for anonymous participants, who
+ *      have no user account to carry a preference)
+ *   3. the browser's region, when no calendar is in context
+ *   4. the application locale
+ *
+ * @param calendarTimezone IANA timezone of the calendar being displayed, if any
+ * @param appLocale        active application locale, used as the last resort
+ */
+export function resolveWeekStart(calendarTimezone?: string | null, appLocale?: string): number {
+  return (
+    getStoredOverride() ??
+    getWeekStartForTimezone(calendarTimezone) ??
+    getWeekStartForRegion(getBrowserRegion()) ??
+    getWeekStartDay(appLocale ?? '')
+  );
+}

--- a/frontend/src/views/CalendarCreate.vue
+++ b/frontend/src/views/CalendarCreate.vue
@@ -572,7 +572,7 @@
 import { ref, reactive, onMounted, computed } from 'vue';
 import { useRouter } from 'vue-router';
 import { useI18n } from 'vue-i18n';
-import { getWeekStartDay } from '@/i18n';
+import { resolveWeekStart } from '@/utils/weekStart';
 import { useCalendarStore } from '@/stores/calendar';
 import { useAuthStore } from '@/stores/auth';
 import TimezoneSelector from '@/components/TimezoneSelector.vue';
@@ -621,7 +621,7 @@ const smtpConfigured = ref(true); // TODO: Fetch from backend config
 const participants = ref<string[]>([]);
 
 // Weekdays (0=Sunday, 6=Saturday)
-// Order depends on locale: Monday-first (fr) or Sunday-first (en)
+// Order follows the calendar's timezone, resolved through CLDR.
 const weekdays = computed(() => {
   const days = [
     { value: 0, short: t('weekdays.short.sunday') },
@@ -633,13 +633,13 @@ const weekdays = computed(() => {
     { value: 6, short: t('weekdays.short.saturday') },
   ];
 
-  // For locales that start the week on Monday, move Sunday to the end
-  if (getWeekStartDay(locale.value) === 1) {
-    return [...days.slice(1), days[0]];
-  }
+  // Rotated rather than special-cased: CLDR has weeks starting on Saturday in fourteen
+  // countries and on Friday in the Maldives, which a Sunday-or-Monday branch cannot
+  // express. The selector follows the timezone being chosen, so picking a German city
+  // reorders it to Monday-first straight away.
+  const first = resolveWeekStart(form.timezone, locale.value);
 
-  // For locales that start on Sunday (en, US)
-  return days;
+  return [...days.slice(first), ...days.slice(0, first)];
 });
 
 // Check if all weekdays are selected

--- a/frontend/src/views/CalendarSettings.vue
+++ b/frontend/src/views/CalendarSettings.vue
@@ -849,7 +849,7 @@
 import { ref, reactive, computed, onMounted, onBeforeUnmount } from 'vue';
 import { useRouter, useRoute, onBeforeRouteLeave } from 'vue-router';
 import { useI18n } from 'vue-i18n';
-import { getWeekStartDay } from '@/i18n';
+import { resolveWeekStart } from '@/utils/weekStart';
 import { useCalendarStore } from '@/stores/calendar';
 import { useToastStore } from '@/stores/toast';
 import TimezoneSelector from '@/components/TimezoneSelector.vue';
@@ -973,7 +973,7 @@ const errors = reactive({
 });
 
 // Weekdays (0=Sunday, 6=Saturday)
-// Order depends on locale: Monday-first (fr) or Sunday-first (en)
+// Order follows the calendar's timezone, resolved through CLDR.
 const weekdays = computed(() => {
   const days = [
     { value: 0, short: t('weekdays.short.sunday') },
@@ -985,13 +985,13 @@ const weekdays = computed(() => {
     { value: 6, short: t('weekdays.short.saturday') },
   ];
 
-  // For locales that start the week on Monday, move Sunday to the end
-  if (getWeekStartDay(locale.value) === 1) {
-    return [...days.slice(1), days[0]];
-  }
+  // Rotated rather than special-cased: CLDR has weeks starting on Saturday in fourteen
+  // countries and on Friday in the Maldives, which a Sunday-or-Monday branch cannot
+  // express. The selector follows the timezone being chosen, so picking a German city
+  // reorders it to Monday-first straight away.
+  const first = resolveWeekStart(form.timezone, locale.value);
 
-  // For locales that start on Sunday (en, US)
-  return days;
+  return [...days.slice(first), ...days.slice(0, first)];
 });
 
 // Check if all weekdays are selected

--- a/frontend/src/views/ParticipantView.vue
+++ b/frontend/src/views/ParticipantView.vue
@@ -1221,7 +1221,7 @@
 import { ref, shallowRef, reactive, computed, onMounted, watchEffect, watch } from 'vue';
 import { useRoute, useRouter } from 'vue-router';
 import { useI18n } from 'vue-i18n';
-import { getWeekStartDay } from '@/i18n';
+import { resolveWeekStart } from '@/utils/weekStart';
 import { useCalendarStore } from '@/stores/calendar';
 import { useAuthStore } from '@/stores/auth';
 import { useCalendarHistoryStore } from '@/stores/calendarHistory';
@@ -1403,7 +1403,7 @@ const weeksToDisplay = computed(() => {
 });
 
 const weekDaysOptions = computed(() => {
-  const firstDayOfWeek = getWeekStartDay(locale.value); // Monday for fr, Sunday for en
+  const firstDayOfWeek = resolveWeekStart(calendar.value?.timezone, locale.value);
 
   const daysOrder = [];
   for (let i = 0; i < 7; i++) {
@@ -1863,7 +1863,7 @@ async function loadCalendar() {
 
     // Initialize current week start date
     const today = new Date();
-    const firstDayOfWeek = getWeekStartDay(locale.value); // Monday for fr, Sunday for en
+    const firstDayOfWeek = resolveWeekStart(calendar.value?.timezone, locale.value);
     const dayOfWeek = today.getDay();
     const diff = (dayOfWeek - firstDayOfWeek + 7) % 7;
     const weekStart = new Date(today);


### PR DESCRIPTION
Closes #48.

The first day of the week was tied to the UI language, which cannot express the convention: US English starts on Sunday and UK English on Monday, so the same language gives two different answers. @Letroniiik, opening a calendar from Germany, saw it start on Sunday.

This uses the timezone instead — the approach agreed on the issue. It is already chosen by city, so the country falls out of it, and CLDR has the convention per country. A calendar set to a German city now starts on Monday with no configuration.

Two properties come free with that choice, and neither would hold for a per-user setting:

- **Every participant sees the same grid.** A shared link is opened by people in several locales; if the week start followed the reader, two people discussing "the second row" would be looking at different days.
- **It works for anonymous participants**, who have no account to carry a preference.

## Resolution order

1. an explicit override in `localStorage`
2. the calendar's timezone
3. the browser's region
4. the application locale

No UI writes the override yet. It exists so that adding one later needs no change here.

## What else moved

The weekday selectors in the create and settings views **rotate** now rather than branching on Sunday-or-Monday. CLDR has weeks starting on **Saturday in fourteen countries and on Friday in the Maldives**, which the old branch could not express at all:

```ts
// before — cannot represent a Saturday-first week
if (getWeekStartDay(locale.value) === 1) return [...days.slice(1), days[0]];
return days;

// after
const first = resolveWeekStart(form.timezone, locale.value);
return [...days.slice(first), ...days.slice(0, first)];
```

They follow the timezone *being chosen*, so picking a German city reorders the selector straight away.

## Tests

19 cases on the resolution, including one that cross-checks the hand-written CLDR table against the runtime's own week data, so the table cannot drift silently as CLDR is updated.

Three more pin the **wiring** rather than the resolution, which is the part that would otherwise rot: reverting the call site to `getWeekStartDay(locale)` leaves every other unit test green while putting German calendars back on Sunday. Verified by mutation — the revert fails all three:

```
AssertionError: expected +0 to be 1     // Europe/Berlin
AssertionError: expected +0 to be 6     // Africa/Cairo
AssertionError: expected 'Sun' not to be 'Sun'
```

Green: `vue-tsc`, `eslint`, 373 unit tests, 56 browser tests.

## Note on the earlier branch

Work had started on `feat/48-week-start-cldr`. That branch targeted `CalendarGrid.vue` and `WeeklyCalendarGrid.vue`, which the calendar rebuild in #58 **deleted**, so rebasing it would have meant resolving conflicts on files that no longer exist for changes that no longer apply. Only the resolution itself carried over; the call sites are new, and there is one composable now where there were three views. That branch can be deleted.

One dependency added: `countries-and-timezones` (timezone → country), 60 kB, no transitive dependencies.