### PR TITLE
chore(deps): apply the same pins to the Dockerfiles CI actually builds

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -70,9 +70,15 @@ updates:
       actions:
         patterns: ['*']
 
-  # ── Image tags in the production and devcontainer Dockerfiles ───────────
+  # ── Image tags in every Dockerfile ──────────────────────────────────────
+  # build/selfhosted and build/cloud are the ones CI and the release workflow
+  # actually build; the root Dockerfile only backs the make docker-* targets.
   - package-ecosystem: docker
-    directories: ['/', '/.devcontainer']
+    directories:
+      - /
+      - /.devcontainer
+      - /build/selfhosted
+      - /build/cloud
     schedule:
       interval: weekly
       day: monday

--- a/.github/workflows/build-cloud.yml
+++ b/.github/workflows/build-cloud.yml
@@ -61,7 +61,7 @@ jobs:
           go-version: '1.26'
 
       - name: Install swag CLI
-        run: go install github.com/swaggo/swag/cmd/swag@latest
+        run: go install github.com/swaggo/swag/cmd/swag@v1.16.6
 
       - name: Generate Swagger docs
         run: swag init -g cmd/main.go -o docs/swagger --parseInternal --generatedTime=false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,7 +97,7 @@ jobs:
           go-version: '1.26'
 
       - name: Install swag CLI
-        run: go install github.com/swaggo/swag/cmd/swag@latest
+        run: go install github.com/swaggo/swag/cmd/swag@v1.16.6
 
       - name: Generate Swagger docs
         run: swag init -g cmd/main.go -o docs/swagger --parseInternal --generatedTime=false

--- a/.github/workflows/release-selfhosted.yml
+++ b/.github/workflows/release-selfhosted.yml
@@ -67,7 +67,7 @@ jobs:
           go-version: '1.26'
 
       - name: Install swag CLI
-        run: go install github.com/swaggo/swag/cmd/swag@latest
+        run: go install github.com/swaggo/swag/cmd/swag@v1.16.6
 
       - name: Generate Swagger docs
         run: swag init -g cmd/main.go -o docs/swagger --parseInternal --generatedTime=false

--- a/build/cloud/Dockerfile
+++ b/build/cloud/Dockerfile
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
 
 # Build stage
-FROM golang:1.26-alpine3.23 AS builder
+FROM golang:1.26-alpine3.24 AS builder
 
 WORKDIR /build
 
@@ -34,18 +34,18 @@ RUN go build \
     ./cmd/
 
 # Download migrate CLI (use BUILDPLATFORM to avoid QEMU issues)
-FROM --platform=$BUILDPLATFORM alpine:3.23 AS migrate-builder
+FROM --platform=$BUILDPLATFORM alpine:3.24 AS migrate-builder
 
 ARG TARGETARCH
 
 # Download golang-migrate binary for target architecture
 RUN apk add --no-cache curl && \
-    curl -fsSL https://github.com/golang-migrate/migrate/releases/download/v4.17.0/migrate.linux-${TARGETARCH}.tar.gz | tar xvz && \
+    curl -fsSL https://github.com/golang-migrate/migrate/releases/download/v4.19.1/migrate.linux-${TARGETARCH}.tar.gz | tar xvz && \
     mv migrate /usr/local/bin/migrate && \
     chmod +x /usr/local/bin/migrate
 
 # Runtime stage
-FROM alpine:3.23
+FROM alpine:3.24
 
 # Install runtime dependencies
 RUN apk add --no-cache ca-certificates tzdata openssl postgresql-client

--- a/build/selfhosted/Dockerfile
+++ b/build/selfhosted/Dockerfile
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
 
 # Build stage
-FROM golang:1.26-alpine3.23 AS builder
+FROM golang:1.26-alpine3.24 AS builder
 
 WORKDIR /build
 
@@ -34,18 +34,18 @@ RUN go build \
     ./cmd/
 
 # Download migrate CLI (use BUILDPLATFORM to avoid QEMU issues)
-FROM --platform=$BUILDPLATFORM alpine:3.23 AS migrate-builder
+FROM --platform=$BUILDPLATFORM alpine:3.24 AS migrate-builder
 
 ARG TARGETARCH
 
 # Download golang-migrate binary for target architecture
 RUN apk add --no-cache curl && \
-    curl -fsSL https://github.com/golang-migrate/migrate/releases/download/v4.17.0/migrate.linux-${TARGETARCH}.tar.gz | tar xvz && \
+    curl -fsSL https://github.com/golang-migrate/migrate/releases/download/v4.19.1/migrate.linux-${TARGETARCH}.tar.gz | tar xvz && \
     mv migrate /usr/local/bin/migrate && \
     chmod +x /usr/local/bin/migrate
 
 # Runtime stage
-FROM alpine:3.23
+FROM alpine:3.24
 
 LABEL org.opencontainers.image.title="WhenTo" \
     org.opencontainers.image.description="Self-hosted scheduling and calendar application" \


### PR DESCRIPTION
## Pourquoi

Suite de #82, qui a raté sa cible sur un point : mon inventaire des Dockerfiles était limité à `find -maxdepth 2` et n'a vu que `Dockerfile` et `.devcontainer/Dockerfile`. Il en existe deux autres, `build/selfhosted/Dockerfile` et `build/cloud/Dockerfile`, et ce sont **eux** que construisent la CI et la release :

| Fichier | Utilisé par |
|---|---|
| `Dockerfile` (racine) | cibles `make docker-build*` uniquement |
| `build/selfhosted/Dockerfile` | `ci.yml` (job `build-dev-image`), `release-selfhosted.yml` |
| `build/cloud/Dockerfile` | `build-cloud.yml` |

Résultat : #82 a bien épinglé le Dockerfile racine, mais **les images réellement publiées étaient inchangées** — toujours Alpine 3.23 et golang-migrate v4.17.0. Le fait que la CI de #82 soit passée au vert ne prouvait rien sur ce point : elle construisait `build/selfhosted/Dockerfile`, que #82 ne touchait pas.

## Contenu

- `build/selfhosted/Dockerfile` et `build/cloud/Dockerfile` : Alpine 3.23 → 3.24, `golang:1.26-alpine3.23` → `alpine3.24`, golang-migrate v4.17.0 → v4.19.1. Alignés sur le Dockerfile racine.
- `ci.yml`, `build-cloud.yml`, `release-selfhosted.yml` : `swag@latest` → `swag@v1.16.6`. Les images de `build/` embarquent l'artefact swagger produit par ces workflows, donc c'était cette version-là qui partait réellement en production — le pin du Dockerfile racine ne couvrait pas ce chemin.
- `dependabot.yml` : l'écosystème `docker` ne surveillait que `/` et `/.devcontainer`. Il couvre maintenant aussi `/build/selfhosted` et `/build/cloud`, c'est-à-dire précisément les fichiers où une dérive passe inaperçue.

## Vérification

Le YAML des 4 workflows et de `dependabot.yml` parse. Le sweep `alpine:3.23 | v4.17.0 | swag@latest` ne remonte plus rien dans le repo.

Le vrai test reste la CI de cette PR : contrairement à #82, le job `build-dev-image` construit cette fois un fichier que la PR modifie, donc un vert ici valide réellement Alpine 3.24 et migrate v4.19.1.

## Note hors périmètre

Les deux fichiers de `build/` portent `SPDX-License-Identifier: AGPL-3.0-or-later` alors que le projet est en BSL-1.1 (`Dockerfile` racine et `LICENSE`). Je ne l'ai pas touché — signalé au cas où ce serait un reliquat.
