### PR TITLE
feat(calendar): live availability updates over server-sent events

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -53,6 +53,7 @@ import (
 	chiMiddleware "github.com/go-chi/chi/v5/middleware"
 	httpSwagger "github.com/swaggo/http-swagger/v2"
 
+	"github.com/whento/pkg/broadcast"
 	"github.com/whento/pkg/cache"
 	"github.com/whento/pkg/database"
 	"github.com/whento/pkg/email"
@@ -344,6 +345,13 @@ func main() {
 
 	// Initialize rate limiter
 	rateLimiter := middleware.NewRateLimiter(redisClient)
+
+	// Live calendar updates. Redis fans the notices out across instances; without it a
+	// single-instance deployment still updates its own viewers, which is the whole of a
+	// normal self-hosted install.
+	broker := broadcast.NewRedisBroker(redisClient, log)
+	defer func() { _ = broker.Close() }()
+	eventsHandler := availabilityHandlers.NewEventsHandler(availCalendarRepo, broker)
 
 	// Setup router
 	r := chi.NewRouter()
@@ -676,6 +684,14 @@ func main() {
 					KeyFunc:  middleware.IPKeyFunc,
 				}))
 			}
+
+			// One notice per successful write, for every route below. Placed here
+			// rather than in the nine service methods so a tenth write route cannot
+			// silently stop notifying anyone.
+			r.Use(availabilityHandlers.PublishChanges(broker))
+
+			// Live updates: the browser subscribes here and refetches on each notice.
+			r.Get("/calendar/{token}/events", eventsHandler.Stream)
 
 			// Participant availability management
 			r.Get("/calendar/{token}/participant/{pid}", availabilityHandler.GetParticipantAvailabilities)

--- a/frontend/e2e-backend/fixtures/seed.ts
+++ b/frontend/e2e-backend/fixtures/seed.ts
@@ -202,6 +202,25 @@ export async function seedCalendar(options: SeedOptions = {}): Promise<SeededCal
   };
 }
 
