### PR TITLE
fix(calendar): stop offering a subscription that no longer exists

### DIFF
--- a/internal/calendar/handlers/calendar_handler.go
+++ b/internal/calendar/handlers/calendar_handler.go
@@ -6,6 +6,7 @@ package handlers
 
 import (
 	"errors"
+	"fmt"
 	"net/http"
 
 	"github.com/go-chi/chi/v5"
@@ -63,6 +64,27 @@ func NewCalendarHandler(
 //	@Failure		401		{object}	httputil.ErrorResponse	"Unauthorized"
 //	@Failure		403		{object}	httputil.ErrorResponse	"Quota exceeded"
 //	@Router			/api/v1/calendars [post]
+//
+// quotaMessage explains a refused calendar creation.
+//
+// Only the hosted service caps anything: the self-hosted build reports an unlimited
+// allowance and never refuses, so a positive limit means this is the cloud. Saying how
+// many, and what the way out is, beats a bare refusal — and the way out is running your
+// own instance, since there is no paid tier to move to.
+//
+// Extracted so it can be tested: the handler around it takes a database transaction
+// before it ever reaches here. The message it replaced ("upgrade your subscription", and
+// on the other branch "upgrade your license") outlived both by a good margin.
+func quotaMessage(limit int) string {
+	if limit <= 0 {
+		return "Calendar limit reached."
+	}
+
+	return fmt.Sprintf(
+		"You have reached the limit of %d calendars on the hosted service. "+
+			"Host your own instance of WhenTo for unlimited calendars.", limit)
+}
+
 func (h *CalendarHandler) CreateCalendar(w http.ResponseWriter, r *http.Request) {
 	userID := middleware.GetUserID(r.Context())
 	if userID == "" {
@@ -172,22 +194,9 @@ func (h *CalendarHandler) CreateCalendar(w http.ResponseWriter, r *http.Request)
 	}
 
 	if !canCreate {
-		// Get limit info for better error message
-		userLimit, _ := h.quotaService.GetUserLimit(r.Context(), userUUID)
-		serverLimit, _ := h.quotaService.GetServerLimit(r.Context())
+		limit, _ := h.quotaService.GetUserLimit(r.Context(), userUUID)
 
-		var errorMsg string
-		if serverLimit > 0 {
-			// Self-hosted: server-wide limit
-			errorMsg = "Server calendar limit reached. Please upgrade your license at https://whento.be/pricing"
-		} else if userLimit > 0 {
-			// Cloud: per-user limit
-			errorMsg = "Calendar limit reached for your plan. Please upgrade your subscription."
-		} else {
-			errorMsg = "Calendar limit reached"
-		}
-
-		httputil.Error(w, http.StatusForbidden, "quota_exceeded", errorMsg)
+		httputil.Error(w, http.StatusForbidden, "quota_exceeded", quotaMessage(limit))
 		return
 	}
 

--- a/internal/calendar/handlers/calendar_handler_test.go
+++ b/internal/calendar/handlers/calendar_handler_test.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
@@ -332,7 +333,7 @@ func TestCalendarHandler_CreateCalendar_QuotaExceeded(t *testing.T) {
 	mockCalRepo := &mockCalendarRepository{}
 	mockPartRepo := &mockParticipantRepository{}
 	mockCache := &mockCache{}
-	mockQuota := &mockQuotaService{canCreate: false} // Quota exceeded
+	mockQuota := &mockQuotaService{canCreate: false, userLimit: 3} // Quota exceeded
 
 	calendarSvc := service.NewCalendarService(mockCalRepo, mockPartRepo, nil, mockCache)
 	cfg := &config.Config{Email: config.EmailConfig{VerificationEnabled: false}}
@@ -350,6 +351,20 @@ func TestCalendarHandler_CreateCalendar_QuotaExceeded(t *testing.T) {
 
 	if w.Code != http.StatusForbidden {
 		t.Errorf("Expected status 403, got %d: %s", w.Code, w.Body.String())
+	}
+
+	// The frontend prints this message verbatim, so what it says is the whole of what a
+	// blocked user is told. quota_message_test.go covers the wording; this is the half
+	// that proves it reaches the response at all.
+	body := w.Body.String()
+	if !strings.Contains(body, "3 calendars") {
+		t.Errorf("the response does not say what the limit is: %s", body)
+	}
+	if !strings.Contains(body, "Host your own instance") {
+		t.Errorf("the response does not offer the way out: %s", body)
+	}
+	if strings.Contains(strings.ToLower(body), "subscription") || strings.Contains(strings.ToLower(body), "licen") {
+		t.Errorf("the response still offers something the product no longer has: %s", body)
 	}
 }
 

--- a/internal/calendar/handlers/quota_message_test.go
+++ b/internal/calendar/handlers/quota_message_test.go
@@ -1,0 +1,96 @@
+// WhenTo - Collaborative event calendar for self-hosted environments
+// Copyright (C) 2025 WhenTo Contributors
+// SPDX-License-Identifier: BSL-1.1
+
+package handlers
+
+import (
+	"strings"
+	"testing"
+)
+
+// This message is the only thing a user gets when their fourth calendar is refused, and
+// the frontend shows it verbatim. It is worth a test because the string it replaced
+// outlived the thing it described: "please upgrade your subscription" survived the
+// removal of subscriptions, and "upgrade your license at whento.be/pricing" survived the
+// removal of licensing and of that page.
+
+func TestQuotaMessage(t *testing.T) {
+	tests := []struct {
+		name  string
+		limit int
+		wants []string
+	}{
+		{
+			name:  "the hosted limit",
+			limit: 3,
+			// The number matters: "limit reached" without it leaves the user guessing
+			// whether they are one over or ten.
+			wants: []string{"3", "hosted service", "Host your own instance"},
+		},
+		{
+			name:  "a different hosted limit",
+			limit: 10,
+			wants: []string{"10"},
+		},
+		{
+			// Self-hosted reports an unlimited allowance and never refuses, so this is
+			// unreachable today. It stays a plain sentence rather than an invitation to
+			// self-host, which would be absurd advice to someone already doing it.
+			name:  "no limit configured",
+			limit: 0,
+			wants: []string{"Calendar limit reached."},
+		},
+		{
+			name:  "a negative limit",
+			limit: -1,
+			wants: []string{"Calendar limit reached."},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := quotaMessage(tt.limit)
+
+			for _, want := range tt.wants {
+				if !strings.Contains(got, want) {
+					t.Errorf("message = %q, want it to mention %q", got, want)
+				}
+			}
+		})
+	}
+}
+
+// TestQuotaMessageOffersNothingThatDoesNotExist is the guard that would have caught the
+// two strings this replaced. There is no paid plan, no licence key and no pricing page;
+// pointing a blocked user at any of them sends them somewhere that does not exist.
+func TestQuotaMessageOffersNothingThatDoesNotExist(t *testing.T) {
+	for _, limit := range []int{-1, 0, 1, 3, 100} {
+		message := strings.ToLower(quotaMessage(limit))
+
+		for _, gone := range []string{"licen", "subscription", "upgrade", "plan", "pricing", "whento.be"} {
+			if strings.Contains(message, gone) {
+				t.Errorf("limit %d yields %q, which offers %q — removed from the product", limit, message, gone)
+			}
+		}
+	}
+}
+
+// TestQuotaMessageIsSelfContained keeps it usable. The frontend prints it as-is, with no
+// formatting of its own, so an unresolved verb or a stray newline lands in front of the
+// user.
+func TestQuotaMessageIsSelfContained(t *testing.T) {
+	for _, limit := range []int{0, 3} {
+		message := quotaMessage(limit)
+
+		if strings.Contains(message, "%!") {
+			t.Errorf("limit %d left an unresolved format verb: %q", limit, message)
+		}
+		if strings.ContainsAny(message, "\n\r\t") {
+			t.Errorf("limit %d produced a message with whitespace control characters: %q", limit, message)
+		}
+		if !strings.HasSuffix(strings.TrimSpace(message), ".") {
+			t.Errorf("limit %d produced %q, which is not a finished sentence", limit, message)
+		}
+	}
+}


### PR DESCRIPTION
A cloud user reaching their fourth calendar was told:

> Calendar limit reached for your plan. Please upgrade your **subscription**.

There is no plan to be on and no subscription to upgrade. #60 removed licensing, subscriptions and payments, and this string outlived all three — so the one sentence a blocked user reads pointed them at nothing.

**Now:**

> You have reached the limit of 3 calendars on the hosted service. Host your own instance of WhenTo for unlimited calendars.

It says how many, and what the actual way out is.

## The other branch went with it

It read *"Server calendar limit reached. Please upgrade your **license** at https://whento.be/pricing"* and was unreachable twice over: self-hosted `CanCreateCalendar` always returns `true`, and its server limit is zero. It named a licence, a pricing page and a product tier, none of which exist.

## Tests

The message moved into a `quotaMessage` function so it can be tested at all — the handler around it opens a database transaction before it ever gets there.

This string survived a whole feature removal unnoticed, so one of the tests holds the **class** rather than the line: it fails on any message mentioning a licence, a subscription, an upgrade, a plan, a pricing page or whento.be.

Confirmed by putting the old wording back:

```
--- FAIL: TestQuotaMessage
    want it to mention "hosted service"
    want it to mention "Host your own instance"
--- FAIL: TestQuotaMessageOffersNothingThatDoesNotExist
    ... which offers "subscription" — removed from the product
    ... which offers "upgrade" — removed from the product
    ... which offers "plan" — removed from the product
```

The pre-existing `TestCalendarHandler_CreateCalendar_QuotaExceeded` only checked for a 403. It now also asserts what the body says, since the frontend prints that message verbatim — `error.message` straight into the alert, no translation layer in between.

## Verified end to end

Against the **cloud** build with a real database:

```
calendrier 1 -> 201 créé
calendrier 2 -> 201 créé
calendrier 3 -> 201 créé
calendrier 4 -> 403 {"code":"quota_exceeded","message":"You have reached the limit of 3
                     calendars on the hosted service. Host your own instance of WhenTo
                     for unlimited calendars."}
```

`make test` and `make test BUILD_TYPE=cloud` both clean, both variants build.

## Worth knowing

These backend messages are English only — there is no i18n on API error strings, and the frontend shows them as they arrive. A French user sees English here. That is pre-existing and out of scope, but it is the reason this wording had to be plain.