### PR TITLE
docs: drop the licensing leftovers, and correct the toolchain versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -298,6 +298,7 @@ whento/
 │   ├── quota/               # Calendar limits (both modes)
 │   └── testutil/            # Test helpers, including the database harness
 ├── pkg/                     # Shared packages, a separate Go module
+│   ├── broadcast/           # Live-update notices, Redis-backed or process-local
 │   ├── cache/               # Redis wrapper with a no-op fallback
 │   ├── database/            # PostgreSQL + Redis
 │   ├── datevalidation/      # Holidays, weekdays, opening hours

--- a/README.md
+++ b/README.md
@@ -285,17 +285,28 @@ whento/
 │   ├── main.go              # Single entry point
 │   ├── init_cloud.go        # Cloud-specific initialization (tag: cloud)
 │   ├── init_selfhosted.go   # Self-hosted initialization (tag: selfhosted)
-├── internal/                # Business modules
-│   ├── auth/                # JWT RS256, users, sessions
+├── internal/                # Business modules, each {handlers,models,repository,service}
+│   ├── auth/                # JWT RS256, users, sessions, magic links
 │   ├── calendar/            # CRUD, participants
 │   ├── availability/        # Availabilities, recurrences
+│   ├── mfa/                 # TOTP and backup codes
+│   ├── passkey/             # WebAuthn registration and sign-in
+│   ├── notify/              # Threshold notifications, webhooks
 │   ├── ics/                 # iCalendar feed generation
-│   └── quota/               # Calendar limits (both modes)
-├── pkg/                     # Shared packages
-│   ├── cache/               # Redis wrapper
+│   ├── seo/                 # robots.txt and sitemap.xml
+│   ├── config/              # Environment parsing
+│   ├── quota/               # Calendar limits (both modes)
+│   └── testutil/            # Test helpers, including the database harness
+├── pkg/                     # Shared packages, a separate Go module
+│   ├── cache/               # Redis wrapper with a no-op fallback
 │   ├── database/            # PostgreSQL + Redis
+│   ├── datevalidation/      # Holidays, weekdays, opening hours
+│   ├── email/               # SMTP delivery
+│   ├── httputil/            # The {data, error} response envelope
 │   ├── jwt/                 # RS256 token management
-│   ├── middleware/          # Auth, rate limiting, CORS
+│   ├── logger/              # Structured logging with request ids
+│   ├── middleware/          # Auth, rate limiting, CORS, security headers
+│   ├── models/              # Shared entities
 │   └── validator/           # Input validation
 ├── frontend/                # Vue 3 SPA
 │   └── src/
@@ -310,8 +321,8 @@ whento/
 
 | Layer                   | Technology                                         |
 | ----------------------- | -------------------------------------------------- |
-| Backend                 | Go 1.25+, Chi router, pgx/v5, go-redis/v9          |
-| Frontend                | Vue 3, Vite 7, TypeScript, Tailwind CSS 4, Pinia 3 |
+| Backend                 | Go 1.26, Chi router, pgx/v5, go-redis/v9           |
+| Frontend                | Vue 3, Vite 8, TypeScript, Tailwind CSS 4, Pinia 4 |
 | Database                | PostgreSQL 16, Redis 7                             |
 | Auth                    | JWT RS256 (asymmetric keys), bcrypt                |
 | Licensing (Self-hosted) | Ed25519 cryptographic signatures                   |