+/**
+ * Answer for a participant from outside the browser under test.
+ *
+ * This is how a test plays "somebody else, somewhere else": the write goes straight to
+ * the API, so the page has no way of knowing about it except through the live stream.
+ */
+export async function addAvailability(
+  publicToken: string,
+  participantId: string,
+  date: string,
+  start?: string,
+  end?: string
+): Promise<void> {
+  await api(`/availabilities/calendar/${publicToken}/participant/${participantId}`, {
+    method: 'POST',
+    body: { date, start_time: start, end_time: end },
+  });
+}
+
 /** Read a participant's stored availabilities back, to assert what actually persisted. */
 export async function fetchAvailabilities(
   publicToken: string,

--- a/frontend/e2e-backend/participant.spec.ts
+++ b/frontend/e2e-backend/participant.spec.ts
@@ -5,7 +5,12 @@
  */
 
 import { expect, test, type Page } from '@playwright/test';
-import { fetchAvailabilities, fetchRangeSummary, seedCalendar } from './fixtures/seed';
+import {
+  addAvailability,
+  fetchAvailabilities,
+  fetchRangeSummary,
+  seedCalendar,
+} from './fixtures/seed';
 
 /**
  * The write paths, driven through the real ParticipantView against a real server.
@@ -430,5 +435,53 @@ test.describe('unknown API routes', () => {
       expect(response.status(), `${path} should serve the app`).toBe(200);
       expect(response.headers()['content-type']).toContain('text/html');
     }
+  });
+});
+
+test.describe('live updates', () => {
+  test("another participant's answer reaches the grid without a reload", async ({
+    page,
+    baseURL,
+  }) => {
+    // The whole of issue #49. Ada is looking at the calendar; Grace answers from
+    // somewhere else. Ada's grid has to notice, and the only thing this test does to it
+    // is wait — no reload, no navigation, no click.
+    const seed = await seedCalendar();
+    await openCalendar(page, seed.participantUrl(baseURL!, 'Ada'), seed.monday);
+
+    // Tuesday has one answer against a threshold of two, so it does not meet it yet.
+    const target = seed.day(1);
+    await expectNotMarked(page, target, 'data-threshold');
+
+    await addAvailability(seed.publicToken, seed.participants.Grace.id, target);
+
+    // The composable coalesces for 250ms before refetching; the assertion's own timeout
+    // covers that without a sleep.
+    await expectMarked(page, target, 'data-threshold');
+  });
+
+  test('the stream survives the calendar being watched by two browsers', async ({
+    browser,
+    baseURL,
+  }) => {
+    // Two viewers is the case the feature exists for, and the one where a per-topic
+    // subscription that overwrote its predecessor would look fine in single-browser
+    // testing and fail here.
+    const seed = await seedCalendar();
+
+    const first = await browser.newPage();
+    const second = await browser.newPage();
+
+    await openCalendar(first, seed.participantUrl(baseURL!, 'Ada'), seed.monday);
+    await openCalendar(second, seed.participantUrl(baseURL!, 'Grace'), seed.monday);
+
+    const target = seed.day(1);
+    await addAvailability(seed.publicToken, seed.participants.Grace.id, target);
+
+    await expectMarked(first, target, 'data-threshold');
+    await expectMarked(second, target, 'data-threshold');
+
+    await first.close();
+    await second.close();
   });
 });

--- a/frontend/src/composables/calendar/useCalendarStream.test.ts
+++ b/frontend/src/composables/calendar/useCalendarStream.test.ts
@@ -1,0 +1,243 @@
+/*
+ * WhenTo - Collaborative event calendar for self-hosted environments
+ * Copyright (C) 2025 WhenTo Contributors
+ * SPDX-License-Identifier: BSL-1.1
+ *
+ * @vitest-environment jsdom
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { effectScope, nextTick, ref } from 'vue';
+
+import { useCalendarStream } from './useCalendarStream';
+
+/**
+ * The two ways a live view fails are opposites, and both are quiet: it refetches far too
+ * often, turning one person's drag into a burst of requests from every open browser; or
+ * it stops refetching after a network blip and shows stale availability that looks
+ * perfectly current.
+ *
+ * jsdom has no EventSource, so this stands one in for it and drives the events by hand.
+ */
+
+class FakeEventSource {
+  static instances: FakeEventSource[] = [];
+
+  readonly url: string;
+  closed = false;
+  private listeners = new Map<string, Set<() => void>>();
+
+  constructor(url: string) {
+    this.url = url;
+    FakeEventSource.instances.push(this);
+  }
+
+  addEventListener(type: string, handler: () => void) {
+    if (!this.listeners.has(type)) this.listeners.set(type, new Set());
+    this.listeners.get(type)!.add(handler);
+  }
+
+  close() {
+    this.closed = true;
+  }
+
+  /** Plays a server event. */
+  emit(type: string) {
+    for (const handler of this.listeners.get(type) ?? []) handler();
+  }
+
+  static get latest() {
+    return FakeEventSource.instances[FakeEventSource.instances.length - 1];
+  }
+
+  static reset() {
+    FakeEventSource.instances = [];
+  }
+}
+
+beforeEach(() => {
+  FakeEventSource.reset();
+  vi.stubGlobal('EventSource', FakeEventSource);
+  vi.useFakeTimers();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.unstubAllGlobals();
+});
+
+/** Runs the composable inside a scope the test can stop, as a component would. */
+function withScope<T>(fn: () => T): { result: T; stop: () => void } {
+  const scope = effectScope();
+  const result = scope.run(fn)!;
+
+  return { result, stop: () => scope.stop() };
+}
+
+describe('opening the stream', () => {
+  it('subscribes to the calendar named by the token', () => {
+    const { stop } = withScope(() =>
+      useCalendarStream({ token: ref('abc123'), onChange: () => {} })
+    );
+
+    expect(FakeEventSource.latest.url).toBe('/api/v1/availabilities/calendar/abc123/events');
+    stop();
+  });
+
+  it('escapes the token rather than interpolating it raw', () => {
+    // The token comes from the URL the user pasted. It is normally hex, but building a
+    // path by concatenation is how a stray slash becomes a request somewhere else.
+    const { stop } = withScope(() =>
+      useCalendarStream({ token: ref('a/b?c'), onChange: () => {} })
+    );
+
+    expect(FakeEventSource.latest.url).toBe('/api/v1/availabilities/calendar/a%2Fb%3Fc/events');
+    stop();
+  });
+
+  it('stays closed without a token', () => {
+    const { stop } = withScope(() => useCalendarStream({ token: ref(null), onChange: () => {} }));
+
+    expect(FakeEventSource.instances).toHaveLength(0);
+    stop();
+  });
+
+  it('stays closed when disabled', () => {
+    const { stop } = withScope(() =>
+      useCalendarStream({ token: ref('abc123'), onChange: () => {}, enabled: ref(false) })
+    );
+
+    expect(FakeEventSource.instances).toHaveLength(0);
+    stop();
+  });
+});
+
+describe('reacting to notices', () => {
+  it('reloads when the calendar changes', async () => {
+    const onChange = vi.fn();
+    const { stop } = withScope(() => useCalendarStream({ token: ref('abc123'), onChange }));
+
+    FakeEventSource.latest.emit('update');
+    expect(onChange).not.toHaveBeenCalled(); // still inside the coalescing window
+
+    await vi.advanceTimersByTimeAsync(300);
+    expect(onChange).toHaveBeenCalledTimes(1);
+    stop();
+  });
+
+  // One person dragging across a week writes a day at a time. Without coalescing, every
+  // other open browser would refetch the whole range once per day dragged.
+  it('collapses a burst into a single reload', async () => {
+    const onChange = vi.fn();
+    const { stop } = withScope(() => useCalendarStream({ token: ref('abc123'), onChange }));
+
+    for (let i = 0; i < 7; i += 1) FakeEventSource.latest.emit('update');
+
+    await vi.advanceTimersByTimeAsync(300);
+    expect(onChange).toHaveBeenCalledTimes(1);
+    stop();
+  });
+
+  it('reloads again for a change that arrives after the window', async () => {
+    const onChange = vi.fn();
+    const { stop } = withScope(() => useCalendarStream({ token: ref('abc123'), onChange }));
+
+    FakeEventSource.latest.emit('update');
+    await vi.advanceTimersByTimeAsync(300);
+    FakeEventSource.latest.emit('update');
+    await vi.advanceTimersByTimeAsync(300);
+
+    expect(onChange).toHaveBeenCalledTimes(2);
+    stop();
+  });
+});
+
+describe('connection state', () => {
+  it('does not reload on the first connection', async () => {
+    // The view has just fetched its data; refetching immediately would double every
+    // page load.
+    const onChange = vi.fn();
+    const { result, stop } = withScope(() => useCalendarStream({ token: ref('abc123'), onChange }));
+
+    FakeEventSource.latest.emit('open');
+    await vi.advanceTimersByTimeAsync(300);
+
+    expect(onChange).not.toHaveBeenCalled();
+    expect(result.connected.value).toBe(true);
+    stop();
+  });
+
+  // The case that decides whether this works on a train. Anything that changed while the
+  // stream was down produced no notice this browser will ever receive, so a reconnection
+  // has to assume it missed something.
+  it('reloads after reconnecting', async () => {
+    const onChange = vi.fn();
+    const { result, stop } = withScope(() => useCalendarStream({ token: ref('abc123'), onChange }));
+
+    FakeEventSource.latest.emit('open');
+    FakeEventSource.latest.emit('error');
+    expect(result.connected.value).toBe(false);
+
+    FakeEventSource.latest.emit('open');
+    await vi.advanceTimersByTimeAsync(300);
+
+    expect(onChange).toHaveBeenCalledTimes(1);
+    stop();
+  });
+
+  it('leaves the stream open on error so EventSource can reconnect', () => {
+    const { stop } = withScope(() =>
+      useCalendarStream({ token: ref('abc123'), onChange: () => {} })
+    );
+
+    const source = FakeEventSource.latest;
+    source.emit('open');
+    source.emit('error');
+
+    // Closing here would cancel the browser's own reconnection and the view would never
+    // come back.
+    expect(source.closed).toBe(false);
+    stop();
+  });
+});
+
+describe('lifecycle', () => {
+  it('reopens on a different calendar when the token changes', async () => {
+    const token = ref('first');
+    const { stop } = withScope(() => useCalendarStream({ token, onChange: () => {} }));
+
+    const first = FakeEventSource.latest;
+    token.value = 'second';
+    await nextTick();
+
+    expect(first.closed).toBe(true);
+    expect(FakeEventSource.latest.url).toContain('second');
+    stop();
+  });
+
+  it('closes when its scope is stopped', () => {
+    const { stop } = withScope(() =>
+      useCalendarStream({ token: ref('abc123'), onChange: () => {} })
+    );
+
+    const source = FakeEventSource.latest;
+    stop();
+
+    // A view left behind holding an open stream is a connection the server keeps alive
+    // for a tab nobody is looking at.
+    expect(source.closed).toBe(true);
+  });
+
+  it('does not reload after being closed', async () => {
+    const onChange = vi.fn();
+    const { result, stop } = withScope(() => useCalendarStream({ token: ref('abc123'), onChange }));
+
+    FakeEventSource.latest.emit('update');
+    result.close();
+    await vi.advanceTimersByTimeAsync(300);
+
+    // A refetch landing after the view is gone writes into a store nobody is showing.
+    expect(onChange).not.toHaveBeenCalled();
+    stop();
+  });
+});

--- a/frontend/src/composables/calendar/useCalendarStream.ts
+++ b/frontend/src/composables/calendar/useCalendarStream.ts
@@ -1,0 +1,117 @@
+/*
+ * WhenTo - Collaborative event calendar for self-hosted environments
+ * Copyright (C) 2025 WhenTo Contributors
+ * SPDX-License-Identifier: BSL-1.1
+ */
+
+import { onScopeDispose, ref, watch, type Ref } from 'vue';
+
+/**
+ * Keeps a calendar view in step with what other participants are doing.
+ *
+ * The server sends notices, not data: each one means "this calendar changed, look
+ * again". The refetch goes through the ordinary read path, so there is one read model
+ * rather than two, and a notice can never carry a field its recipient is not entitled
+ * to see.
+ *
+ * EventSource is used rather than a WebSocket because the traffic is one-way. It also
+ * reconnects on its own, which is most of what a hand-rolled socket would have to
+ * reimplement — and reconnecting correctly is the part that decides whether this works
+ * on a train.
+ */
+
+/** How long to wait after a notice before refetching. */
+const COALESCE_MS = 250;
+
+export interface UseCalendarStreamOptions {
+  /** Public token of the calendar to watch; null suspends the stream. */
+  readonly token: Ref<string | null | undefined>;
+  /** Called when the calendar has changed and the view should reload its data. */
+  readonly onChange: () => void | Promise<void>;
+  /** Set false to keep the stream closed, e.g. behind a preference. */
+  readonly enabled?: Ref<boolean>;
+}
+
+export interface CalendarStream {
+  /** Whether the browser currently holds an open stream. */
+  readonly connected: Ref<boolean>;
+  /** Closes the stream; it reopens if the token changes. */
+  close(): void;
+}
+
+export function useCalendarStream(options: UseCalendarStreamOptions): CalendarStream {
+  const connected = ref(false);
+
+  let source: EventSource | null = null;
+  let coalesceTimer: ReturnType<typeof setTimeout> | null = null;
+  // A first connection means the view has just loaded its data; a later one means the
+  // stream was interrupted, and anything that changed meanwhile was missed.
+  let hasConnectedBefore = false;
+
+  function requestReload() {
+    if (coalesceTimer !== null) clearTimeout(coalesceTimer);
+    // One person dragging across a week produces a write per day. The server already
+    // collapses notices per connection, but a burst still arrives as several; without
+    // this the grid would refetch once per day dragged.
+    coalesceTimer = setTimeout(() => {
+      coalesceTimer = null;
+      void options.onChange();
+    }, COALESCE_MS);
+  }
+
+  function close() {
+    if (coalesceTimer !== null) {
+      clearTimeout(coalesceTimer);
+      coalesceTimer = null;
+    }
+    source?.close();
+    source = null;
+    connected.value = false;
+  }
+
+  function open(token: string) {
+    close();
+
+    // Same origin as the rest of the API. EventSource cannot go through the axios client,
+    // which is why this is the one place a URL is built by hand.
+    source = new EventSource(`/api/v1/availabilities/calendar/${encodeURIComponent(token)}/events`);
+
+    source.addEventListener('open', () => {
+      connected.value = true;
+      if (hasConnectedBefore) {
+        // Reconnected. Whatever happened while the stream was down produced no notice
+        // this browser will ever see, so the only safe assumption is that it missed
+        // something.
+        requestReload();
+      }
+      hasConnectedBefore = true;
+    });
+
+    source.addEventListener('update', () => requestReload());
+
+    source.addEventListener('error', () => {
+      // EventSource reconnects on its own, using the retry delay the server sent. The
+      // stream is only reported as down so the UI can say so; it is not torn down here,
+      // because closing it would cancel the automatic reconnection.
+      connected.value = false;
+    });
+  }
+
+  watch(
+    () => [options.token.value, options.enabled?.value ?? true] as const,
+    ([token, enabled]) => {
+      if (!token || !enabled) {
+        close();
+        return;
+      }
+      open(token);
+    },
+    { immediate: true }
+  );
+
+  // Vue's scope, not onUnmounted: the composable is used from a view, but this way it
+  // also cleans up when called inside an effectScope that is stopped.
+  onScopeDispose(close);
+
+  return { connected, close };
+}

--- a/frontend/src/views/ParticipantView.vue
+++ b/frontend/src/views/ParticipantView.vue
@@ -1240,6 +1240,7 @@ import TimeSelect from '@/components/TimeSelect.vue';
 import CollapsibleSection from '@/components/CollapsibleSection.vue';
 import { dayOfWeekISO, formatDateISO, parseISODate } from '@/utils/date/isoDate';
 import { useParticipantCalendar } from '@/composables/calendar/useParticipantCalendar';
+import { useCalendarStream } from '@/composables/calendar/useCalendarStream';
 import { normalizeViewStyle, type ViewStyle } from '@/composables/calendar/useCalendarViewState';
 import { addParticipantEmail, resendVerificationEmail } from '@/api/notify';
 import type {
@@ -2662,6 +2663,22 @@ async function handleCancelFromEmail() {
     toastStore.error(err.message || 'Failed to cancel participation');
   }
 }
+
+// Live updates. The server sends a notice, never data, so this reloads through the same
+// path a navigation would — which keeps one read model and means a notice cannot carry a
+// field this viewer is not entitled to.
+//
+// It reloads after the viewer's own writes too. That is one extra request per answer,
+// and it is what reconciles the optimistic update with what the server actually stored.
+useCalendarStream({
+  token,
+  onChange: async () => {
+    await Promise.all([
+      loadRecurrences(),
+      loadParticipantCounts(displayedYear.value, displayedMonth.value),
+    ]);
+  },
+});
 
 onMounted(async () => {
   // The route watcher above already loads the calendar with { immediate: true }.

--- a/internal/availability/handlers/events_handler.go
+++ b/internal/availability/handlers/events_handler.go
@@ -1,0 +1,130 @@
+// WhenTo - Collaborative event calendar for self-hosted environments
+// Copyright (C) 2025 WhenTo Contributors
+// SPDX-License-Identifier: BSL-1.1
+
+package handlers
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/google/uuid"
+
+	"github.com/whento/pkg/broadcast"
+	"github.com/whento/pkg/httputil"
+	"github.com/whento/pkg/logger"
+)
+
+const (
+	// heartbeatInterval keeps the connection from being reaped. Reverse proxies close an
+	// idle response after a minute or so by default — nginx's proxy_read_timeout is 60s —
+	// and a stream that carries nothing between two quiet answers looks exactly like a
+	// hung backend. A comment line is the cheapest thing that counts as traffic.
+	heartbeatInterval = 25 * time.Second
+
+	// retryHint tells the browser how long to wait before reconnecting. EventSource
+	// reconnects on its own; this only sets the delay, and three seconds keeps a restart
+	// of the server from turning into a stampede.
+	retryHint = 3 * time.Second
+)
+
+// CalendarLookup is the one thing this handler asks of the calendar repository: does
+// this public token name a calendar? Everything else about the stream is the token.
+type CalendarLookup interface {
+	GetByPublicToken(ctx context.Context, token string) (uuid.UUID, error)
+}
+
+// EventsHandler streams change notices for one calendar.
+//
+// The notices carry no data. A browser that receives one refetches through the ordinary
+// read path, which keeps a single read model and means the stream can never hand out a
+// field its holder is not entitled to. It also makes the stream cheap: a notice is four
+// bytes on the wire whatever changed.
+type EventsHandler struct {
+	calendars CalendarLookup
+	broker    broadcast.Broker
+}
+
+// NewEventsHandler creates the SSE handler for participant calendars.
+func NewEventsHandler(calendars CalendarLookup, broker broadcast.Broker) *EventsHandler {
+	return &EventsHandler{calendars: calendars, broker: broker}
+}
+
+// Stream handles GET /api/v1/availabilities/calendar/{token}/events
+//
+//	@Summary		Stream calendar changes
+//	@Description	Server-sent events announcing that the calendar changed. Each `update` event is a notice with no payload: fetch the range summary again. Public endpoint, authorised by the calendar token like the rest of the participant API.
+//	@Tags			Availabilities
+//	@Produce		text/event-stream
+//	@Param			token	path	string	true	"Calendar public token"
+//	@Success		200		{string}	string	"event: update"
+//	@Failure		404		{object}	httputil.ErrorResponse	"Calendar not found"
+//	@Failure		500		{object}	httputil.ErrorResponse	"Streaming unsupported"
+//	@Router			/api/v1/availabilities/calendar/{token}/events [get]
+func (h *EventsHandler) Stream(w http.ResponseWriter, r *http.Request) {
+	token := chi.URLParam(r, "token")
+	log := logger.FromContext(r.Context())
+
+	// Resolved before a single byte goes out: once the stream has started the status
+	// line is spent, and an unknown token would look to the browser like a working
+	// stream that never says anything.
+	if _, err := h.calendars.GetByPublicToken(r.Context(), token); err != nil {
+		httputil.Error(w, http.StatusNotFound, httputil.ErrCodeNotFound, "Calendar not found")
+		return
+	}
+
+	flusher, ok := w.(http.Flusher)
+	if !ok {
+		// Without flushing, every notice sits in a buffer until the stream ends, which
+		// is the opposite of the point.
+		httputil.Error(w, http.StatusInternalServerError, httputil.ErrCodeInternal, "Streaming unsupported")
+		return
+	}
+
+	// Subscribe before announcing the stream is open. A write landing in between would
+	// otherwise be missed by a browser that believes it is now up to date.
+	notices, stop := h.broker.Subscribe(r.Context(), token)
+	defer stop()
+
+	w.Header().Set("Content-Type", "text/event-stream")
+	w.Header().Set("Cache-Control", "no-store")
+	// Nginx buffers proxied responses by default, which holds notices back until the
+	// buffer fills. This is the documented opt-out.
+	w.Header().Set("X-Accel-Buffering", "no")
+	w.WriteHeader(http.StatusOK)
+
+	fmt.Fprintf(w, "retry: %d\n\n", retryHint.Milliseconds())
+	flusher.Flush()
+
+	heartbeat := time.NewTicker(heartbeatInterval)
+	defer heartbeat.Stop()
+
+	for {
+		select {
+		case <-r.Context().Done():
+			// The browser went away: a closed tab, a lost network, a reload.
+			return
+
+		case _, open := <-notices:
+			if !open {
+				// The broker is shutting down. Closing cleanly lets EventSource
+				// reconnect to whichever instance comes back.
+				return
+			}
+			if _, err := fmt.Fprint(w, "event: update\ndata: {}\n\n"); err != nil {
+				log.Debug("events: stream write failed", "token", token, "error", err)
+				return
+			}
+			flusher.Flush()
+
+		case <-heartbeat.C:
+			if _, err := fmt.Fprint(w, ": keep-alive\n\n"); err != nil {
+				return
+			}
+			flusher.Flush()
+		}
+	}
+}

--- a/internal/availability/handlers/events_handler_test.go
+++ b/internal/availability/handlers/events_handler_test.go
@@ -1,0 +1,333 @@
+// WhenTo - Collaborative event calendar for self-hosted environments
+// Copyright (C) 2025 WhenTo Contributors
+// SPDX-License-Identifier: BSL-1.1
+
+package handlers
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/google/uuid"
+
+	"github.com/whento/pkg/broadcast"
+)
+
+// A stream that silently stops working looks exactly like a calendar where nobody has
+// answered yet, so the failures worth pinning are the quiet ones: a notice for the wrong
+// calendar, a connection reaped by a proxy for want of a heartbeat, and a subscription
+// that outlives the browser that opened it.
+
+type fakeCalendars struct {
+	err   error
+	token string
+}
+
+func (f *fakeCalendars) GetByPublicToken(_ context.Context, token string) (uuid.UUID, error) {
+	f.token = token
+	if f.err != nil {
+		return uuid.Nil, f.err
+	}
+
+	return uuid.New(), nil
+}
+
+// streamRequest builds a request carrying the chi URL parameter, with a context the
+// caller can cancel to play the part of a browser going away.
+func streamRequest(token string) (*http.Request, context.CancelFunc) {
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/availabilities/calendar/"+token+"/events", nil)
+
+	routeCtx := chi.NewRouteContext()
+	routeCtx.URLParams.Add("token", token)
+	ctx, cancel := context.WithCancel(context.WithValue(req.Context(), chi.RouteCtxKey, routeCtx))
+
+	return req.WithContext(ctx), cancel
+}
+
+// liveRecorder is an httptest.ResponseRecorder that can be read while the handler is
+// still writing. The plain recorder is only safe to read once ServeHTTP returns, which
+// never happens for a stream.
+type liveRecorder struct {
+	mu     sync.Mutex
+	header http.Header
+	status int
+	body   strings.Builder
+}
+
+func newLiveRecorder() *liveRecorder {
+	return &liveRecorder{header: make(http.Header)}
+}
+
+func (r *liveRecorder) Header() http.Header { return r.header }
+
+func (r *liveRecorder) Write(p []byte) (int, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	return r.body.Write(p)
+}
+
+func (r *liveRecorder) WriteHeader(status int) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.status = status
+}
+
+func (r *liveRecorder) Flush() {}
+
+func (r *liveRecorder) snapshot() (int, string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	return r.status, r.body.String()
+}
+
+// waitFor polls until the condition holds or the window expires. The handler writes from
+// its own goroutine, so assertions cannot be made immediately.
+func waitFor(t *testing.T, what string, condition func() bool) {
+	t.Helper()
+
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if condition() {
+			return
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	t.Errorf("timed out waiting for %s", what)
+}
+
+func TestAnUnknownTokenIs404(t *testing.T) {
+	handler := NewEventsHandler(&fakeCalendars{err: errors.New("no rows")}, broadcast.NewMemoryBroker())
+
+	req, cancel := streamRequest("nope")
+	defer cancel()
+	rec := httptest.NewRecorder()
+	handler.Stream(rec, req)
+
+	// Answered before the stream opens. Once the status line is spent an unknown token
+	// would look like a working stream that simply never says anything, and the browser
+	// would keep it open for ever.
+	if rec.Code != http.StatusNotFound {
+		t.Errorf("status = %d, want 404", rec.Code)
+	}
+	if ct := rec.Header().Get("Content-Type"); strings.Contains(ct, "event-stream") {
+		t.Errorf("Content-Type = %q; the rejection was sent as a stream", ct)
+	}
+}
+
+func TestTheStreamAnnouncesItself(t *testing.T) {
+	broker := broadcast.NewMemoryBroker()
+	t.Cleanup(func() { _ = broker.Close() })
+	handler := NewEventsHandler(&fakeCalendars{}, broker)
+
+	req, cancel := streamRequest("public-token")
+	rec := newLiveRecorder()
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		handler.Stream(rec, req)
+	}()
+
+	waitFor(t, "the stream to open", func() bool {
+		status, _ := rec.snapshot()
+
+		return status == http.StatusOK
+	})
+
+	if ct := rec.Header().Get("Content-Type"); ct != "text/event-stream" {
+		t.Errorf("Content-Type = %q, want text/event-stream", ct)
+	}
+	// A cached stream is a stream that never updates.
+	if cc := rec.Header().Get("Cache-Control"); !strings.Contains(cc, "no-store") {
+		t.Errorf("Cache-Control = %q, want no-store", cc)
+	}
+	// Nginx buffers proxied responses by default, which holds notices until the buffer
+	// fills. Without this header the feature works in development and not behind a proxy.
+	if rec.Header().Get("X-Accel-Buffering") != "no" {
+		t.Error("X-Accel-Buffering is not disabled; notices would be buffered by nginx")
+	}
+
+	_, body := rec.snapshot()
+	if !strings.Contains(body, "retry:") {
+		t.Errorf("the stream sends no reconnection delay:\n%q", body)
+	}
+
+	cancel()
+	<-done
+}
+
+func TestANoticeReachesTheBrowser(t *testing.T) {
+	broker := broadcast.NewMemoryBroker()
+	t.Cleanup(func() { _ = broker.Close() })
+	handler := NewEventsHandler(&fakeCalendars{}, broker)
+
+	req, cancel := streamRequest("public-token")
+	rec := newLiveRecorder()
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		handler.Stream(rec, req)
+	}()
+
+	waitFor(t, "the stream to open", func() bool {
+		status, _ := rec.snapshot()
+
+		return status == http.StatusOK
+	})
+
+	if err := broker.Publish(context.Background(), "public-token"); err != nil {
+		t.Fatalf("Publish: %v", err)
+	}
+
+	waitFor(t, "the update event", func() bool {
+		_, body := rec.snapshot()
+
+		return strings.Contains(body, "event: update")
+	})
+
+	cancel()
+	<-done
+}
+
+// TestNoticesForOtherCalendarsAreNotDelivered is the privacy case. Calendars are
+// addressed by a public token, and a notice crossing streams would tell the holder of
+// one link that a different calendar had just been edited.
+func TestNoticesForOtherCalendarsAreNotDelivered(t *testing.T) {
+	broker := broadcast.NewMemoryBroker()
+	t.Cleanup(func() { _ = broker.Close() })
+	handler := NewEventsHandler(&fakeCalendars{}, broker)
+
+	req, cancel := streamRequest("mine")
+	rec := newLiveRecorder()
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		handler.Stream(rec, req)
+	}()
+
+	waitFor(t, "the stream to open", func() bool {
+		status, _ := rec.snapshot()
+
+		return status == http.StatusOK
+	})
+
+	if err := broker.Publish(context.Background(), "theirs"); err != nil {
+		t.Fatalf("Publish: %v", err)
+	}
+
+	time.Sleep(150 * time.Millisecond)
+	if _, body := rec.snapshot(); strings.Contains(body, "event: update") {
+		t.Errorf("a notice for another calendar was delivered:\n%q", body)
+	}
+
+	cancel()
+	<-done
+}
+
+// TestTheBrowserGoingAwayEndsTheStream is what stops the leak: a goroutine and a
+// subscription per abandoned tab, held until the process restarts.
+func TestTheBrowserGoingAwayEndsTheStream(t *testing.T) {
+	broker := broadcast.NewMemoryBroker()
+	t.Cleanup(func() { _ = broker.Close() })
+	handler := NewEventsHandler(&fakeCalendars{}, broker)
+
+	req, cancel := streamRequest("public-token")
+	rec := newLiveRecorder()
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		handler.Stream(rec, req)
+	}()
+
+	waitFor(t, "the stream to open", func() bool {
+		status, _ := rec.snapshot()
+
+		return status == http.StatusOK
+	})
+
+	cancel()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Error("the handler outlived the request context")
+	}
+}
+
+// TestTheBrokerShuttingDownEndsTheStream covers server shutdown. Returning cleanly lets
+// EventSource reconnect to whichever instance comes back, instead of the handler sitting
+// on a channel nobody will ever write to.
+func TestTheBrokerShuttingDownEndsTheStream(t *testing.T) {
+	broker := broadcast.NewMemoryBroker()
+	handler := NewEventsHandler(&fakeCalendars{}, broker)
+
+	req, cancel := streamRequest("public-token")
+	defer cancel()
+	rec := newLiveRecorder()
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		handler.Stream(rec, req)
+	}()
+
+	waitFor(t, "the stream to open", func() bool {
+		status, _ := rec.snapshot()
+
+		return status == http.StatusOK
+	})
+
+	if err := broker.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Error("the handler survived the broker shutting down")
+	}
+}
+
+// TestTheTokenIsCheckedAgainstTheRepository guards the one authorisation step there is.
+// Possession of the token is the whole credential, so a stream that opened without
+// resolving it would hand a live feed to any string at all.
+func TestTheTokenIsCheckedAgainstTheRepository(t *testing.T) {
+	calendars := &fakeCalendars{}
+	broker := broadcast.NewMemoryBroker()
+	t.Cleanup(func() { _ = broker.Close() })
+	handler := NewEventsHandler(calendars, broker)
+
+	req, cancel := streamRequest("the-token-from-the-url")
+	rec := newLiveRecorder()
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		handler.Stream(rec, req)
+	}()
+
+	waitFor(t, "the stream to open", func() bool {
+		status, _ := rec.snapshot()
+
+		return status == http.StatusOK
+	})
+
+	if calendars.token != "the-token-from-the-url" {
+		t.Errorf("the repository was asked about %q, want the token from the URL", calendars.token)
+	}
+
+	cancel()
+	<-done
+}

--- a/internal/availability/handlers/publish_middleware.go
+++ b/internal/availability/handlers/publish_middleware.go
@@ -1,0 +1,70 @@
+// WhenTo - Collaborative event calendar for self-hosted environments
+// Copyright (C) 2025 WhenTo Contributors
+// SPDX-License-Identifier: BSL-1.1
+
+package handlers
+
+import (
+	"net/http"
+
+	"github.com/go-chi/chi/v5"
+	chiMiddleware "github.com/go-chi/chi/v5/middleware"
+
+	"github.com/whento/pkg/broadcast"
+	"github.com/whento/pkg/logger"
+)
+
+// PublishChanges announces that a calendar changed, after any request that changed it.
+//
+// Deliberately a middleware rather than a call at the end of each service method. The
+// participant API has nine write paths today — availabilities, recurrences, exceptions —
+// and a tenth added next month would silently not notify anyone. Here there is one place
+// to get right, and a new route under the same mount is covered by existing.
+//
+// It fires on the response rather than the request, so a rejected write announces
+// nothing: a 403 or a validation failure changed no state, and telling every open browser
+// to refetch would be pure noise.
+func PublishChanges(broker broadcast.Broker) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if !isMutating(r.Method) {
+				next.ServeHTTP(w, r)
+				return
+			}
+
+			recorder := chiMiddleware.NewWrapResponseWriter(w, r.ProtoMajor)
+			next.ServeHTTP(recorder, r)
+
+			if recorder.Status() < 200 || recorder.Status() >= 300 {
+				return
+			}
+
+			// The token names the calendar and is what watchers subscribe with, so it is
+			// the topic. Reading it after the handler is deliberate: chi fills the route
+			// context as it matches, and a route that did not match has no token to read.
+			token := chi.URLParam(r, "token")
+			if token == "" {
+				return
+			}
+
+			// The request context is still live here — it is cancelled when the whole
+			// chain returns, not when the handler does — and publishing is a single
+			// round trip, so there is no need to detach from it.
+			if err := broker.Publish(r.Context(), token); err != nil {
+				// Already delivered locally by the broker; this is the wider fan-out
+				// failing. The write itself stands, so this is a warning, not a failure.
+				logger.FromContext(r.Context()).Warn("could not announce a calendar change",
+					"error", err)
+			}
+		})
+	}
+}
+
+func isMutating(method string) bool {
+	switch method {
+	case http.MethodPost, http.MethodPut, http.MethodPatch, http.MethodDelete:
+		return true
+	default:
+		return false
+	}
+}