@@ -381,8 +392,8 @@ your-domain.com {
 
 ### Prerequisites
 
-- Go 1.25+
-- Node.js 20+
+- Go 1.26
+- Node.js 24
 - Docker & Docker Compose
 
 ### Running in Development Mode

--- a/README.md
+++ b/README.md
@@ -269,13 +269,9 @@ TRUSTED_PROXIES=                              # Comma-separated trusted reverse 
 # TOTP_DIGITS=6
 ```
 
-#### Self-Hosted Only (build tag `selfhosted`)
-
-```bash
-# License — leave empty for Community tier (30 calendars).
-# JSON license key; auto-activates at startup if the DB has no license yet.
-# Can also be activated via the Admin UI.
-```
+The two build variants read the same environment. There is nothing to configure that is
+specific to one of them: the only difference is the calendar allowance, which is compiled
+in rather than configured.
 
 ---
 

--- a/migrations/README.md
+++ b/migrations/README.md
@@ -8,11 +8,19 @@ WhenTo uses a conditional migration system to support both Cloud (SaaS) and Self
 migrations/
 ├── common/          # Migrations applied to both cloud and selfhosted
 │   └── 001_init.*   # Initial schema (users, calendars, etc.)
-├── cloud/           # Cloud-only migrations (Stripe subscriptions)
-│   └── 002_subscriptions.*
-└── selfhosted/      # Self-hosted only migrations (License management)
-    └── 003_licenses.*
+├── cloud/           # Cloud-only migrations
+│   ├── 005_ecommerce.*
+│   ├── 011_order_shop_session.*
+│   └── 013_drop_billing.*
+└── selfhosted/      # Self-hosted only migrations
+    ├── 005_licenses.*
+    └── 013_drop_licensing.*
 ```
+
+Both variant directories now exist largely to undo themselves. Licensing, subscriptions
+and payments were removed from the product, and `013_drop_billing` / `013_drop_licensing`
+are what take the tables out of a database that already ran the earlier ones. Neither
+variant has anything left to add on top of `common/`.
 
 ## How It Works
 
@@ -77,11 +85,16 @@ migrate create -ext sql -dir migrations/selfhosted -seq migration_name
 
 ## Migration Naming
 
-- **Common**: `001_init`, `004_add_notifications`, etc.
-- **Cloud**: `002_subscriptions`, `005_stripe_webhooks`, etc.
-- **Self-hosted**: `003_licenses`, `006_license_audit_log`, etc.
+- **Common**: `001_init`, `008_notification_log`, `012_unified_ics_feed`
+- **Cloud**: `005_ecommerce`, `011_order_shop_session`, `013_drop_billing`
+- **Self-hosted**: `005_licenses`, `013_drop_licensing`
 
-> **Note**: Migration numbers should be unique across all directories to avoid conflicts when they're combined.
+> **Note**: the numbering space is shared, but only one variant directory is ever copied
+> into a build, so a number may be reused between `cloud/` and `selfhosted/` — `005` and
+> `013` both are. It must stay unique against `common/`.
+
+The latest common migration is `012`, so **the next common migration is `014`**: `013` is
+taken by the two per-variant drop migrations.
 
 ## Testing
 


### PR DESCRIPTION
Follow-up to #79. These three commits were pushed to that branch a few minutes after it merged, so they never made it in.

## Licensing leftovers

The **"Self-Hosted Only" configuration block documented no variables at all**. Just three comments about a Community tier of 30 calendars, a JSON licence key, and activation through the Admin UI — none of which have existed since #60 removed licensing.

Checking whether anything else referred to it turned up something worse. `migrations/README.md` cited `002_subscriptions`, `003_licenses`, `005_stripe_webhooks` and `006_license_audit_log`. **None of those files has ever existed.** What is actually on disk:

| | |
| --- | --- |
| `cloud/` | `005_ecommerce`, `011_order_shop_session`, `013_drop_billing` |
| `selfhosted/` | `005_licenses`, `013_drop_licensing` |

Both variant directories now exist largely to undo themselves. That is worth saying, along with the numbering rule that is easy to get wrong and expensive to discover: the space is shared, but only one variant directory is ever copied into a build, so a number may be reused between `cloud/` and `selfhosted/` — `005` and `013` both are. The next common migration is `014`.

## Four stale versions

| README said | Actually |
| --- | --- |
| Go 1.25+ | **Go 1.26** — `go.mod` and all three CI jobs |
| Node.js 20+ | **Node 24** — CI |
| Vite 7 | **Vite 8** |
| Pinia 3 | **Pinia 4** |

`CLAUDE.md` had these right, so the README was the only thing telling a contributor to install the wrong toolchain. PostgreSQL 16 and Redis 7 were checked against the compose files and are correct, and every `make` target and npm script the README cites exists.

## The module map

It listed 5 of the 11 `internal/` modules and 5 of the 10 `pkg/` packages. MFA, passkeys, notifications, SEO, config and the test utilities were all missing, as were `datevalidation`, `email`, `httputil`, `logger` and `models` — most of what a newcomer would go looking for.

`pkg/broadcast` is in its own commit: it was deliberately left out of the first pass because it only existed in #78 at the time, and documenting a package that was not yet in `main` would have been the same class of mistake this PR is fixing.

## Still outstanding, deliberately not here

Two error messages in [`calendar_handler.go`](https://github.com/When-To/whento/blob/main/internal/calendar/handlers/calendar_handler.go#L179-L187) still talk about licences and subscriptions:

- *"Server calendar limit reached. Please upgrade your **license** at whento.be/pricing"* — unreachable: self-hosted `CanCreateCalendar` always returns `true`, and `GetServerLimit` returns 0.
- *"Calendar limit reached for your plan. Please upgrade your **subscription**."* — **reachable**. It is what a cloud user sees on their fourth calendar, and there is no subscription and no pricing page any more.

Those are user-visible strings, so a behaviour change rather than a documentation one.