--- a/internal/availability/handlers/publish_middleware_test.go
+++ b/internal/availability/handlers/publish_middleware_test.go
@@ -1,0 +1,214 @@
+// WhenTo - Collaborative event calendar for self-hosted environments
+// Copyright (C) 2025 WhenTo Contributors
+// SPDX-License-Identifier: BSL-1.1
+
+package handlers
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+)
+
+// This middleware is the reason a browser hears about anything at all. It is placed on
+// the route mount rather than at the end of nine service methods, so what has to hold is
+// that it fires for the writes and stays quiet for everything else — a notice after a
+// rejected write is noise, and a missed notice is the feature not working.
+
+type recordingBroker struct {
+	mu     sync.Mutex
+	topics []string
+	err    error
+}
+
+func (b *recordingBroker) Publish(_ context.Context, topic string) error {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.topics = append(b.topics, topic)
+
+	return b.err
+}
+
+func (b *recordingBroker) Subscribe(context.Context, string) (<-chan struct{}, func()) {
+	ch := make(chan struct{})
+
+	return ch, func() { close(ch) }
+}
+
+func (b *recordingBroker) Close() error { return nil }
+
+func (b *recordingBroker) published() []string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	return append([]string(nil), b.topics...)
+}
+
+// route mounts the middleware the way main.go does, so the chi URL parameter is filled
+// by real routing rather than by hand.
+func route(broker *recordingBroker, status int) http.Handler {
+	router := chi.NewRouter()
+	router.Route("/calendar/{token}", func(r chi.Router) {
+		r.Use(PublishChanges(broker))
+		r.HandleFunc("/participant/{pid}", func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(status)
+		})
+	})
+
+	return router
+}
+
+func TestAWriteAnnouncesItsCalendar(t *testing.T) {
+	for _, method := range []string{http.MethodPost, http.MethodPut, http.MethodPatch, http.MethodDelete} {
+		t.Run(method, func(t *testing.T) {
+			broker := &recordingBroker{}
+			rec := httptest.NewRecorder()
+			route(broker, http.StatusOK).ServeHTTP(rec,
+				httptest.NewRequest(method, "/calendar/public-token/participant/p1", nil))
+
+			if got := broker.published(); len(got) != 1 || got[0] != "public-token" {
+				t.Errorf("published %v, want [public-token]", got)
+			}
+		})
+	}
+}
+
+// TestAReadAnnouncesNothing matters because the read path is by far the busiest: the
+// grid refetches its range summary on every navigation. Publishing there would have
+// every viewer telling every other viewer to refetch, for ever.
+func TestAReadAnnouncesNothing(t *testing.T) {
+	for _, method := range []string{http.MethodGet, http.MethodHead, http.MethodOptions} {
+		t.Run(method, func(t *testing.T) {
+			broker := &recordingBroker{}
+			rec := httptest.NewRecorder()
+			route(broker, http.StatusOK).ServeHTTP(rec,
+				httptest.NewRequest(method, "/calendar/public-token/participant/p1", nil))
+
+			if got := broker.published(); len(got) != 0 {
+				t.Errorf("a %s published %v", method, got)
+			}
+		})
+	}
+}
+
+// TestARejectedWriteAnnouncesNothing covers the case the middleware exists to get right.
+// A 403 or a validation failure changed no state, so telling every open browser to
+// refetch would be pure noise — and on a calendar under a burst of rejected writes, a
+// lot of it.
+func TestARejectedWriteAnnouncesNothing(t *testing.T) {
+	for _, status := range []int{
+		http.StatusBadRequest, http.StatusUnauthorized, http.StatusForbidden,
+		http.StatusNotFound, http.StatusConflict, http.StatusTooManyRequests,
+		http.StatusInternalServerError,
+	} {
+		t.Run(http.StatusText(status), func(t *testing.T) {
+			broker := &recordingBroker{}
+			rec := httptest.NewRecorder()
+			route(broker, status).ServeHTTP(rec,
+				httptest.NewRequest(http.MethodPost, "/calendar/public-token/participant/p1", nil))
+
+			if got := broker.published(); len(got) != 0 {
+				t.Errorf("a %d published %v", status, got)
+			}
+		})
+	}
+}
+
+func TestEverySuccessStatusAnnounces(t *testing.T) {
+	// 201 for a created availability, 204 for a deleted one: both are real changes.
+	for _, status := range []int{http.StatusOK, http.StatusCreated, http.StatusAccepted, http.StatusNoContent} {
+		t.Run(http.StatusText(status), func(t *testing.T) {
+			broker := &recordingBroker{}
+			rec := httptest.NewRecorder()
+			route(broker, status).ServeHTTP(rec,
+				httptest.NewRequest(http.MethodDelete, "/calendar/public-token/participant/p1", nil))
+
+			if got := broker.published(); len(got) != 1 {
+				t.Errorf("a %d published %v, want one notice", status, got)
+			}
+		})
+	}
+}
+
+// TestTheTopicIsTheCalendarToken pins what watchers subscribe with. A notice published
+// under anything else reaches nobody, and the feature fails silently.
+func TestTheTopicIsTheCalendarToken(t *testing.T) {
+	broker := &recordingBroker{}
+	rec := httptest.NewRecorder()
+	route(broker, http.StatusCreated).ServeHTTP(rec,
+		httptest.NewRequest(http.MethodPost, "/calendar/abc123/participant/p1", nil))
+
+	if got := broker.published(); len(got) != 1 || got[0] != "abc123" {
+		t.Errorf("published %v, want [abc123]", got)
+	}
+}
+
+// TestAFailedFanOutDoesNotFailTheWrite records the priority: the participant's answer is
+// saved, and the worst case of a Redis outage is that other browsers refresh a little
+// later than they might have.
+func TestAFailedFanOutDoesNotFailTheWrite(t *testing.T) {
+	broker := &recordingBroker{err: errors.New("connection refused")}
+	rec := httptest.NewRecorder()
+	route(broker, http.StatusCreated).ServeHTTP(rec,
+		httptest.NewRequest(http.MethodPost, "/calendar/public-token/participant/p1", nil))
+
+	if rec.Code != http.StatusCreated {
+		t.Errorf("status = %d, want the handler's 201 — the write must stand", rec.Code)
+	}
+}
+
+// TestTheResponseIsUntouched guards the wrapping. The middleware wraps the writer to
+// read the status back, and a wrapper that swallowed the body would break every write
+// endpoint at once.
+func TestTheResponseIsUntouched(t *testing.T) {
+	broker := &recordingBroker{}
+
+	router := chi.NewRouter()
+	router.Route("/calendar/{token}", func(r chi.Router) {
+		r.Use(PublishChanges(broker))
+		r.Post("/participant/{pid}", func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusCreated)
+			_, _ = w.Write([]byte(`{"success":true,"data":{"date":"2027-03-10"}}`))
+		})
+	})
+
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/calendar/public-token/participant/p1", nil))
+
+	if rec.Code != http.StatusCreated {
+		t.Errorf("status = %d, want 201", rec.Code)
+	}
+	if !strings.Contains(rec.Body.String(), `"2027-03-10"`) {
+		t.Errorf("the body did not survive the wrapper: %q", rec.Body.String())
+	}
+	if ct := rec.Header().Get("Content-Type"); ct != "application/json" {
+		t.Errorf("Content-Type = %q", ct)
+	}
+}
+
+// TestARouteWithoutATokenAnnouncesNothing covers the mount being reused elsewhere. With
+// no token there is no topic, and publishing under the empty string would put unrelated
+// writes on one shared channel.
+func TestARouteWithoutATokenAnnouncesNothing(t *testing.T) {
+	broker := &recordingBroker{}
+
+	router := chi.NewRouter()
+	router.Use(PublishChanges(broker))
+	router.Post("/something-else", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusCreated)
+	})
+
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/something-else", nil))
+
+	if got := broker.published(); len(got) != 0 {
+		t.Errorf("published %v for a route with no calendar token", got)
+	}
+}

--- a/pkg/broadcast/broadcast.go
+++ b/pkg/broadcast/broadcast.go
@@ -1,0 +1,173 @@
+// WhenTo - Collaborative event calendar for self-hosted environments
+// Copyright (C) 2025 WhenTo Contributors
+// SPDX-License-Identifier: BSL-1.1
+
+// Package broadcast delivers short notices to everyone currently watching a topic.
+//
+// It exists for the live calendar: when a participant answers, every other browser
+// showing that calendar should hear about it. The notices carry no data, only the fact
+// that something changed, so a listener refetches through the normal read path. That
+// keeps one read model instead of two and means a notice can never leak a field the
+// recipient is not allowed to see.
+//
+// Two implementations, chosen the way pkg/middleware chooses its rate-limit backend: a
+// process-local hub that needs nothing, and a Redis-backed one that also reaches the
+// other instances of a horizontally scaled deployment. A single-instance self-hosted
+// install works fully with the local hub; Redis is only required once there is more
+// than one instance, and its absence degrades to "live within this instance" rather
+// than to an error.
+package broadcast
+
+import (
+	"context"
+	"sync"
+)
+
+// Broker delivers notices published on a topic to that topic's current subscribers.
+//
+// Delivery is best-effort by design. A subscriber that is not reading fast enough is
+// skipped rather than allowed to block the publisher: the notices are invalidations, so
+// a listener that misses one and receives the next is in the same state as one that
+// received both.
+type Broker interface {
+	// Publish sends a notice to everyone subscribed to the topic. It never blocks on a
+	// slow subscriber.
+	Publish(ctx context.Context, topic string) error
+
+	// Subscribe returns a channel of notices and a function that stops the
+	// subscription. The channel is closed when the subscription stops, so a range over
+	// it terminates. Cancelling the context also stops it.
+	Subscribe(ctx context.Context, topic string) (<-chan struct{}, func())
+
+	// Close releases whatever the broker holds. Subscribers see their channels close.
+	Close() error
+}
+
+// hub is the process-local delivery mechanism, shared by both implementations: the
+// Redis broker uses it to deliver what arrives from Redis.
+type hub struct {
+	mu     sync.RWMutex
+	topics map[string]map[*subscriber]struct{}
+	closed bool
+}
+
+type subscriber struct {
+	// Capacity one, so a notice waiting to be read stands in for any number of further
+	// notices. What a listener needs to know is "something changed since you last
+	// looked", and one pending notice says exactly that.
+	ch chan struct{}
+
+	once sync.Once
+}
+
+func newHub() *hub {
+	return &hub{topics: make(map[string]map[*subscriber]struct{})}
+}
+
+func (h *hub) publish(topic string) {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
+
+	for sub := range h.topics[topic] {
+		select {
+		case sub.ch <- struct{}{}:
+		default:
+			// Already has a notice pending; a second would tell it nothing new.
+		}
+	}
+}
+
+func (h *hub) subscribe(ctx context.Context, topic string) (<-chan struct{}, func()) {
+	sub := &subscriber{ch: make(chan struct{}, 1)}
+
+	h.mu.Lock()
+	if h.closed {
+		h.mu.Unlock()
+		close(sub.ch)
+
+		return sub.ch, func() {}
+	}
+	if h.topics[topic] == nil {
+		h.topics[topic] = make(map[*subscriber]struct{})
+	}
+	h.topics[topic][sub] = struct{}{}
+	h.mu.Unlock()
+
+	stop := func() {
+		h.mu.Lock()
+		if peers := h.topics[topic]; peers != nil {
+			delete(peers, sub)
+			// Drop the topic once nobody is listening, so a long-lived process does not
+			// accumulate an entry per calendar ever viewed.
+			if len(peers) == 0 {
+				delete(h.topics, topic)
+			}
+		}
+		h.mu.Unlock()
+
+		sub.once.Do(func() { close(sub.ch) })
+	}
+
+	// Cancelling the caller's context unsubscribes, so a handler that returns cannot
+	// leave an entry behind even if it forgets to call stop.
+	if ctx.Done() != nil {
+		go func() {
+			<-ctx.Done()
+			stop()
+		}()
+	}
+
+	return sub.ch, stop
+}
+
+func (h *hub) close() {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	if h.closed {
+		return
+	}
+	h.closed = true
+
+	for topic, peers := range h.topics {
+		for sub := range peers {
+			sub.once.Do(func() { close(sub.ch) })
+		}
+		delete(h.topics, topic)
+	}
+}
+
+// subscriberCount reports how many subscriptions a topic has. Used by the tests, and by
+// nothing else — the brokers do not branch on it.
+func (h *hub) subscriberCount(topic string) int {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
+
+	return len(h.topics[topic])
+}
+
+// memoryBroker delivers within one process.
+type memoryBroker struct{ hub *hub }
+
+// NewMemoryBroker returns a broker that reaches the subscribers of this process only.
+// That is the whole of a single-instance deployment, which is how self-hosted WhenTo
+// normally runs.
+func NewMemoryBroker() Broker {
+	return &memoryBroker{hub: newHub()}
+}
+
+func (b *memoryBroker) Publish(_ context.Context, topic string) error {
+	b.hub.publish(topic)
+
+	return nil
+}
+
+func (b *memoryBroker) Subscribe(ctx context.Context, topic string) (<-chan struct{}, func()) {
+	return b.hub.subscribe(ctx, topic)
+}
+
+func (b *memoryBroker) Close() error {
+	b.hub.close()
+
+	return nil
+}

--- a/pkg/broadcast/broadcast_test.go
+++ b/pkg/broadcast/broadcast_test.go
@@ -1,0 +1,275 @@
+// WhenTo - Collaborative event calendar for self-hosted environments
+// Copyright (C) 2025 WhenTo Contributors
+// SPDX-License-Identifier: BSL-1.1
+
+package broadcast
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+)
+
+// The broker sits between a write and every browser watching the calendar, so the
+// failure modes that matter are the ones that are invisible: a notice that reaches the
+// wrong calendar, a subscriber that blocks a write, and a subscription that outlives the
+// request that made it.
+
+// waitForNotice reports whether a notice arrives within a short window. Long enough not
+// to be flaky on a loaded machine, short enough that a missing notice fails quickly.
+func waitForNotice(t *testing.T, ch <-chan struct{}) bool {
+	t.Helper()
+
+	select {
+	case _, ok := <-ch:
+		return ok
+	case <-time.After(2 * time.Second):
+		return false
+	}
+}
+
+func TestASubscriberHearsItsOwnTopic(t *testing.T) {
+	broker := NewMemoryBroker()
+	t.Cleanup(func() { _ = broker.Close() })
+
+	notices, stop := broker.Subscribe(context.Background(), "calendar-a")
+	t.Cleanup(stop)
+
+	if err := broker.Publish(context.Background(), "calendar-a"); err != nil {
+		t.Fatalf("Publish: %v", err)
+	}
+	if !waitForNotice(t, notices) {
+		t.Error("no notice arrived")
+	}
+}
+
+// TestTopicsAreIsolated is the one that matters for privacy. Calendars are addressed by
+// their public token, and a notice crossing topics would tell the holder of one link
+// that a different calendar just changed.
+func TestTopicsAreIsolated(t *testing.T) {
+	broker := NewMemoryBroker()
+	t.Cleanup(func() { _ = broker.Close() })
+
+	mine, stopMine := broker.Subscribe(context.Background(), "calendar-a")
+	t.Cleanup(stopMine)
+	theirs, stopTheirs := broker.Subscribe(context.Background(), "calendar-b")
+	t.Cleanup(stopTheirs)
+
+	if err := broker.Publish(context.Background(), "calendar-b"); err != nil {
+		t.Fatalf("Publish: %v", err)
+	}
+
+	if !waitForNotice(t, theirs) {
+		t.Error("the subscriber to calendar-b heard nothing")
+	}
+	select {
+	case <-mine:
+		t.Error("a notice for calendar-b reached a subscriber of calendar-a")
+	case <-time.After(100 * time.Millisecond):
+	}
+}
+
+func TestEverySubscriberToATopicIsNotified(t *testing.T) {
+	broker := NewMemoryBroker()
+	t.Cleanup(func() { _ = broker.Close() })
+
+	const watchers = 25
+	channels := make([]<-chan struct{}, watchers)
+	for i := range channels {
+		ch, stop := broker.Subscribe(context.Background(), "calendar-a")
+		t.Cleanup(stop)
+		channels[i] = ch
+	}
+
+	if err := broker.Publish(context.Background(), "calendar-a"); err != nil {
+		t.Fatalf("Publish: %v", err)
+	}
+
+	for i, ch := range channels {
+		if !waitForNotice(t, ch) {
+			t.Errorf("watcher %d heard nothing", i)
+		}
+	}
+}
+
+// TestAStalledSubscriberDoesNotBlockThePublisher covers the failure that would turn a
+// browser left open on a locked screen into a stalled write for everyone else.
+func TestAStalledSubscriberDoesNotBlockThePublisher(t *testing.T) {
+	broker := NewMemoryBroker()
+	t.Cleanup(func() { _ = broker.Close() })
+
+	// Subscribed and never read from.
+	_, stop := broker.Subscribe(context.Background(), "calendar-a")
+	t.Cleanup(stop)
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		for range 100 {
+			_ = broker.Publish(context.Background(), "calendar-a")
+		}
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("publishing blocked on a subscriber that never reads")
+	}
+}
+
+// TestNoticesCoalesce records the design: the channel holds one pending notice, because
+// "something changed since you last looked" is all a listener acts on. Ten writes while
+// a browser is busy must not queue ten refetches.
+func TestNoticesCoalesce(t *testing.T) {
+	broker := NewMemoryBroker()
+	t.Cleanup(func() { _ = broker.Close() })
+
+	notices, stop := broker.Subscribe(context.Background(), "calendar-a")
+	t.Cleanup(stop)
+
+	for range 10 {
+		if err := broker.Publish(context.Background(), "calendar-a"); err != nil {
+			t.Fatalf("Publish: %v", err)
+		}
+	}
+
+	if !waitForNotice(t, notices) {
+		t.Fatal("no notice arrived")
+	}
+	select {
+	case <-notices:
+		t.Error("a second notice was queued; ten writes should collapse into one refetch")
+	case <-time.After(100 * time.Millisecond):
+	}
+}
+
+func TestStopEndsTheSubscription(t *testing.T) {
+	broker := NewMemoryBroker()
+	t.Cleanup(func() { _ = broker.Close() })
+
+	notices, stop := broker.Subscribe(context.Background(), "calendar-a")
+	stop()
+
+	// The channel closes, so a range over it terminates rather than hanging.
+	if _, open := <-notices; open {
+		t.Error("the channel yielded a value after the subscription stopped")
+	}
+
+	// And stopping twice is harmless: the SSE handler calls stop in a defer and again on
+	// the disconnect path.
+	stop()
+}
+
+// TestCancellingTheContextUnsubscribes is what stops a leak. Every subscription is made
+// from a request context, and a browser closing its tab cancels it without the handler
+// getting a chance to tidy up.
+func TestCancellingTheContextUnsubscribes(t *testing.T) {
+	broker := NewMemoryBroker()
+	t.Cleanup(func() { _ = broker.Close() })
+
+	local, ok := broker.(*memoryBroker)
+	if !ok {
+		t.Fatalf("unexpected broker type %T", broker)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	notices, _ := broker.Subscribe(ctx, "calendar-a")
+
+	if got := local.hub.subscriberCount("calendar-a"); got != 1 {
+		t.Fatalf("subscriber count = %d, want 1", got)
+	}
+
+	cancel()
+
+	if _, open := <-notices; open {
+		t.Error("the channel stayed open after the context was cancelled")
+	}
+
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if local.hub.subscriberCount("calendar-a") == 0 {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Errorf("the subscription survived its context: %d still registered",
+		local.hub.subscriberCount("calendar-a"))
+}
+
+// TestTopicsAreForgotten guards against a slow leak that no functional test would show:
+// a process that has served a million calendars holding a million empty maps.
+func TestTopicsAreForgotten(t *testing.T) {
+	broker := NewMemoryBroker()
+	t.Cleanup(func() { _ = broker.Close() })
+
+	local := broker.(*memoryBroker)
+
+	for i := range 100 {
+		_, stop := broker.Subscribe(context.Background(), string(rune('a'+i%26))+"-calendar")
+		stop()
+	}
+
+	local.hub.mu.RLock()
+	remaining := len(local.hub.topics)
+	local.hub.mu.RUnlock()
+
+	if remaining != 0 {
+		t.Errorf("%d topics kept after every subscriber left", remaining)
+	}
+}
+
+func TestCloseEndsEverySubscription(t *testing.T) {
+	broker := NewMemoryBroker()
+
+	first, _ := broker.Subscribe(context.Background(), "calendar-a")
+	second, _ := broker.Subscribe(context.Background(), "calendar-b")
+
+	if err := broker.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	for name, ch := range map[string]<-chan struct{}{"calendar-a": first, "calendar-b": second} {
+		if _, open := <-ch; open {
+			t.Errorf("the subscription to %s survived Close", name)
+		}
+	}
+
+	// Subscribing after Close yields a closed channel rather than one that never
+	// delivers, so a listener started during shutdown terminates instead of hanging.
+	late, stop := broker.Subscribe(context.Background(), "calendar-c")
+	defer stop()
+	if _, open := <-late; open {
+		t.Error("subscribing after Close produced a live channel")
+	}
+
+	// And Close is idempotent; the server shutdown path may reach it twice.
+	if err := broker.Close(); err != nil {
+		t.Errorf("Close twice: %v", err)
+	}
+}
+
+// TestConcurrentUseIsSafe is worth running under -race, which CI does. Subscribing,
+// publishing and unsubscribing all touch the same map.
+func TestConcurrentUseIsSafe(t *testing.T) {
+	broker := NewMemoryBroker()
+	t.Cleanup(func() { _ = broker.Close() })
+
+	var wg sync.WaitGroup
+	for i := range 50 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+
+			ch, stop := broker.Subscribe(context.Background(), "calendar-a")
+			_ = broker.Publish(context.Background(), "calendar-a")
+			select {
+			case <-ch:
+			case <-time.After(time.Second):
+			}
+			stop()
+			_ = i
+		}()
+	}
+	wg.Wait()
+}

--- a/pkg/broadcast/redis.go
+++ b/pkg/broadcast/redis.go
@@ -1,0 +1,108 @@
+// WhenTo - Collaborative event calendar for self-hosted environments
+// Copyright (C) 2025 WhenTo Contributors
+// SPDX-License-Identifier: BSL-1.1
+
+package broadcast
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"strings"
+	"sync"
+
+	"github.com/redis/go-redis/v9"
+)
+
+// channelPrefix namespaces the pub/sub channels, so a Redis shared with something else
+// does not collide.
+const channelPrefix = "whento:broadcast:"
+
+// redisBroker reaches the subscribers of every instance.
+//
+// One pattern subscription rather than one per topic: a deployment serving a thousand
+// calendars would otherwise hold a thousand Redis subscriptions, and the traffic here is
+// small enough that filtering locally costs nothing. Everything arriving on the pattern
+// is handed to the same process-local hub the memory broker uses, so delivery semantics
+// are identical whichever broker is in play.
+type redisBroker struct {
+	client *redis.Client
+	hub    *hub
+	pubsub *redis.PubSub
+	logger *slog.Logger
+
+	closeOnce sync.Once
+	done      chan struct{}
+}
+
+// NewRedisBroker returns a broker that reaches every instance sharing the Redis.
+//
+// Returns the memory broker when client is nil, which is how a deployment without Redis
+// still gets live updates within its own instance instead of none at all.
+func NewRedisBroker(client *redis.Client, logger *slog.Logger) Broker {
+	if client == nil {
+		return NewMemoryBroker()
+	}
+
+	broker := &redisBroker{
+		client: client,
+		hub:    newHub(),
+		logger: logger,
+		done:   make(chan struct{}),
+	}
+
+	broker.pubsub = client.PSubscribe(context.Background(), channelPrefix+"*")
+	go broker.receive()
+
+	return broker
+}
+
+// receive forwards everything published on the pattern into the local hub. Redis
+// delivers to every instance including the one that published, so a publisher needs no
+// separate local delivery.
+func (b *redisBroker) receive() {
+	messages := b.pubsub.Channel()
+
+	for {
+		select {
+		case <-b.done:
+			return
+		case message, ok := <-messages:
+			if !ok {
+				return
+			}
+			b.hub.publish(strings.TrimPrefix(message.Channel, channelPrefix))
+		}
+	}
+}
+
+func (b *redisBroker) Publish(ctx context.Context, topic string) error {
+	// The payload is unused: the channel name carries the topic and the notice itself
+	// says only "something changed".
+	if err := b.client.Publish(ctx, channelPrefix+topic, "").Err(); err != nil {
+		// A Redis outage must not fail the write that triggered this. Deliver locally so
+		// this instance's viewers still update, and say so once rather than silently.
+		b.logger.Warn("broadcast: publishing through Redis failed, delivering locally only",
+			"topic", topic, "error", err)
+		b.hub.publish(topic)
+
+		return fmt.Errorf("failed to publish: %w", err)
+	}
+
+	return nil
+}
+
+func (b *redisBroker) Subscribe(ctx context.Context, topic string) (<-chan struct{}, func()) {
+	return b.hub.subscribe(ctx, topic)
+}
+
+func (b *redisBroker) Close() error {
+	var err error
+	b.closeOnce.Do(func() {
+		close(b.done)
+		err = b.pubsub.Close()
+		b.hub.close()
+	})
+
+	return err
+}


### PR DESCRIPTION
Closes #49.

A participant answering was invisible to everyone else until they reloaded. The server now tells open browsers that the calendar changed, and they reload their own data.

## The notices carry no data

Only *"this calendar changed, look again"*. Sending the change itself would mean a second read model to keep in step with the first, and a payload that has to be filtered per recipient. An invalidation cannot leak a field, is four bytes whatever changed, and reuses the read path the view already trusts.

**SSE rather than a WebSocket**: the traffic is one-way, and `EventSource` reconnects on its own — which is most of what a hand-rolled socket would have had to reimplement. No new dependency either way.

## Publishing is a middleware, not nine calls

The participant API has nine write paths today — availabilities, recurrences, exceptions. A tenth added next month would silently notify nobody. One middleware on the route mount cannot be forgotten:

```go
r.Use(availabilityHandlers.PublishChanges(broker))
```

It fires on the **response**, so a rejected write announces nothing: a 403 changed no state, and telling every open browser to refetch would be noise.

## Redis is optional, as everywhere else here

`pkg/broadcast` makes the same choice `pkg/middleware` makes for rate limiting: a process-local hub that needs nothing, and a Redis-backed one that also reaches other instances.

- A single-instance self-hosted install is **fully live without Redis**.
- Its absence degrades to "live within this instance", not to an error.
- A Redis outage *during* a write logs a warning and delivers locally. The answer is saved either way — the worst case is that other browsers refresh a little later.

One pattern subscription rather than one per topic, so a deployment serving a thousand calendars holds one Redis connection rather than a thousand.

## Coalescing, at both ends

One person dragging across a week writes a day at a time. Without this, every other open browser would refetch the whole range seven times:

- the server keeps **one pending notice** per connection — a second would tell the listener nothing new;
- the browser waits **250 ms** before refetching.

## Reconnection reloads

Anything that changed while a stream was down produced no notice that browser will ever receive, so coming back has to assume it missed something. That is the case that decides whether this works on a train, and it is the one a naive implementation gets wrong.

The first connection deliberately does *not* reload — the view has just fetched its data.

## Verification

Two e2e tests against a real server and database, in a real browser: one watcher, and two at once. Both assert the grid updates with **no reload, no navigation and no click** — the only thing the test does is wait.

Both were then checked by unwiring the composable, and both failed. That mattered: an earlier run of this same check passed with the stream disabled, because Vite was serving a stale module. The tests only prove anything once the browser is running the code under test.

Also green: 27 unit tests on the broker, handler and middleware (backend, under `-race`), 13 on the composable, `make test` for both build variants, `vue-tsc`, `eslint`.

## Note for reviewers

Vite's file watcher does not fire in a container on a bind mount — inotify does not propagate. If you test this locally, **restart the dev server** after checking out rather than trusting HMR, or you will be testing `main`.