### PR TITLE
fix: correct six production defects surfaced by a technical audit

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -71,6 +71,12 @@ REDIS_PORT=6379
 
 # ------------------------------------------------------------------------------
 # JWT - Keys are auto-generated on first container start
+#
+# The key pair MUST persist across restarts and container recreations: a new pair
+# invalidates every access and refresh token, logging out every signed-in user.
+# The official docker-compose.yml keeps it in the named volume `whento_keys`
+# mounted on /app/keys (the paths below are the ones used outside Docker).
+# Participant calendar links are unaffected — they authorise by the link itself.
 # ------------------------------------------------------------------------------
 JWT_PRIVATE_KEY_PATH=keys/private.pem
 JWT_PUBLIC_KEY_PATH=keys/public.pem
@@ -131,6 +137,14 @@ TRUSTED_PROXIES=
 # Rate Limiting
 # ------------------------------------------------------------------------------
 RATE_LIMIT_ENABLED=true
+
+# Salt used to derive rate limit bucket names. Buckets are stored hashed, so
+# Redis never holds an IP address, a calendar token or a participant id.
+# Leave empty for a single instance: one is then generated per process.
+# Running several instances against the SAME Redis requires setting this to an
+# identical secret everywhere — otherwise each instance keeps its own buckets
+# and N instances grant N times the configured allowance.
+# RATE_LIMIT_KEY_SALT=
 
 # ------------------------------------------------------------------------------
 # Docker build argument (not consumed at runtime)

--- a/Dockerfile
+++ b/Dockerfile
@@ -50,11 +50,18 @@ RUN swag init -g cmd/main.go -o docs/swagger --parseInternal --generatedTime=fal
 RUN chmod +x scripts/build-migrations.sh && \
     sh scripts/build-migrations.sh selfhosted ./migrations-build
 
-# Build with selfhosted tag
+# Build with selfhosted tag.
+#
+# The -X targets must match the variables declared in cmd/buildinfo.go: the linker
+# silently ignores -X for an unknown symbol, so a typo here costs nothing at build
+# time and reports "dev" forever at runtime.
+# The build type is not injected — it comes from the -tags value above.
 ARG VERSION=dev
+ARG BUILD_DATE=unknown
+ARG VCS_REF=unknown
 RUN go build \
     -tags selfhosted \
-    -ldflags "-X main.Version=${VERSION} -X main.BuildType=selfhosted" \
+    -ldflags "-X main.Version=${VERSION} -X main.BuildDate=${BUILD_DATE} -X main.VCSRef=${VCS_REF}" \
     -o whento \
     ./cmd/
 

--- a/README.md
+++ b/README.md
@@ -368,6 +368,38 @@ SMTP_FROM=whento@example.com
 
 > **Note:** with this compose file, `DATABASE_URL` and `REDIS_URL` are constructed automatically from `DB_*` / `REDIS_PASSWORD`. Setting them directly in `.env` has no effect here — they only apply to standalone / binary deployments.
 
+### JWT signing keys must be persisted
+
+On first start the container generates an RSA-4096 key pair in `/app/keys` and signs
+every access and refresh token with it. **That directory has to survive container
+recreation.** If it does not, a new key pair is minted on the next start, every token
+already issued stops verifying, and every signed-in user is logged out — on an image
+update, on an `.env` change, on anything that makes Compose recreate the container.
+
+The shipped `docker-compose.yml` handles this with a named volume:
+
+```yaml
+services:
+  app:
+    volumes:
+      - whento_keys:/app/keys
+
+volumes:
+  whento_keys:
+    driver: local
+```
+
+Consequences worth knowing:
+
+- **Back up `whento_keys` alongside the database.** Restoring the database without the
+  keys works, but logs everyone out.
+- **Deleting the volume is the way to rotate the keys** — a deliberate, global logout.
+- **Calendar participant links are not affected.** They authorise by possession of the
+  link itself, not by a signed token, so they keep working across a key rotation.
+- Running the binary outside Docker: point `JWT_PRIVATE_KEY_PATH` /
+  `JWT_PUBLIC_KEY_PATH` at a directory that persists across deployments, and keep the
+  private key at mode `600`.
+
 ### Building from Source
 
 ```bash
@@ -386,6 +418,12 @@ your-domain.com {
     reverse_proxy localhost:8080
 }
 ```
+
+Behind a proxy, set `TRUSTED_PROXIES` to the address the proxy connects from (for the
+compose stack, the Docker bridge range, e.g. `172.16.0.0/12`). `X-Forwarded-For` and
+`X-Real-IP` are ignored for every other source, by design: believing them
+unconditionally would let any client choose its own rate-limit bucket. Until it is set,
+per-IP rate limits count all proxied traffic as one client.
 
 ---
 

--- a/build/cloud/Dockerfile
+++ b/build/cloud/Dockerfile
@@ -25,11 +25,18 @@ COPY frontend/dist ./web/dist
 RUN chmod +x scripts/build-migrations.sh && \
     sh scripts/build-migrations.sh cloud ./migrations-build
 
-# Build with cloud tag
+# Build with cloud tag.
+#
+# The -X targets must match the variables declared in cmd/buildinfo.go: the linker
+# silently ignores -X for an unknown symbol, so a typo here costs nothing at build
+# time and reports "dev" forever at runtime.
+# The build type is not injected — it comes from the -tags value above.
 ARG VERSION=dev
+ARG BUILD_DATE=unknown
+ARG VCS_REF=unknown
 RUN go build \
     -tags cloud \
-    -ldflags "-X main.Version=${VERSION} -X main.BuildType=cloud" \
+    -ldflags "-X main.Version=${VERSION} -X main.BuildDate=${BUILD_DATE} -X main.VCSRef=${VCS_REF}" \
     -o whento \
     ./cmd/
 

--- a/build/selfhosted/Dockerfile
+++ b/build/selfhosted/Dockerfile
@@ -25,11 +25,18 @@ COPY frontend/dist ./web/dist
 RUN chmod +x scripts/build-migrations.sh && \
     sh scripts/build-migrations.sh selfhosted ./migrations-build
 
-# Build with selfhosted tag
+# Build with selfhosted tag.
+#
+# The -X targets must match the variables declared in cmd/buildinfo.go: the linker
+# silently ignores -X for an unknown symbol, so a typo here costs nothing at build
+# time and reports "dev" forever at runtime.
+# The build type is not injected — it comes from the -tags value above.
 ARG VERSION=dev
+ARG BUILD_DATE=unknown
+ARG VCS_REF=unknown
 RUN go build \
     -tags selfhosted \
-    -ldflags "-X main.Version=${VERSION} -X main.BuildType=selfhosted" \
+    -ldflags "-X main.Version=${VERSION} -X main.BuildDate=${BUILD_DATE} -X main.VCSRef=${VCS_REF}" \
     -o whento \
     ./cmd/
 

--- a/cmd/buildinfo.go
+++ b/cmd/buildinfo.go
@@ -1,0 +1,40 @@
+// WhenTo - Collaborative event calendar for self-hosted environments
+// Copyright (C) 2025 WhenTo Contributors
+// SPDX-License-Identifier: BSL-1.1
+
+package main
+
+import "log/slog"
+
+// Build metadata, injected at link time:
+//
+//	go build -ldflags "-X main.Version=1.6.3 -X main.BuildDate=... -X main.VCSRef=..."
+//
+// These have to be package-level string variables with constant initializers: the
+// linker silently ignores -X for a symbol it cannot find, which is exactly how every
+// released image ended up reporting nothing at all.
+//
+// The build variant is deliberately not injectable. It is decided by the build tag
+// (buildType, in init_cloud.go / init_selfhosted.go), so it can never disagree with
+// the code that was actually compiled.
+var (
+	// Version is the release version, e.g. "1.6.3". "dev" for unversioned builds.
+	Version = "dev"
+
+	// BuildDate is the RFC 3339 UTC timestamp of the build.
+	BuildDate = "unknown"
+
+	// VCSRef is the git commit the binary was built from.
+	VCSRef = "unknown"
+)
+
+// logBuildInfo records what this binary actually is, once, at startup. It is the
+// only place the four values are reported, so a bug report can be tied to a commit.
+func logBuildInfo(log *slog.Logger) {
+	log.Info("WhenTo build info",
+		"version", Version,
+		"build_type", buildType,
+		"build_date", BuildDate,
+		"vcs_ref", VCSRef,
+	)
+}

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: BSL-1.1
 
 //	@title						WhenTo API
-//	@version					1.0.0
+//	@version					1.6.3
 //	@description				WhenTo is a self-hosted web application for organizing events among friends through collaborative calendars.
 //	@description				Each calendar answers a simple question: **when can we meet?** Participants indicate their availability, and time slots reaching a defined threshold become events accessible via an **iCalendar subscription URL** — automatic synchronization in Google Calendar, Apple Calendar, Outlook, etc.
 //	@description
@@ -18,6 +18,7 @@
 //	@description				- **Public auth endpoints**: 3-5 requests/minute/IP
 //	@description				- **Public calendar endpoints**: 60 requests/minute/IP
 //	@description				- **ICS feed endpoints**: 30 requests/minute/IP
+//	@description				- **Live availability stream (SSE)**: 300 connections/minute/IP per calendar
 //	@description				- **Authenticated endpoints**: 100 requests/minute/user
 //	@description
 //	@description				Rate limit headers are included in responses: `X-RateLimit-Limit`, `X-RateLimit-Remaining`, `X-RateLimit-Reset`
@@ -50,7 +51,6 @@ import (
 	"time"
 
 	"github.com/go-chi/chi/v5"
-	chiMiddleware "github.com/go-chi/chi/v5/middleware"
 	httpSwagger "github.com/swaggo/http-swagger/v2"
 
 	"github.com/whento/pkg/broadcast"
@@ -105,7 +105,7 @@ import (
 	"github.com/whento/whento/web"
 
 	// Swagger docs (generated)
-	_ "github.com/whento/whento/docs/swagger"
+	swaggerDocs "github.com/whento/whento/docs/swagger"
 )
 
 func main() {
@@ -122,7 +122,13 @@ func main() {
 		os.Exit(1)
 	}
 
+	logBuildInfo(log)
 	log.Info("Starting WhenTo Application", "port", cfg.Port, "env", cfg.AppEnv)
+
+	// The generated spec carries the version frozen into the annotation at the last
+	// `make swagger`; the linker knows the real one. Overriding it here keeps
+	// /swagger honest for the binary that is serving it.
+	swaggerDocs.SwaggerInfo.Version = Version
 
 	// Context for initialization
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
@@ -343,7 +349,19 @@ func main() {
 	availabilityHandler := availabilityHandlers.NewAvailabilityHandler(availabilitySvc)
 	recurrenceHandler := availabilityHandlers.NewRecurrenceHandler(availabilitySvc)
 
-	// Initialize rate limiter
+	// Initialize rate limiter.
+	//
+	// Buckets are stored under a salted hash so that Redis never holds an IP, a
+	// calendar token or a participant id. That salt has to be shared by every
+	// instance pointing at the same Redis: with a per-process one, the same
+	// client hashes to a different bucket on each instance and N instances hand
+	// out N times the configured allowance. A single instance is unaffected,
+	// which is why an empty salt is allowed rather than fatal.
+	middleware.SetRateLimitKeySalt(cfg.RateLimitKeySalt)
+	if cfg.RateLimitEnabled && cfg.RateLimitKeySalt == "" && redisClient != nil {
+		log.Warn("RATE_LIMIT_KEY_SALT is unset; rate limit buckets are per-instance. " +
+			"Set it to a shared secret if more than one instance uses this Redis.")
+	}
 	rateLimiter := middleware.NewRateLimiter(redisClient)
 
 	// Live calendar updates. Redis fans the notices out across instances; without it a
@@ -356,8 +374,15 @@ func main() {
 	// Setup router
 	r := chi.NewRouter()
 
-	// Global middleware
-	r.Use(chiMiddleware.RealIP)
+	// Global middleware.
+	//
+	// chi's RealIP is deliberately absent, and must stay absent: it overwrites
+	// r.RemoteAddr from X-Forwarded-For / X-Real-IP for *every* request, before
+	// anything gets to ask whether the connection came from a trusted proxy. That
+	// turns TRUSTED_PROXIES (below) into decoration and makes every per-IP rate
+	// limit a client-chosen header away from being bypassed. Proxy headers are
+	// honoured in exactly one place instead — middleware.IPKeyFunc — and only for
+	// connections that actually originate from a configured proxy.
 	r.Use(middleware.RequestID)
 	r.Use(middleware.Logger)
 	r.Use(middleware.Recoverer)
@@ -674,6 +699,27 @@ func main() {
 
 	// ========== AVAILABILITY ROUTES ==========
 	r.Route("/api/v1/availabilities", func(r chi.Router) {
+		// Live updates: the browser subscribes here and refetches on each notice.
+		//
+		// Kept out of the 60/min bucket below. An EventSource is a long-lived
+		// connection that the browser re-establishes on its own after every hiccup,
+		// deploy or idle timeout, so sharing a bucket with the participant API meant
+		// a handful of reconnects could lock a participant out of the calendar they
+		// were reconnecting to. Its own bucket, keyed on path+IP so one calendar's
+		// reconnect loop cannot starve another, and sized for several tabs behind a
+		// shared NAT rather than for API call volume.
+		r.Group(func(r chi.Router) {
+			if cfg.RateLimitEnabled {
+				r.Use(rateLimiter.Limit(middleware.RateLimitConfig{
+					Requests: 300,
+					Window:   time.Minute,
+					KeyFunc:  middleware.CombinedKeyFunc,
+				}))
+			}
+
+			r.Get("/calendar/{token}/events", eventsHandler.Stream)
+		})
+
 		// Public routes with rate limiting (all availability endpoints are public)
 		r.Group(func(r chi.Router) {
 			if cfg.RateLimitEnabled {
@@ -689,9 +735,6 @@ func main() {
 			// rather than in the nine service methods so a tenth write route cannot
 			// silently stop notifying anyone.
 			r.Use(availabilityHandlers.PublishChanges(broker))
-
-			// Live updates: the browser subscribes here and refetches on each notice.
-			r.Get("/calendar/{token}/events", eventsHandler.Stream)
 
 			// Participant availability management
 			r.Get("/calendar/{token}/participant/{pid}", availabilityHandler.GetParticipantAvailabilities)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -42,6 +42,14 @@ services:
       - EMAIL_VERIFICATION_ENABLED=${EMAIL_VERIFICATION_ENABLED:-true}
       - ALLOWED_REGISTER=${ALLOWED_REGISTER:-true}
       - ALLOWED_EMAILS=${ALLOWED_EMAILS:-*}
+    volumes:
+      # The JWT signing keys are generated on first start by the entrypoint. Without
+      # this volume they live in the container's writable layer, so every `docker
+      # compose up` that recreates the container (image update, changed env var)
+      # mints a new key pair and invalidates every issued token: all users are
+      # logged out. Participant links are unaffected — they authorise by the link
+      # itself, not by a signed token.
+      - whento_keys:/app/keys
     depends_on:
       postgres:
         condition: service_healthy
@@ -97,6 +105,9 @@ volumes:
   postgres_data:
     driver: local
   redis_data:
+    driver: local
+  # JWT signing keys. Deleting this volume logs every user out.
+  whento_keys:
     driver: local
 
 networks:

--- a/frontend/src/components/CalendarSidebar.vue
+++ b/frontend/src/components/CalendarSidebar.vue
@@ -158,13 +158,13 @@ function close() {
 }
 
 function handleRemove(token: string) {
-  if (confirm(t('calendar.confirmRemoveHistory', 'Remove this calendar from history?'))) {
+  if (confirm(t('calendar.confirmRemoveHistory'))) {
     historyStore.removeCalendar(token);
   }
 }
 
 function handleClearAll() {
-  if (confirm(t('calendar.confirmClearHistory', 'Clear all history?'))) {
+  if (confirm(t('calendar.confirmClearHistory'))) {
     historyStore.clearHistory();
     close();
   }

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -422,6 +422,8 @@
     "saturday": "Saturday",
     "availabilityAdded": "Availability added",
     "availabilityDeleted": "Availability deleted",
+    "confirmDelete": "Delete this availability?",
+    "confirmDeleteRecurrence": "Delete this recurrence?",
     "created": "Availability created",
     "deleted": "Availability deleted",
     "updated": "Availability updated",

--- a/frontend/src/locales/fr.json
+++ b/frontend/src/locales/fr.json
@@ -422,6 +422,8 @@
     "saturday": "Samedi",
     "availabilityAdded": "Disponibilité ajoutée",
     "availabilityDeleted": "Disponibilité supprimée",
+    "confirmDelete": "Supprimer cette disponibilité ?",
+    "confirmDeleteRecurrence": "Supprimer cette récurrence ?",
     "created": "Disponibilité créée",
     "deleted": "Disponibilité supprimée",
     "updated": "Disponibilité modifiée",

--- a/frontend/src/views/ParticipantView.vue
+++ b/frontend/src/views/ParticipantView.vue
@@ -1950,7 +1950,7 @@ async function loadParticipantCounts(year?: number, month?: number) {
 }
 
 async function handleDeleteAvailability(date: string) {
-  if (!confirm(t('common.delete', 'Delete this availability?'))) return;
+  if (!confirm(t('availability.confirmDelete'))) return;
 
   try {
     await availabilitiesApi.delete(token.value, participantId.value, date);
@@ -1998,7 +1998,7 @@ async function handleAddRecurrence() {
 }
 
 async function handleDeleteRecurrence(recurrenceId: string) {
-  if (!confirm(t('common.delete', 'Delete this recurrence?'))) return;
+  if (!confirm(t('availability.confirmDeleteRecurrence'))) return;
 
   try {
     await availabilitiesApi.deleteRecurrence(token.value, participantId.value, recurrenceId);

--- a/internal/auth/handlers/auth_handler_context_test.go
+++ b/internal/auth/handlers/auth_handler_context_test.go
@@ -1,0 +1,128 @@
+// WhenTo - Collaborative event calendar for self-hosted environments
+// Copyright (C) 2025 WhenTo Contributors
+// SPDX-License-Identifier: BSL-1.1
+
+package handlers_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/whento/whento/internal/auth/models"
+	"github.com/whento/whento/internal/auth/service"
+)
+
+// The refresh-token insert used to run under context.Background(), so a request the
+// client had already abandoned still wrote a row. These tests drive the real handlers
+// with a dead *http.Request context and check that the write is refused and the
+// endpoint answers 500 rather than handing out a token pair.
+//
+// mockTokenRepository ignores its context — that is what hid the defect — so the
+// repository below refuses to write once the context is done, the way the pgx-backed
+// one does.
+
+type contextAwareTokenRepository struct {
+	mockTokenRepository
+
+	creates   int
+	createCtx context.Context
+}
+
+var _ service.TokenRepository = (*contextAwareTokenRepository)(nil)
+
+func (m *contextAwareTokenRepository) Create(ctx context.Context, token *models.RefreshToken) error {
+	m.creates++
+	m.createCtx = ctx
+
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+
+	return m.mockTokenRepository.Create(ctx, token)
+}
+
+// deadRequest returns a request whose context is already cancelled, which is what the
+// net/http server hands the handler once the client goes away mid-request.
+func deadRequest(path, body string) *http.Request {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	return post(path, body).WithContext(ctx)
+}
+
+func TestHandlersRefuseToMintTokensForAnAbandonedRequest(t *testing.T) {
+	const password = "Correct-Horse-9"
+
+	for _, tt := range []struct {
+		name    string
+		options func(t *testing.T, tokens *contextAwareTokenRepository) rigOptions
+		call    func(r *rig, rec *httptest.ResponseRecorder, req *http.Request)
+		request func() *http.Request
+	}{
+		{
+			name: "Register",
+			options: func(_ *testing.T, tokens *contextAwareTokenRepository) rigOptions {
+				return rigOptions{
+					allowedRegister: true,
+					users:           &mockUserRepository{count: 1},
+					tokens:          tokens,
+				}
+			},
+			call: func(r *rig, rec *httptest.ResponseRecorder, req *http.Request) {
+				r.handler.Register(rec, req)
+			},
+			request: func() *http.Request {
+				return deadRequest("/api/v1/auth/register",
+					`{"email":"ada@example.test","password":"`+password+`","display_name":"Ada"}`)
+			},
+		},
+		{
+			name: "Login",
+			options: func(t *testing.T, tokens *contextAwareTokenRepository) rigOptions {
+				return rigOptions{
+					allowedRegister: true,
+					users:           &mockUserRepository{count: 1, user: existingUser(t, password)},
+					tokens:          tokens,
+				}
+			},
+			call: func(r *rig, rec *httptest.ResponseRecorder, req *http.Request) {
+				r.handler.Login(rec, req)
+			},
+			request: func() *http.Request {
+				return deadRequest("/api/v1/auth/login",
+					`{"email":"ada@example.test","password":"`+password+`"}`)
+			},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			tokens := &contextAwareTokenRepository{}
+			r := newRig(t, tt.options(t, tokens))
+
+			rec := httptest.NewRecorder()
+			tt.call(r, rec, tt.request())
+
+			if rec.Code != http.StatusInternalServerError {
+				t.Fatalf("status = %d, want 500 (%q)", rec.Code, rec.Body.String())
+			}
+			if tokens.creates != 1 {
+				t.Fatalf("tokenRepo.Create called %d times, want exactly 1", tokens.creates)
+			}
+			if tokens.createCtx.Err() == nil {
+				t.Error("Create ran under a live context: the abandoned request context was not propagated")
+			}
+
+			// And nothing usable leaked out: no token pair in the body, no refresh cookie.
+			body := decode(t, rec)
+			if body.Error == nil {
+				t.Errorf("the response is not an error envelope: %q", rec.Body.String())
+			}
+			for _, cookie := range rec.Result().Cookies() {
+				if cookie.Name == "refresh_token" && cookie.Value != "" {
+					t.Error("a refresh-token cookie was set for a request that failed")
+				}
+			}
+		})
+	}
+}

--- a/internal/auth/handlers/auth_handler_http_test.go
+++ b/internal/auth/handlers/auth_handler_http_test.go
@@ -166,7 +166,7 @@ func newManager(t *testing.T) *jwt.Manager {
 type rig struct {
 	handler  *handlers.AuthHandler
 	users    *mockUserRepository
-	tokens   *mockTokenRepository
+	tokens   service.TokenRepository
 	store    *fakeUserStore
 	mail     *fakeEmailSender
 	manager  *jwt.Manager
@@ -179,10 +179,12 @@ type rigOptions struct {
 	verificationOn  bool
 	emailConfigured bool
 	users           *mockUserRepository
-	tokens          *mockTokenRepository
-	mfa             *mockMFARepository
-	mfaStatus       *fakeMFAStatus
-	passkeyCount    *fakePasskeyCounter
+	// tokens is the interface rather than the concrete mock so a test can substitute a
+	// context-aware repository — see auth_handler_context_test.go.
+	tokens       service.TokenRepository
+	mfa          *mockMFARepository
+	mfaStatus    *fakeMFAStatus
+	passkeyCount *fakePasskeyCounter
 }
 
 func newRig(t *testing.T, opts rigOptions) *rig {

--- a/internal/auth/service/auth_service.go
+++ b/internal/auth/service/auth_service.go
@@ -154,7 +154,7 @@ func (s *AuthService) Register(ctx context.Context, req *models.RegisterRequest)
 	}
 
 	// Generate tokens
-	return s.generateAuthResponse(user)
+	return s.generateAuthResponse(ctx, user)
 }
 
 // Login authenticates a user
@@ -212,7 +212,7 @@ func (s *AuthService) Login(ctx context.Context, req *models.LoginRequest) (*mod
 	}
 
 	// No MFA - generate full tokens
-	return s.generateAuthResponse(user)
+	return s.generateAuthResponse(ctx, user)
 }
 
 // incrementLoginAttempts increments the failed login counter for the given key
@@ -257,7 +257,7 @@ func (s *AuthService) RefreshToken(ctx context.Context, refreshToken string) (*m
 	}
 
 	// Generate new tokens
-	return s.generateAuthResponse(user)
+	return s.generateAuthResponse(ctx, user)
 }
 
 // Logout invalidates the refresh token
@@ -393,7 +393,11 @@ func (s *AuthService) DeleteUser(ctx context.Context, currentUserID, targetUserI
 	return s.userRepo.Delete(ctx, uid)
 }
 
-func (s *AuthService) generateAuthResponse(user *models.User) (*models.AuthResponse, error) {
+// generateAuthResponse issues the access/refresh token pair and persists the refresh
+// token hash. The refresh token write is a synchronous database call on the request
+// path, so it runs under the caller's context: a client disconnect, a request deadline
+// or a server shutdown must be able to cancel it.
+func (s *AuthService) generateAuthResponse(ctx context.Context, user *models.User) (*models.AuthResponse, error) {
 	// Generate access token
 	accessToken, err := s.jwtManager.GenerateAccessToken(user.ID.String(), user.Email, user.Role)
 	if err != nil {
@@ -414,7 +418,7 @@ func (s *AuthService) generateAuthResponse(user *models.User) (*models.AuthRespo
 	}
 	storedToken.ID = uuid.New()
 
-	if err := s.tokenRepo.Create(context.Background(), storedToken); err != nil {
+	if err := s.tokenRepo.Create(ctx, storedToken); err != nil {
 		return nil, fmt.Errorf("failed to store refresh token: %w", err)
 	}
 
@@ -468,7 +472,7 @@ func (s *AuthService) PasskeyLogin(ctx context.Context, user *models.User) (*mod
 	}
 
 	// No MFA - generate full tokens directly
-	return s.generateAuthResponse(user)
+	return s.generateAuthResponse(ctx, user)
 }
 
 // VerifyMFAAndLogin verifies the MFA code and completes login
@@ -515,5 +519,5 @@ func (s *AuthService) VerifyMFAAndLogin(ctx context.Context, tempToken string, m
 	}
 
 	// Generate full tokens
-	return s.generateAuthResponse(user)
+	return s.generateAuthResponse(ctx, user)
 }

--- a/internal/auth/service/auth_service_context_test.go
+++ b/internal/auth/service/auth_service_context_test.go
@@ -1,0 +1,267 @@
+// WhenTo - Collaborative event calendar for self-hosted environments
+// Copyright (C) 2025 WhenTo Contributors
+// SPDX-License-Identifier: BSL-1.1
+
+package service
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"golang.org/x/crypto/bcrypt"
+
+	"github.com/whento/pkg/jwt"
+	"github.com/whento/whento/internal/auth/models"
+	"github.com/whento/whento/internal/auth/repository"
+	mfaModels "github.com/whento/whento/internal/mfa/models"
+)
+
+// generateAuthResponse used to persist the refresh token under context.Background(),
+// so a client disconnect, a request deadline or a server shutdown could not stop that
+// write. The tests below lock the fix in from every entry point that reaches it:
+// Register, Login, RefreshToken, PasskeyLogin and VerifyMFAAndLogin.
+//
+// fakeTokenRepo ignores the context it is given, which is exactly what let the defect
+// hide. contextTokenRepo behaves like the pgx-backed repository instead: it refuses to
+// write once the context is done, and it records the context it was handed so the tests
+// can tell the request context apart from a detached one.
+
+// requestCtxKey is a private key type, so the marker value cannot collide with anything
+// the service itself puts in the context.
+type requestCtxKey struct{}
+
+const requestCtxMarker = "request-scoped"
+
+type contextTokenRepo struct {
+	*fakeTokenRepo
+
+	creates   int
+	createCtx context.Context
+}
+
+var _ TokenRepository = (*contextTokenRepo)(nil)
+
+func (r *contextTokenRepo) Create(ctx context.Context, token *models.RefreshToken) error {
+	r.creates++
+	r.createCtx = ctx
+
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+
+	return r.fakeTokenRepo.Create(ctx, token)
+}
+
+type contextFixture struct {
+	service *AuthService
+	users   *fakeUserRepo
+	tokens  *contextTokenRepo
+	mfa     *fakeMFARepo
+	jwt     *jwt.Manager
+}
+
+func newContextFixture(t *testing.T) *contextFixture {
+	t.Helper()
+
+	users := newFakeUserRepo()
+	tokens := &contextTokenRepo{fakeTokenRepo: newFakeTokenRepo()}
+	mfa := &fakeMFARepo{}
+	manager := testJWT(t)
+
+	return &contextFixture{
+		service: NewAuthService(
+			users, tokens, mfa, manager, newCountingCache(),
+			bcrypt.MinCost, true, []string{"*"},
+		),
+		users:  users,
+		tokens: tokens,
+		mfa:    mfa,
+		jwt:    manager,
+	}
+}
+
+func (f *contextFixture) seedUser(t *testing.T, email, password string) *models.User {
+	t.Helper()
+
+	hash, err := bcrypt.GenerateFromPassword([]byte(password), bcrypt.MinCost)
+	if err != nil {
+		t.Fatalf("hash password: %v", err)
+	}
+
+	user := &models.User{
+		Email:        email,
+		PasswordHash: string(hash),
+		DisplayName:  "Context User",
+		Role:         models.RoleUser,
+		Locale:       models.LocaleEN,
+	}
+	user.ID = uuid.New()
+
+	return f.users.add(user)
+}
+
+// authEntryPoint is one exported call that ends in generateAuthResponse.
+type authEntryPoint struct {
+	name   string
+	invoke func(t *testing.T, f *contextFixture, ctx context.Context) error
+}
+
+const contextTestPassword = "Str0ng!Passw0rd"
+
+func authEntryPoints() []authEntryPoint {
+	return []authEntryPoint{
+		{
+			name: "Register",
+			invoke: func(_ *testing.T, f *contextFixture, ctx context.Context) error {
+				_, err := f.service.Register(ctx, &models.RegisterRequest{
+					Email:       "register@example.test",
+					Password:    contextTestPassword,
+					DisplayName: "Register",
+				})
+
+				return err
+			},
+		},
+		{
+			name: "Login",
+			invoke: func(t *testing.T, f *contextFixture, ctx context.Context) error {
+				f.seedUser(t, "login@example.test", contextTestPassword)
+				_, err := f.service.Login(ctx, &models.LoginRequest{
+					Email:    "login@example.test",
+					Password: contextTestPassword,
+				})
+
+				return err
+			},
+		},
+		{
+			name: "RefreshToken",
+			invoke: func(t *testing.T, f *contextFixture, ctx context.Context) error {
+				user := f.seedUser(t, "refresh@example.test", contextTestPassword)
+
+				token, expiresAt, err := f.jwt.GenerateRefreshToken(user.ID.String())
+				if err != nil {
+					t.Fatalf("generate refresh token: %v", err)
+				}
+				stored := &models.RefreshToken{
+					UserID:    user.ID,
+					TokenHash: repository.HashToken(token),
+					ExpiresAt: expiresAt,
+				}
+				stored.ID = uuid.New()
+				f.tokens.stored[stored.TokenHash] = stored
+
+				_, err = f.service.RefreshToken(ctx, token)
+
+				return err
+			},
+		},
+		{
+			name: "PasskeyLogin",
+			invoke: func(t *testing.T, f *contextFixture, ctx context.Context) error {
+				user := f.seedUser(t, "passkey@example.test", contextTestPassword)
+				_, err := f.service.PasskeyLogin(ctx, user)
+
+				return err
+			},
+		},
+		{
+			name: "VerifyMFAAndLogin",
+			invoke: func(t *testing.T, f *contextFixture, ctx context.Context) error {
+				user := f.seedUser(t, "mfa@example.test", contextTestPassword)
+				f.mfa.mfa = &mfaModels.UserMFA{Enabled: true}
+
+				tempToken, err := f.service.generateTempToken(user.ID)
+				if err != nil {
+					t.Fatalf("generate temp token: %v", err)
+				}
+
+				_, err = f.service.VerifyMFAAndLogin(ctx, tempToken, "000000")
+
+				return err
+			},
+		},
+	}
+}
+
+// TestAuthFlowsAbortTheRefreshTokenWriteOnADeadContext is the regression guard. With
+// context.Background() hard-coded in generateAuthResponse, every one of these subtests
+// returned no error and persisted a refresh token for a request nobody was waiting on.
+func TestAuthFlowsAbortTheRefreshTokenWriteOnADeadContext(t *testing.T) {
+	deadContexts := []struct {
+		name  string
+		build func() (context.Context, context.CancelFunc)
+		want  error
+	}{
+		{
+			name: "the client disconnected",
+			build: func() (context.Context, context.CancelFunc) {
+				ctx, cancel := context.WithCancel(context.Background())
+				cancel()
+
+				return ctx, func() {}
+			},
+			want: context.Canceled,
+		},
+		{
+			name: "the request deadline passed",
+			build: func() (context.Context, context.CancelFunc) {
+				return context.WithDeadline(context.Background(), time.Now().Add(-time.Second))
+			},
+			want: context.DeadlineExceeded,
+		},
+	}
+
+	for _, dead := range deadContexts {
+		t.Run(dead.name, func(t *testing.T) {
+			for _, entry := range authEntryPoints() {
+				t.Run(entry.name, func(t *testing.T) {
+					f := newContextFixture(t)
+					ctx, cancel := dead.build()
+					defer cancel()
+
+					err := entry.invoke(t, f, ctx)
+					if err == nil {
+						t.Fatal("the call succeeded on a dead context: the refresh-token write is not cancellable")
+					}
+					if !errors.Is(err, dead.want) {
+						t.Errorf("error = %v, want it to wrap %v", err, dead.want)
+					}
+					if len(f.tokens.stored) != 0 {
+						t.Errorf("%d refresh token(s) persisted despite the dead context", len(f.tokens.stored))
+					}
+				})
+			}
+		})
+	}
+}
+
+// TestAuthFlowsStoreTheRefreshTokenUnderTheRequestContext checks the positive half: the
+// write runs under the caller's own context, not a lookalike. A detached
+// context.Background() would carry none of the request's values.
+func TestAuthFlowsStoreTheRefreshTokenUnderTheRequestContext(t *testing.T) {
+	for _, entry := range authEntryPoints() {
+		t.Run(entry.name, func(t *testing.T) {
+			f := newContextFixture(t)
+			ctx := context.WithValue(context.Background(), requestCtxKey{}, requestCtxMarker)
+
+			if err := entry.invoke(t, f, ctx); err != nil {
+				t.Fatalf("%s: %v", entry.name, err)
+			}
+
+			if f.tokens.creates != 1 {
+				t.Fatalf("tokenRepo.Create called %d times, want 1", f.tokens.creates)
+			}
+			if got := f.tokens.createCtx.Value(requestCtxKey{}); got != requestCtxMarker {
+				t.Errorf("Create ran under a context carrying %v, want %q: the request context was not propagated",
+					got, requestCtxMarker)
+			}
+			if len(f.tokens.stored) != 1 {
+				t.Errorf("%d refresh token(s) stored, want 1", len(f.tokens.stored))
+			}
+		})
+	}
+}

--- a/internal/availability/handlers/availability_handler.go
+++ b/internal/availability/handlers/availability_handler.go
@@ -239,8 +239,18 @@ func handleAvailabilityError(w http.ResponseWriter, r *http.Request, err error, 
 		httputil.Error(w, http.StatusNotFound, httputil.ErrCodeNotFound, "Availability not found")
 	case errors.Is(err, service.ErrAvailabilityExists):
 		httputil.Error(w, http.StatusConflict, httputil.ErrCodeConflict, "Availability already exists for this date")
+	case errors.Is(err, service.ErrInvalidParticipantID):
+		httputil.Error(w, http.StatusBadRequest, httputil.ErrCodeBadRequest, "Invalid participant ID")
 	case errors.Is(err, service.ErrInvalidDate):
 		httputil.Error(w, http.StatusBadRequest, httputil.ErrCodeBadRequest, "Invalid date format, expected YYYY-MM-DD")
+	// A range with the two ends the wrong way round is a request the caller got wrong,
+	// not a fault on our side: without this case it fell through to the 500 below.
+	case errors.Is(err, service.ErrInvalidDateRange):
+		httputil.Error(w, http.StatusBadRequest, httputil.ErrCodeBadRequest, "End date must be after start date")
+	case errors.Is(err, service.ErrDateBeforeCalendarStart):
+		httputil.Error(w, http.StatusBadRequest, httputil.ErrCodeBadRequest, "Date is before the calendar start date")
+	case errors.Is(err, service.ErrDateAfterCalendarEnd):
+		httputil.Error(w, http.StatusBadRequest, httputil.ErrCodeBadRequest, "Date is after the calendar end date")
 	case errors.Is(err, service.ErrInvalidTime):
 		httputil.Error(w, http.StatusBadRequest, httputil.ErrCodeBadRequest, "Invalid time format, expected HH:MM")
 	case errors.Is(err, service.ErrInvalidTimeRange):

--- a/internal/availability/handlers/availability_handler_test.go
+++ b/internal/availability/handlers/availability_handler_test.go
@@ -7,8 +7,10 @@ package handlers_test
 import (
 	"context"
 	"encoding/json"
+	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
@@ -171,6 +173,8 @@ func newHandler(t *testing.T, calendar *repository.Calendar, calendarErr error, 
 
 	router := chi.NewRouter()
 	router.Get("/api/v1/public/calendars/{token}/availabilities/range", handler.GetRangeSummary)
+	router.Get("/api/v1/public/calendars/{token}/participants/{pid}/availabilities", handler.GetParticipantAvailabilities)
+	router.Post("/api/v1/public/calendars/{token}/participants/{pid}/availabilities", handler.CreateAvailability)
 
 	return router
 }
@@ -192,7 +196,10 @@ func TestGetRangeSummaryRequiresBothDates(t *testing.T) {
 		// A malformed date reaches the service and comes back as a 400 too, but by
 		// a different route — worth distinguishing from the missing-parameter case.
 		{name: "a malformed start", query: "?start=01/03/2026&end=2026-03-31", want: http.StatusBadRequest},
-		{name: "an inverted range", query: "?start=2026-03-31&end=2026-03-01", want: http.StatusInternalServerError},
+		// An inverted range is the caller's mistake, and used to be answered with a 500
+		// purely because the service returned a bare fmt.Errorf that no errors.Is could
+		// match, leaving handleAvailabilityError nothing to go on.
+		{name: "an inverted range", query: "?start=2026-03-31&end=2026-03-01", want: http.StatusBadRequest},
 	}
 
 	for _, tt := range tests {
@@ -338,5 +345,103 @@ func TestGetRangeSummaryEmptySerialisesAsArray(t *testing.T) {
 
 	if string(body.Data) != "[]" {
 		t.Errorf("data = %s, want []", body.Data)
+	}
+}
+
+// TestRejectedInputIsNotReportedAsAServerError pins the status code for the requests the
+// caller got wrong.
+//
+// Every case below used to come back as a 500. The service returned a bare fmt.Errorf for
+// each of them, no errors.Is could match it, and handleAvailabilityError has nothing to
+// fall back on but its default branch — so an inverted date range, a participant ID that
+// is not a UUID, or a date outside the calendar's own window were all reported as faults
+// on our side. A 500 tells the browser to retry and tells the operator to go looking for
+// a bug that is not there.
+func TestRejectedInputIsNotReportedAsAServerError(t *testing.T) {
+	calendarID := uuid.New()
+	participant := &repository.Participant{ID: uuid.New(), CalendarID: calendarID, Name: "Alice"}
+
+	// Far enough out that the past-date check never fires and the test does not rot.
+	opens := time.Date(2099, time.June, 10, 0, 0, 0, 0, time.UTC)
+	closes := time.Date(2099, time.June, 20, 0, 0, 0, 0, time.UTC)
+
+	calendar := &repository.Calendar{
+		ID:              calendarID,
+		AllowedWeekdays: []int{0, 1, 2, 3, 4, 5, 6},
+		Timezone:        "Europe/Paris",
+		StartDate:       &opens,
+		EndDate:         &closes,
+	}
+
+	const base = "/api/v1/public/calendars/tok"
+
+	tests := []struct {
+		name   string
+		method string
+		path   string
+		body   string
+		want   int
+	}{
+		{
+			name:   "a range that ends before it starts",
+			method: http.MethodGet,
+			path:   base + "/availabilities/range?start=2099-06-20&end=2099-06-11",
+			want:   http.StatusBadRequest,
+		},
+		{
+			name:   "a participant ID that is not a UUID",
+			method: http.MethodGet,
+			path:   base + "/participants/not-a-uuid/availabilities",
+			want:   http.StatusBadRequest,
+		},
+		{
+			name:   "a date before the calendar opens",
+			method: http.MethodPost,
+			path:   base + "/participants/" + participant.ID.String() + "/availabilities",
+			body:   `{"date":"2099-06-01"}`,
+			want:   http.StatusBadRequest,
+		},
+		{
+			name:   "a date after the calendar closes",
+			method: http.MethodPost,
+			path:   base + "/participants/" + participant.ID.String() + "/availabilities",
+			body:   `{"date":"2099-06-30"}`,
+			want:   http.StatusBadRequest,
+		},
+		// The counterweight: the mapping must not have turned every failure into a 400.
+		{
+			name:   "a participant who does not exist",
+			method: http.MethodGet,
+			path:   base + "/participants/" + uuid.New().String() + "/availabilities",
+			want:   http.StatusNotFound,
+		},
+		{
+			name:   "a date the calendar accepts",
+			method: http.MethodPost,
+			path:   base + "/participants/" + participant.ID.String() + "/availabilities",
+			body:   `{"date":"2099-06-15"}`,
+			want:   http.StatusCreated,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			router := newHandler(t, calendar, nil, nil, []*repository.Participant{participant})
+
+			var body io.Reader
+			if tt.body != "" {
+				body = strings.NewReader(tt.body)
+			}
+
+			req := httptest.NewRequest(tt.method, tt.path, body)
+			req.Header.Set("Content-Type", "application/json")
+			rec := httptest.NewRecorder()
+
+			router.ServeHTTP(rec, req)
+
+			if rec.Code != tt.want {
+				t.Errorf("status = %d, want %d (body %s)", rec.Code, tt.want, rec.Body)
+			}
+		})
 	}
 }

--- a/internal/availability/handlers/events_handler.go
+++ b/internal/availability/handlers/events_handler.go
@@ -6,6 +6,7 @@ package handlers
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"time"
@@ -46,11 +47,15 @@ type CalendarLookup interface {
 type EventsHandler struct {
 	calendars CalendarLookup
 	broker    broadcast.Broker
+
+	// heartbeat is heartbeatInterval in production. It is a field only so that a test
+	// can watch several heartbeats go by without taking half a minute over it.
+	heartbeat time.Duration
 }
 
 // NewEventsHandler creates the SSE handler for participant calendars.
 func NewEventsHandler(calendars CalendarLookup, broker broadcast.Broker) *EventsHandler {
-	return &EventsHandler{calendars: calendars, broker: broker}
+	return &EventsHandler{calendars: calendars, broker: broker, heartbeat: heartbeatInterval}
 }
 
 // Stream handles GET /api/v1/availabilities/calendar/{token}/events
@@ -84,6 +89,21 @@ func (h *EventsHandler) Stream(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// The server arms a write deadline once, when it reads the request headers, and
+	// nothing rearms it. For an ordinary answer that is the whole point; for a stream
+	// meant to stay open for hours it is fatal — every write after WriteTimeout fails,
+	// starting with the first heartbeat, and the browser reconnects on the retry hint
+	// for ever. Clearing the deadline is what makes this connection long-lived.
+	if err := http.NewResponseController(w).SetWriteDeadline(time.Time{}); err != nil {
+		if errors.Is(err, http.ErrNotSupported) {
+			// A ResponseWriter that cannot be unwrapped down to the connection: the
+			// stream still works, it just keeps whatever deadline the server set.
+			log.Debug("events: write deadlines are not supported by this response writer", "token", token)
+		} else {
+			log.Warn("events: could not clear the write deadline", "token", token, "error", err)
+		}
+	}
+
 	// Subscribe before announcing the stream is open. A write landing in between would
 	// otherwise be missed by a browser that believes it is now up to date.
 	notices, stop := h.broker.Subscribe(r.Context(), token)
@@ -99,7 +119,12 @@ func (h *EventsHandler) Stream(w http.ResponseWriter, r *http.Request) {
 	fmt.Fprintf(w, "retry: %d\n\n", retryHint.Milliseconds())
 	flusher.Flush()
 
-	heartbeat := time.NewTicker(heartbeatInterval)
+	interval := h.heartbeat
+	if interval <= 0 {
+		interval = heartbeatInterval
+	}
+
+	heartbeat := time.NewTicker(interval)
 	defer heartbeat.Stop()
 
 	for {

--- a/internal/availability/handlers/events_handler_test.go
+++ b/internal/availability/handlers/events_handler_test.go
@@ -5,6 +5,7 @@
 package handlers
 
 import (
+	"bufio"
 	"context"
 	"errors"
 	"net/http"
@@ -330,4 +331,103 @@ func TestTheTokenIsCheckedAgainstTheRepository(t *testing.T) {
 
 	cancel()
 	<-done
+}
+
+// TestTheStreamOutlivesTheServerWriteTimeout is the case every test above is blind to.
+//
+// httptest.NewRecorder is not a connection: it has no deadline, so a stream written into
+// one survives anything. A real http.Server arms its WriteTimeout once, when it reads the
+// request headers, and never rearms it — so every write past that point fails, starting
+// with the very first heartbeat, and the browser reconnects on the retry hint for ever.
+// Nothing about that is visible until the handler is mounted on an actual server whose
+// WriteTimeout is shorter than the test is willing to wait.
+func TestTheStreamOutlivesTheServerWriteTimeout(t *testing.T) {
+	const (
+		writeTimeout = 300 * time.Millisecond
+		heartbeat    = 50 * time.Millisecond
+	)
+
+	tests := []struct {
+		name string
+		// publish sends a notice once the server's write deadline has certainly passed.
+		publish bool
+		// want is the line the browser must still be able to receive afterwards.
+		want string
+	}{
+		{
+			name: "a heartbeat still lands after the write timeout",
+			want: ": keep-alive",
+		},
+		{
+			name:    "a notice still lands after the write timeout",
+			publish: true,
+			want:    "event: update",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			broker := broadcast.NewMemoryBroker()
+			t.Cleanup(func() { _ = broker.Close() })
+
+			handler := NewEventsHandler(&fakeCalendars{}, broker)
+			handler.heartbeat = heartbeat
+
+			router := chi.NewRouter()
+			router.Get("/calendar/{token}/events", handler.Stream)
+
+			server := httptest.NewUnstartedServer(router)
+			server.Config.WriteTimeout = writeTimeout
+			server.Start()
+			t.Cleanup(server.Close)
+
+			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+			defer cancel()
+
+			req, err := http.NewRequestWithContext(ctx, http.MethodGet, server.URL+"/calendar/public-token/events", nil)
+			if err != nil {
+				t.Fatalf("build request: %v", err)
+			}
+
+			started := time.Now()
+			resp, err := server.Client().Do(req)
+			if err != nil {
+				t.Fatalf("open the stream: %v", err)
+			}
+			defer resp.Body.Close()
+
+			if resp.StatusCode != http.StatusOK {
+				t.Fatalf("status = %d, want 200", resp.StatusCode)
+			}
+
+			// The notice is sent well past the deadline the server armed when it read
+			// the request headers.
+			if tt.publish {
+				timer := time.AfterFunc(writeTimeout+2*heartbeat, func() {
+					_ = broker.Publish(context.Background(), "public-token")
+				})
+				defer timer.Stop()
+			}
+
+			// Read continuously rather than sleeping first: a line that is still sitting
+			// in the socket buffer says nothing about when it was written, and the
+			// heartbeats sent before the deadline are exactly that.
+			settled := writeTimeout + 2*heartbeat
+			reader := bufio.NewReader(resp.Body)
+			for {
+				line, err := reader.ReadString('\n')
+				if err != nil {
+					t.Fatalf(
+						"the stream died %v after it opened, with a WriteTimeout of %v: %v",
+						time.Since(started).Round(time.Millisecond), writeTimeout, err,
+					)
+				}
+
+				// Only a line that arrived past the deadline proves anything.
+				if strings.HasPrefix(line, tt.want) && time.Since(started) > settled {
+					return
+				}
+			}
+		})
+	}
 }

--- a/internal/availability/handlers/recurrence_handler.go
+++ b/internal/availability/handlers/recurrence_handler.go
@@ -253,10 +253,17 @@ func handleRecurrenceError(w http.ResponseWriter, r *http.Request, err error, de
 		httputil.Error(w, http.StatusNotFound, httputil.ErrCodeNotFound, "Participant not found")
 	case errors.Is(err, service.ErrInvalidParticipantID):
 		httputil.Error(w, http.StatusBadRequest, httputil.ErrCodeBadRequest, "Invalid participant ID")
+	case errors.Is(err, service.ErrInvalidRecurrenceID):
+		httputil.Error(w, http.StatusBadRequest, httputil.ErrCodeBadRequest, "Invalid recurrence ID")
 	case errors.Is(err, service.ErrRecurrenceNotFound):
 		httputil.Error(w, http.StatusNotFound, httputil.ErrCodeNotFound, "Recurrence not found")
+	case errors.Is(err, service.ErrExceptionNotFound):
+		httputil.Error(w, http.StatusNotFound, httputil.ErrCodeNotFound, "Exception not found")
 	case errors.Is(err, service.ErrInvalidDate):
 		httputil.Error(w, http.StatusBadRequest, httputil.ErrCodeBadRequest, "Invalid date format, expected YYYY-MM-DD")
+	// The end of a recurrence before its start is user input, not a server fault.
+	case errors.Is(err, service.ErrInvalidDateRange):
+		httputil.Error(w, http.StatusBadRequest, httputil.ErrCodeBadRequest, "End date must be after start date")
 	case errors.Is(err, service.ErrInvalidTime):
 		httputil.Error(w, http.StatusBadRequest, httputil.ErrCodeBadRequest, "Invalid time format, expected HH:MM")
 	case errors.Is(err, service.ErrInvalidTimeRange):

--- a/internal/availability/repository/recurrence_repository.go
+++ b/internal/availability/repository/recurrence_repository.go
@@ -6,12 +6,20 @@ package repository
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5/pgxpool"
 
 	"github.com/whento/whento/internal/availability/models"
+)
+
+// Sentinels, so that callers can tell "the row is not there" — which is a request the
+// user got wrong — from "the database refused", which is not. Compare with errors.Is.
+var (
+	ErrRecurrenceNotFound = errors.New("recurrence not found")
+	ErrExceptionNotFound  = errors.New("exception not found")
 )
 
 type RecurrenceRepository struct {
@@ -215,7 +223,7 @@ func (r *RecurrenceRepository) UpdateRecurrence(ctx context.Context, recurrence 
 	}
 
 	if result.RowsAffected() == 0 {
-		return fmt.Errorf("recurrence not found")
+		return ErrRecurrenceNotFound
 	}
 
 	return nil
@@ -231,7 +239,7 @@ func (r *RecurrenceRepository) DeleteRecurrence(ctx context.Context, id uuid.UUI
 	}
 
 	if result.RowsAffected() == 0 {
-		return fmt.Errorf("recurrence not found")
+		return ErrRecurrenceNotFound
 	}
 
 	return nil
@@ -307,7 +315,7 @@ func (r *RecurrenceRepository) DeleteException(ctx context.Context, recurrenceID
 	}
 
 	if result.RowsAffected() == 0 {
-		return fmt.Errorf("exception not found")
+		return ErrExceptionNotFound
 	}
 
 	return nil

--- a/internal/availability/service/availability_service.go
+++ b/internal/availability/service/availability_service.go
@@ -8,28 +8,39 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"runtime/debug"
 	"time"
 
 	"github.com/google/uuid"
 
 	"github.com/whento/pkg/cache"
 	"github.com/whento/pkg/datevalidation"
+	"github.com/whento/pkg/logger"
 	"github.com/whento/whento/internal/availability/models"
 	"github.com/whento/whento/internal/availability/repository"
 )
 
+// Sentinels. handleAvailabilityError and handleRecurrenceError turn these into status
+// codes with errors.Is, and anything that does not match one of them is reported as a
+// 500 — so a rejection the caller could act on has to be one of these, wrapped with %w,
+// rather than a bare fmt.Errorf.
 var (
 	ErrCalendarNotFound        = errors.New("calendar not found")
 	ErrParticipantNotFound     = errors.New("participant not found")
 	ErrInvalidParticipantID    = errors.New("invalid participant ID")
 	ErrInvalidDate             = errors.New("invalid date format, expected YYYY-MM-DD")
+	ErrInvalidDateRange        = errors.New("end date must be after start date")
+	ErrDateBeforeCalendarStart = errors.New("date is before the calendar start date")
+	ErrDateAfterCalendarEnd    = errors.New("date is after the calendar end date")
 	ErrInvalidTime             = errors.New("invalid time format, expected HH:MM")
 	ErrInvalidTimeRange        = errors.New("end time must be after start time")
 	ErrTimeOutsideAllowedHours = errors.New("time range does not fit within allowed hours for this day")
 	ErrDurationTooShort        = errors.New("availability duration is less than the minimum required")
 	ErrAvailabilityExists      = errors.New("availability already exists for this date")
 	ErrAvailabilityNotFound    = errors.New("availability not found")
+	ErrInvalidRecurrenceID     = errors.New("invalid recurrence ID")
 	ErrRecurrenceNotFound      = errors.New("recurrence not found")
+	ErrExceptionNotFound       = errors.New("exception not found")
 	ErrRecurrenceOverlap       = errors.New("recurrence overlaps with an existing recurrence on the same day")
 	ErrInvalidDayOfWeek        = errors.New("day_of_week must be between 0 (Sunday) and 6 (Saturday)")
 	ErrWeekdayNotAllowed       = errors.New("this day of the week is not allowed for this calendar")
@@ -108,6 +119,58 @@ func NewAvailabilityService(
 	}
 }
 
+// notifyThresholdTimeout bounds the detached threshold check. Nothing is waiting on it —
+// the request that triggered it has already been answered — so the deadline is there to
+// stop a wedged SMTP or database call from pinning a goroutine for the life of the
+// process, one per availability written.
+const notifyThresholdTimeout = 30 * time.Second
+
+// notifyThresholdAsync runs the threshold check outside the request that caused it.
+//
+// Threshold notifications are the emails this product exists to send, so a failure here
+// is worth a log line: the three copies of this block that it replaces each ended in an
+// empty branch under a comment reading "log only", and every failure vanished.
+//
+// The context is detached rather than dropped: cancellation is what must not carry over —
+// the request is finished, and its context is cancelled the moment the handler returns —
+// while the request ID must, or the log line has nothing to be correlated with.
+func (s *AvailabilityService) notifyThresholdAsync(
+	ctx context.Context,
+	calendarID uuid.UUID,
+	date time.Time,
+	previousCount int,
+) {
+	log := logger.FromContext(ctx)
+	detached := context.WithoutCancel(ctx)
+
+	go func() {
+		// middleware.Recoverer only wraps the request goroutine. A panic raised here
+		// would take the whole process down with it, calendar and all.
+		defer func() {
+			if r := recover(); r != nil {
+				log.Error("threshold notification panicked",
+					"calendar_id", calendarID,
+					"date", date.Format("2006-01-02"),
+					"panic", r,
+					"stack", string(debug.Stack()),
+				)
+			}
+		}()
+
+		notifyCtx, cancel := context.WithTimeout(detached, notifyThresholdTimeout)
+		defer cancel()
+
+		if err := s.notifyService.CheckThresholdAndNotify(notifyCtx, calendarID, date, previousCount); err != nil {
+			log.Error("threshold notification failed",
+				"calendar_id", calendarID,
+				"date", date.Format("2006-01-02"),
+				"previous_count", previousCount,
+				"error", err,
+			)
+		}
+	}()
+}
+
 // CreateAvailability creates a new availability for a participant
 func (s *AvailabilityService) CreateAvailability(ctx context.Context, token, participantID string, req *models.CreateAvailabilityRequest) (*models.AvailabilityResponse, error) {
 	// Validate calendar token and get calendar info
@@ -123,7 +186,7 @@ func (s *AvailabilityService) CreateAvailability(ctx context.Context, token, par
 	// Parse and validate participant ID
 	partID, err := uuid.Parse(participantID)
 	if err != nil {
-		return nil, fmt.Errorf("invalid participant id: %w", err)
+		return nil, fmt.Errorf("%w: %w", ErrInvalidParticipantID, err)
 	}
 
 	// Verify participant exists and belongs to this calendar
@@ -154,10 +217,10 @@ func (s *AvailabilityService) CreateAvailability(ctx context.Context, token, par
 
 	// Validate that the date is within calendar's date range if set
 	if calendarInfo.StartDate != nil && date.Before(*calendarInfo.StartDate) {
-		return nil, fmt.Errorf("date is before calendar start date (%s)", calendarInfo.StartDate.Format("2006-01-02"))
+		return nil, fmt.Errorf("%w (%s)", ErrDateBeforeCalendarStart, calendarInfo.StartDate.Format("2006-01-02"))
 	}
 	if calendarInfo.EndDate != nil && date.After(*calendarInfo.EndDate) {
-		return nil, fmt.Errorf("date is after calendar end date (%s)", calendarInfo.EndDate.Format("2006-01-02"))
+		return nil, fmt.Errorf("%w (%s)", ErrDateAfterCalendarEnd, calendarInfo.EndDate.Format("2006-01-02"))
 	}
 
 	// Validate that the date is allowed for this calendar
@@ -228,13 +291,9 @@ func (s *AvailabilityService) CreateAvailability(ctx context.Context, token, par
 		return nil, err
 	}
 
-	// Trigger notification check (fire-and-forget, don't block availability operation)
-	go func() {
-		notifyCtx := context.Background()
-		if err := s.notifyService.CheckThresholdAndNotify(notifyCtx, calendarID, date, previousCount); err != nil {
-			// Log only, don't fail the availability operation
-		}
-	}()
+	// The availability is already stored: the threshold check must not be able to fail
+	// the write, so it runs detached from the request.
+	s.notifyThresholdAsync(ctx, calendarID, date, previousCount)
 
 	return toAvailabilityResponse(availability, participant.Name, participant.Email, participant.EmailVerified), nil
 }
@@ -253,7 +312,7 @@ func (s *AvailabilityService) GetParticipantAvailabilities(ctx context.Context, 
 	// Parse participant ID
 	partID, err := uuid.Parse(participantID)
 	if err != nil {
-		return nil, fmt.Errorf("invalid participant id: %w", err)
+		return nil, fmt.Errorf("%w: %w", ErrInvalidParticipantID, err)
 	}
 
 	// Verify participant belongs to this calendar
@@ -332,7 +391,7 @@ func (s *AvailabilityService) UpdateAvailability(ctx context.Context, token, par
 	// Parse participant ID
 	partID, err := uuid.Parse(participantID)
 	if err != nil {
-		return nil, fmt.Errorf("invalid participant id: %w", err)
+		return nil, fmt.Errorf("%w: %w", ErrInvalidParticipantID, err)
 	}
 
 	// Verify participant belongs to this calendar
@@ -430,14 +489,9 @@ func (s *AvailabilityService) UpdateAvailability(ctx context.Context, token, par
 		return nil, err
 	}
 
-	// Trigger notification check (fire-and-forget)
-	// Note: Update doesn't change participant count, but we still check in case threshold config changed
-	go func() {
-		notifyCtx := context.Background()
-		if err := s.notifyService.CheckThresholdAndNotify(notifyCtx, calendarID, date, currentCount); err != nil {
-			// Log only, don't fail the availability operation
-		}
-	}()
+	// An update does not change the participant count, but the threshold configuration
+	// may have changed since, so the check still runs.
+	s.notifyThresholdAsync(ctx, calendarID, date, currentCount)
 
 	return toAvailabilityResponse(availability, participant.Name, participant.Email, participant.EmailVerified), nil
 }
@@ -456,7 +510,7 @@ func (s *AvailabilityService) DeleteAvailability(ctx context.Context, token, par
 	// Parse participant ID
 	partID, err := uuid.Parse(participantID)
 	if err != nil {
-		return fmt.Errorf("invalid participant id: %w", err)
+		return fmt.Errorf("%w: %w", ErrInvalidParticipantID, err)
 	}
 
 	// Verify participant belongs to this calendar
@@ -500,13 +554,7 @@ func (s *AvailabilityService) DeleteAvailability(ctx context.Context, token, par
 		return err
 	}
 
-	// Trigger notification check (fire-and-forget)
-	go func() {
-		notifyCtx := context.Background()
-		if err := s.notifyService.CheckThresholdAndNotify(notifyCtx, calendarID, date, previousCount); err != nil {
-			// Log only, don't fail the availability operation
-		}
-	}()
+	s.notifyThresholdAsync(ctx, calendarID, date, previousCount)
 
 	return nil
 }
@@ -723,7 +771,7 @@ func (s *AvailabilityService) GetRangeSummary(ctx context.Context, token, startD
 
 	// Validate range
 	if endDate.Before(startDate) {
-		return nil, fmt.Errorf("end date must be after start date")
+		return nil, fmt.Errorf("%w (%s..%s)", ErrInvalidDateRange, startDateStr, endDateStr)
 	}
 
 	// Get all availabilities in range
@@ -1031,7 +1079,7 @@ func (s *AvailabilityService) CreateRecurrence(ctx context.Context, token, parti
 	// Parse participant ID
 	partID, err := uuid.Parse(participantID)
 	if err != nil {
-		return nil, fmt.Errorf("invalid participant id: %w", err)
+		return nil, fmt.Errorf("%w: %w", ErrInvalidParticipantID, err)
 	}
 
 	// Verify participant belongs to this calendar
@@ -1081,7 +1129,7 @@ func (s *AvailabilityService) CreateRecurrence(ctx context.Context, token, parti
 			return nil, ErrInvalidDate
 		}
 		if endDate.Before(startDate) {
-			return nil, fmt.Errorf("end date must be after start date")
+			return nil, fmt.Errorf("%w (%s..%s)", ErrInvalidDateRange, req.StartDate, *req.EndDate)
 		}
 	}
 
@@ -1143,7 +1191,7 @@ func (s *AvailabilityService) GetParticipantRecurrences(ctx context.Context, tok
 	// Parse participant ID
 	partID, err := uuid.Parse(participantID)
 	if err != nil {
-		return nil, fmt.Errorf("invalid participant id: %w", err)
+		return nil, fmt.Errorf("%w: %w", ErrInvalidParticipantID, err)
 	}
 
 	// Verify participant belongs to this calendar
@@ -1205,7 +1253,7 @@ func (s *AvailabilityService) UpdateRecurrence(ctx context.Context, token, parti
 	// Parse recurrence ID
 	recID, err := uuid.Parse(recurrenceID)
 	if err != nil {
-		return nil, fmt.Errorf("invalid recurrence ID")
+		return nil, fmt.Errorf("%w: %w", ErrInvalidRecurrenceID, err)
 	}
 
 	// Verify participant belongs to calendar
@@ -1220,10 +1268,12 @@ func (s *AvailabilityService) UpdateRecurrence(ctx context.Context, token, parti
 	// Verify recurrence exists and belongs to participant
 	existingRec, err := s.recurrenceRepo.GetRecurrenceByID(ctx, recID)
 	if err != nil {
-		return nil, fmt.Errorf("recurrence not found")
+		return nil, ErrRecurrenceNotFound
 	}
+	// A recurrence belonging to someone else is reported as missing rather than as a
+	// refusal: the holder of the link learns nothing about what the ID names.
 	if existingRec.ParticipantID != partID {
-		return nil, fmt.Errorf("recurrence does not belong to participant")
+		return nil, ErrRecurrenceNotFound
 	}
 
 	// Validate day of week
@@ -1260,7 +1310,7 @@ func (s *AvailabilityService) UpdateRecurrence(ctx context.Context, token, parti
 			return nil, ErrInvalidDate
 		}
 		if endDate.Before(startDate) {
-			return nil, fmt.Errorf("end date must be after start date")
+			return nil, fmt.Errorf("%w (%s..%s)", ErrInvalidDateRange, req.StartDate, *req.EndDate)
 		}
 	}
 
@@ -1302,6 +1352,9 @@ func (s *AvailabilityService) UpdateRecurrence(ctx context.Context, token, parti
 	recurrence.ID = recID
 
 	if err := s.recurrenceRepo.UpdateRecurrence(ctx, recurrence); err != nil {
+		if errors.Is(err, repository.ErrRecurrenceNotFound) {
+			return nil, ErrRecurrenceNotFound
+		}
 		return nil, err
 	}
 
@@ -1322,7 +1375,7 @@ func (s *AvailabilityService) DeleteRecurrence(ctx context.Context, token, parti
 	// Parse participant ID
 	partID, err := uuid.Parse(participantID)
 	if err != nil {
-		return fmt.Errorf("invalid participant id: %w", err)
+		return fmt.Errorf("%w: %w", ErrInvalidParticipantID, err)
 	}
 
 	// Verify participant belongs to this calendar
@@ -1341,7 +1394,7 @@ func (s *AvailabilityService) DeleteRecurrence(ctx context.Context, token, parti
 	// Parse recurrence ID
 	recID, err := uuid.Parse(recurrenceID)
 	if err != nil {
-		return fmt.Errorf("invalid recurrence id: %w", err)
+		return fmt.Errorf("%w: %w", ErrInvalidRecurrenceID, err)
 	}
 
 	// Verify recurrence belongs to this participant
@@ -1356,6 +1409,9 @@ func (s *AvailabilityService) DeleteRecurrence(ctx context.Context, token, parti
 
 	// Delete recurrence
 	if err := s.recurrenceRepo.DeleteRecurrence(ctx, recID); err != nil {
+		if errors.Is(err, repository.ErrRecurrenceNotFound) {
+			return ErrRecurrenceNotFound
+		}
 		return err
 	}
 
@@ -1376,7 +1432,7 @@ func (s *AvailabilityService) CreateException(ctx context.Context, token, partic
 	// Parse participant ID
 	partID, err := uuid.Parse(participantID)
 	if err != nil {
-		return nil, fmt.Errorf("invalid participant id: %w", err)
+		return nil, fmt.Errorf("%w: %w", ErrInvalidParticipantID, err)
 	}
 
 	// Verify participant belongs to this calendar
@@ -1395,7 +1451,7 @@ func (s *AvailabilityService) CreateException(ctx context.Context, token, partic
 	// Parse recurrence ID
 	recID, err := uuid.Parse(recurrenceID)
 	if err != nil {
-		return nil, fmt.Errorf("invalid recurrence id: %w", err)
+		return nil, fmt.Errorf("%w: %w", ErrInvalidRecurrenceID, err)
 	}
 
 	// Verify recurrence belongs to this participant
@@ -1443,7 +1499,7 @@ func (s *AvailabilityService) DeleteException(ctx context.Context, token, partic
 	// Parse participant ID
 	partID, err := uuid.Parse(participantID)
 	if err != nil {
-		return fmt.Errorf("invalid participant id: %w", err)
+		return fmt.Errorf("%w: %w", ErrInvalidParticipantID, err)
 	}
 
 	// Verify participant belongs to this calendar
@@ -1462,7 +1518,7 @@ func (s *AvailabilityService) DeleteException(ctx context.Context, token, partic
 	// Parse recurrence ID
 	recID, err := uuid.Parse(recurrenceID)
 	if err != nil {
-		return fmt.Errorf("invalid recurrence id: %w", err)
+		return fmt.Errorf("%w: %w", ErrInvalidRecurrenceID, err)
 	}
 
 	// Verify recurrence belongs to this participant
@@ -1483,6 +1539,9 @@ func (s *AvailabilityService) DeleteException(ctx context.Context, token, partic
 
 	// Delete exception
 	if err := s.recurrenceRepo.DeleteException(ctx, recID, dateStr); err != nil {
+		if errors.Is(err, repository.ErrExceptionNotFound) {
+			return ErrExceptionNotFound
+		}
 		return err
 	}
 

--- a/internal/availability/service/availability_service_test.go
+++ b/internal/availability/service/availability_service_test.go
@@ -5,10 +5,18 @@
 package service
 
 import (
+	"bytes"
+	"context"
+	"errors"
+	"log/slog"
+	"strings"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/google/uuid"
 
+	"github.com/whento/pkg/logger"
 	"github.com/whento/whento/internal/availability/models"
 )
 
@@ -292,6 +300,146 @@ func TestRecurrencesOverlap(t *testing.T) {
 			if result != tt.expected {
 				t.Errorf("recurrencesOverlap(%s, %s, %s, %s) = %v, expected %v",
 					tt.startDateA, tt.endDateA, tt.startDateB, tt.endDateB, result, tt.expected)
+			}
+		})
+	}
+}
+
+// syncBuffer collects log output written from the detached goroutine while the test
+// reads it from its own.
+type syncBuffer struct {
+	mu  sync.Mutex
+	buf bytes.Buffer
+}
+
+func (s *syncBuffer) Write(p []byte) (int, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	return s.buf.Write(p)
+}
+
+func (s *syncBuffer) String() string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	return s.buf.String()
+}
+
+// recordingNotifier stands in for the notify service and reports what the detached
+// goroutine handed it.
+type recordingNotifier struct {
+	err       error
+	panicWith any
+
+	called      chan struct{}
+	mu          sync.Mutex
+	hadDeadline bool
+	ctxErr      error
+}
+
+func newRecordingNotifier(err error, panicWith any) *recordingNotifier {
+	return &recordingNotifier{err: err, panicWith: panicWith, called: make(chan struct{})}
+}
+
+func (n *recordingNotifier) CheckThresholdAndNotify(ctx context.Context, _ uuid.UUID, _ time.Time, _ int) error {
+	n.mu.Lock()
+	_, n.hadDeadline = ctx.Deadline()
+	n.ctxErr = ctx.Err()
+	n.mu.Unlock()
+
+	close(n.called)
+
+	if n.panicWith != nil {
+		panic(n.panicWith)
+	}
+
+	return n.err
+}
+
+// TestNotifyThresholdAsync covers the three ways the fire-and-forget threshold check used
+// to fail silently.
+//
+// The block this helper replaces logged nothing at all — its error branch was empty under
+// a comment reading "log only" — ran on a context.Background() that could never time out,
+// and had no recover(), so a panic in the notify path took the process down with it
+// (middleware.Recoverer only wraps the request goroutine).
+func TestNotifyThresholdAsync(t *testing.T) {
+	tests := []struct {
+		name string
+		// err is what the notify service returns.
+		err error
+		// panicWith, when set, makes the notify service panic instead.
+		panicWith any
+		// cancelRequest cancels the caller's context before the check is started.
+		cancelRequest bool
+		// wantLogged is a fragment the log line must contain.
+		wantLogged string
+	}{
+		{
+			name:       "a failed notification is logged",
+			err:        errors.New("smtp: connection refused"),
+			wantLogged: "threshold notification failed",
+		},
+		{
+			name:       "a panic is recovered instead of killing the process",
+			panicWith:  "notify exploded",
+			wantLogged: "threshold notification panicked",
+		},
+		{
+			name:          "the check still runs once the request is over",
+			cancelRequest: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			out := &syncBuffer{}
+			previous := logger.Default()
+			logger.SetDefault(slog.New(slog.NewJSONHandler(out, &slog.HandlerOptions{Level: slog.LevelDebug})))
+			t.Cleanup(func() { logger.SetDefault(previous) })
+
+			notifier := newRecordingNotifier(tt.err, tt.panicWith)
+			svc := NewAvailabilityService(nil, nil, nil, nil, notifier, nil)
+
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+
+			svc.notifyThresholdAsync(ctx, uuid.New(), time.Now(), 2)
+
+			if tt.cancelRequest {
+				// The handler has returned and chi has cancelled the request context.
+				// The notification must not be cancelled along with it.
+				cancel()
+			}
+
+			select {
+			case <-notifier.called:
+			case <-time.After(2 * time.Second):
+				t.Fatal("the threshold check was never run")
+			}
+
+			notifier.mu.Lock()
+			hadDeadline, ctxErr := notifier.hadDeadline, notifier.ctxErr
+			notifier.mu.Unlock()
+
+			if !hadDeadline {
+				t.Error("the detached context has no deadline: a wedged call would pin this goroutine for ever")
+			}
+			if ctxErr != nil {
+				t.Errorf("the detached context was already done: %v", ctxErr)
+			}
+
+			if tt.wantLogged == "" {
+				return
+			}
+
+			deadline := time.Now().Add(2 * time.Second)
+			for !strings.Contains(out.String(), tt.wantLogged) {
+				if time.Now().After(deadline) {
+					t.Fatalf("nothing was logged about the failure; log was:\n%s", out.String())
+				}
+				time.Sleep(5 * time.Millisecond)
 			}
 		})
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -38,6 +38,13 @@ type Config struct {
 
 	// Rate Limiting
 	RateLimitEnabled bool
+	// RateLimitKeySalt pins the salt used to derive rate limit bucket names.
+	// Buckets are stored hashed so that no IP, token or participant id is ever
+	// written to Redis. The salt therefore has to be identical across every
+	// instance sharing one Redis, or the same client lands in a different
+	// bucket per instance and N instances grant N times the allowance. Empty
+	// means "generate one per process", which is correct for a single instance.
+	RateLimitKeySalt string
 
 	// Security
 	TrustedProxies []string // IPs allowed to set X-Forwarded-For
@@ -111,6 +118,7 @@ func Load() *Config {
 
 		// Rate Limiting
 		RateLimitEnabled: getBool("RATE_LIMIT_ENABLED", true),
+		RateLimitKeySalt: getEnv("RATE_LIMIT_KEY_SALT", ""),
 
 		// Security
 		TrustedProxies: getStringList("TRUSTED_PROXIES", nil),

--- a/pkg/email/service.go
+++ b/pkg/email/service.go
@@ -5,11 +5,33 @@
 package email
 
 import (
+	"context"
 	"crypto/tls"
 	"fmt"
 	"log/slog"
+	"net"
 	"net/smtp"
+	"strconv"
 	"strings"
+	"time"
+)
+
+const (
+	// defaultDialTimeout bounds the TCP connect and, on port 465, the TLS handshake.
+	// Without it a host that accepts the connection and then says nothing holds the
+	// caller for as long as the operating system's own connect timeout — minutes — and
+	// the callers here are detached goroutines nobody is waiting on, so they simply
+	// accumulate, one per notification.
+	defaultDialTimeout = 10 * time.Second
+
+	// defaultTimeout bounds the whole SMTP conversation, greeting included. Reaching a
+	// host is not the same as it answering: a server that completes the TCP handshake
+	// and never sends its 220 banner would otherwise park the goroutine for ever.
+	defaultTimeout = 30 * time.Second
+
+	// implicitTLSPort speaks TLS from the first byte, rather than upgrading with
+	// STARTTLS the way 587 does.
+	implicitTLSPort = 465
 )
 
 // Service handles email sending via SMTP
@@ -20,6 +42,8 @@ type Service struct {
 	password    string
 	fromAddress string
 	fromName    string
+	dialTimeout time.Duration
+	timeout     time.Duration
 	logger      *slog.Logger
 }
 
@@ -31,10 +55,25 @@ type Config struct {
 	Password    string
 	FromAddress string
 	FromName    string
+
+	// DialTimeout bounds the connection attempt. Zero means defaultDialTimeout.
+	DialTimeout time.Duration
+	// Timeout bounds the whole conversation. Zero means defaultTimeout.
+	Timeout time.Duration
 }
 
 // NewService creates a new email service
 func NewService(cfg Config, logger *slog.Logger) *Service {
+	dialTimeout := cfg.DialTimeout
+	if dialTimeout <= 0 {
+		dialTimeout = defaultDialTimeout
+	}
+
+	timeout := cfg.Timeout
+	if timeout <= 0 {
+		timeout = defaultTimeout
+	}
+
 	return &Service{
 		host:        cfg.Host,
 		port:        cfg.Port,
@@ -42,6 +81,8 @@ func NewService(cfg Config, logger *slog.Logger) *Service {
 		password:    cfg.Password,
 		fromAddress: cfg.FromAddress,
 		fromName:    cfg.FromName,
+		dialTimeout: dialTimeout,
+		timeout:     timeout,
 		logger:      logger,
 	}
 }
@@ -54,8 +95,16 @@ type Email struct {
 	HTML    bool
 }
 
-// Send sends an email via SMTP
+// Send sends an email via SMTP, bounded by the service's own timeout.
 func (s *Service) Send(email Email) error {
+	return s.SendContext(context.Background(), email)
+}
+
+// SendContext sends an email via SMTP, giving up when ctx does.
+//
+// A caller with a deadline of its own keeps it; anything else is bounded by the service
+// timeout, so no send can outlive it.
+func (s *Service) SendContext(ctx context.Context, email Email) error {
 	// Validate configuration
 	if s.host == "" {
 		return fmt.Errorf("SMTP host not configured")
@@ -82,8 +131,14 @@ func (s *Service) Send(email Email) error {
 			email.Body + "\r\n",
 	)
 
+	if _, ok := ctx.Deadline(); !ok {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, s.timeout)
+		defer cancel()
+	}
+
 	// Connect to SMTP server
-	addr := fmt.Sprintf("%s:%d", s.host, s.port)
+	addr := net.JoinHostPort(s.host, strconv.Itoa(s.port))
 
 	// Setup authentication
 	var auth smtp.Auth
@@ -92,7 +147,7 @@ func (s *Service) Send(email Email) error {
 	}
 
 	// Try to send with TLS first (port 465 or explicit STARTTLS)
-	err := s.sendWithTLS(addr, auth, s.fromAddress, email.To, message)
+	err := s.sendWithTLS(ctx, addr, auth, s.fromAddress, email.To, message)
 	if err != nil {
 		s.logger.Error("Failed to send email",
 			slog.String("error", err.Error()),
@@ -110,66 +165,90 @@ func (s *Service) Send(email Email) error {
 }
 
 // sendWithTLS attempts to send email with TLS/STARTTLS
-func (s *Service) sendWithTLS(addr string, auth smtp.Auth, from string, to []string, msg []byte) error {
-	// For port 465 (implicit TLS)
-	if s.port == 465 {
-		// Create TLS config
-		tlsConfig := &tls.Config{
-			ServerName: s.host,
-		}
+func (s *Service) sendWithTLS(ctx context.Context, addr string, auth smtp.Auth, from string, to []string, msg []byte) error {
+	conn, err := s.dial(ctx, addr)
+	if err != nil {
+		return err
+	}
+	defer conn.Close()
 
-		// Connect with TLS
-		conn, err := tls.Dial("tcp", addr, tlsConfig)
-		if err != nil {
+	// One deadline for the whole conversation. net/smtp has no context of its own, so
+	// this is what keeps a silent server from parking the goroutine on a read.
+	if deadline, ok := ctx.Deadline(); ok {
+		if err := conn.SetDeadline(deadline); err != nil {
 			return err
 		}
-		defer conn.Close()
-
-		// Create SMTP client
-		client, err := smtp.NewClient(conn, s.host)
-		if err != nil {
-			return err
-		}
-		defer client.Quit()
-
-		// Authenticate
-		if auth != nil {
-			if err = client.Auth(auth); err != nil {
-				return err
-			}
-		}
-
-		// Set sender
-		if err = client.Mail(from); err != nil {
-			return err
-		}
-
-		// Set recipients
-		for _, recipient := range to {
-			if err = client.Rcpt(recipient); err != nil {
-				return err
-			}
-		}
-
-		// Send message
-		w, err := client.Data()
-		if err != nil {
-			return err
-		}
-		_, err = w.Write(msg)
-		if err != nil {
-			return err
-		}
-		err = w.Close()
-		if err != nil {
-			return err
-		}
-
-		return nil
 	}
 
-	// For port 587 or others (STARTTLS)
-	return smtp.SendMail(addr, auth, from, to, msg)
+	// Create SMTP client
+	client, err := smtp.NewClient(conn, s.host)
+	if err != nil {
+		return err
+	}
+	defer client.Close()
+
+	// For anything but implicit TLS, upgrade the plain connection when the server
+	// offers it — this is what port 587 expects.
+	if s.port != implicitTLSPort {
+		if ok, _ := client.Extension("STARTTLS"); ok {
+			if err := client.StartTLS(&tls.Config{ServerName: s.host}); err != nil {
+				return err
+			}
+		}
+	}
+
+	// Authenticate
+	if auth != nil {
+		if ok, _ := client.Extension("AUTH"); !ok {
+			return fmt.Errorf("smtp: server does not support AUTH")
+		}
+		if err := client.Auth(auth); err != nil {
+			return err
+		}
+	}
+
+	// Set sender
+	if err := client.Mail(from); err != nil {
+		return err
+	}
+
+	// Set recipients
+	for _, recipient := range to {
+		if err := client.Rcpt(recipient); err != nil {
+			return err
+		}
+	}
+
+	// Send message
+	w, err := client.Data()
+	if err != nil {
+		return err
+	}
+	if _, err := w.Write(msg); err != nil {
+		return err
+	}
+	if err := w.Close(); err != nil {
+		return err
+	}
+
+	return client.Quit()
+}
+
+// dial opens the connection, in TLS from the first byte on port 465 and in the clear
+// elsewhere. Both paths carry a timeout: the dialer's, and the context's on top of it.
+func (s *Service) dial(ctx context.Context, addr string) (net.Conn, error) {
+	dialer := &net.Dialer{Timeout: s.dialTimeout}
+
+	if s.port == implicitTLSPort {
+		tlsDialer := &tls.Dialer{
+			NetDialer: dialer,
+			Config:    &tls.Config{ServerName: s.host},
+		}
+
+		return tlsDialer.DialContext(ctx, "tcp", addr)
+	}
+
+	return dialer.DialContext(ctx, "tcp", addr)
 }
 
 // buildFromHeader builds the From header with optional name

--- a/pkg/email/service_test.go
+++ b/pkg/email/service_test.go
@@ -1,0 +1,379 @@
+// WhenTo - Collaborative event calendar for self-hosted environments
+// Copyright (C) 2025 WhenTo Contributors
+// SPDX-License-Identifier: BSL-1.1
+
+package email
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"net"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+// The sends exercised here run inside detached goroutines in production — nothing waits
+// on them and nothing reports them. A connection with no timeout does not fail, it hangs,
+// and one goroutine is parked per notification until the process is restarted. What these
+// tests pin is that an unreachable or silent SMTP host produces an error, promptly.
+
+func discardLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, nil))
+}
+
+// silentServer accepts connections and then says nothing at all: no TLS handshake, no 220
+// banner. This is what a wedged or blackholed SMTP host looks like from the client side,
+// and it is the case a dial timeout alone does not cover.
+func silentServer(t *testing.T) (host string, port int) {
+	t.Helper()
+
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+
+	var (
+		mu    sync.Mutex
+		conns []net.Conn
+	)
+	done := make(chan struct{})
+
+	// Cleanups run last-registered-first, so this one runs after the listener is closed
+	// — which is what ends the accept loop.
+	t.Cleanup(func() {
+		<-done
+
+		mu.Lock()
+		defer mu.Unlock()
+		for _, conn := range conns {
+			_ = conn.Close()
+		}
+	})
+	t.Cleanup(func() { _ = listener.Close() })
+
+	go func() {
+		defer close(done)
+
+		for {
+			conn, err := listener.Accept()
+			if err != nil {
+				return
+			}
+
+			mu.Lock()
+			conns = append(conns, conn)
+			mu.Unlock()
+		}
+	}()
+
+	addr, ok := listener.Addr().(*net.TCPAddr)
+	if !ok {
+		t.Fatalf("unexpected listener address %T", listener.Addr())
+	}
+
+	return "127.0.0.1", addr.Port
+}
+
+// closedPort returns an address nothing is listening on, so the connection is refused
+// rather than left hanging.
+func closedPort(t *testing.T) (host string, port int) {
+	t.Helper()
+
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+
+	addr, ok := listener.Addr().(*net.TCPAddr)
+	if !ok {
+		t.Fatalf("unexpected listener address %T", listener.Addr())
+	}
+	if err := listener.Close(); err != nil {
+		t.Fatalf("close listener: %v", err)
+	}
+
+	return "127.0.0.1", addr.Port
+}
+
+func TestSendFailsInsteadOfHanging(t *testing.T) {
+	const (
+		dialTimeout = 150 * time.Millisecond
+		// The whole conversation. This is what bounds a server that accepts the
+		// connection and then never speaks.
+		timeout = 300 * time.Millisecond
+		// Generous enough to survive a loaded CI machine, far short of the minutes an
+		// unbounded connection attempt would take.
+		budget = 5 * time.Second
+	)
+
+	silentHost, silentPort := silentServer(t)
+	refusedHost, refusedPort := closedPort(t)
+
+	tests := []struct {
+		name string
+		cfg  Config
+		// wantErrContains is a fragment of the message, where the reason is worth pinning.
+		wantErrContains string
+	}{
+		{
+			name:            "no host configured",
+			cfg:             Config{},
+			wantErrContains: "SMTP host not configured",
+		},
+		{
+			name: "the connection is refused",
+			cfg: Config{
+				Host:        refusedHost,
+				Port:        refusedPort,
+				FromAddress: "calendar@example.test",
+				DialTimeout: dialTimeout,
+				Timeout:     timeout,
+			},
+			wantErrContains: "failed to send email",
+		},
+		{
+			name: "the host accepts the connection and never sends its banner",
+			cfg: Config{
+				Host:        silentHost,
+				Port:        silentPort,
+				FromAddress: "calendar@example.test",
+				DialTimeout: dialTimeout,
+				Timeout:     timeout,
+			},
+			wantErrContains: "failed to send email",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			service := NewService(tt.cfg, discardLogger())
+
+			done := make(chan error, 1)
+			started := time.Now()
+
+			go func() {
+				done <- service.Send(Email{
+					To:      []string{"participant@example.test"},
+					Subject: "Everyone is free on Thursday",
+					Body:    "Come along.",
+				})
+			}()
+
+			select {
+			case err := <-done:
+				if err == nil {
+					t.Fatal("the send reported success against a server that never answered")
+				}
+				if tt.wantErrContains != "" && !strings.Contains(err.Error(), tt.wantErrContains) {
+					t.Errorf("error = %q, want it to mention %q", err, tt.wantErrContains)
+				}
+			case <-time.After(budget):
+				t.Fatalf("the send was still hanging after %v: this is the goroutine leak", time.Since(started))
+			}
+		})
+	}
+}
+
+// TestDialDoesNotHangOnASilentHost covers the connection itself, both ways round. Port
+// 465 speaks TLS from the first byte, so the handshake — not just the TCP connect — has
+// to be bounded: tls.Dial with no dialer of its own waits for a ServerHello that a silent
+// host will never send.
+func TestDialDoesNotHangOnASilentHost(t *testing.T) {
+	const dialTimeout = 150 * time.Millisecond
+
+	host, port := silentServer(t)
+	addr := net.JoinHostPort(host, strconv.Itoa(port))
+
+	tests := []struct {
+		name string
+		// port selects the connection mode; the address dialled is the silent server
+		// either way.
+		port    int
+		wantErr bool
+	}{
+		{
+			name:    "implicit TLS never completes its handshake",
+			port:    implicitTLSPort,
+			wantErr: true,
+		},
+		{
+			name:    "a plain connection is established, and the silence comes later",
+			port:    587,
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			service := NewService(Config{
+				Host:        host,
+				Port:        tt.port,
+				DialTimeout: dialTimeout,
+			}, discardLogger())
+
+			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			defer cancel()
+
+			started := time.Now()
+			conn, err := service.dial(ctx, addr)
+			elapsed := time.Since(started)
+
+			if conn != nil {
+				t.Cleanup(func() { _ = conn.Close() })
+			}
+
+			switch {
+			case tt.wantErr && err == nil:
+				t.Fatal("the handshake reported success against a host that sent nothing")
+			case !tt.wantErr && err != nil:
+				t.Fatalf("dial: %v", err)
+			}
+
+			if tt.wantErr && elapsed > 2*time.Second {
+				t.Errorf("gave up after %v, want about %v: the handshake is not bounded", elapsed, dialTimeout)
+			}
+		})
+	}
+}
+
+// TestSendContextGivesUpWithTheCaller checks that a caller's own deadline is honoured
+// rather than replaced by the service's, so a shutdown can drain instead of waiting out
+// the full SMTP timeout.
+func TestSendContextGivesUpWithTheCaller(t *testing.T) {
+	host, port := silentServer(t)
+
+	tests := []struct {
+		name        string
+		callerLimit time.Duration
+	}{
+		{name: "a caller in a hurry", callerLimit: 100 * time.Millisecond},
+		{name: "a slightly more patient caller", callerLimit: 250 * time.Millisecond},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			service := NewService(Config{
+				Host:        host,
+				Port:        port,
+				FromAddress: "calendar@example.test",
+				// Far longer than the caller is prepared to wait.
+				Timeout: time.Minute,
+			}, discardLogger())
+
+			ctx, cancel := context.WithTimeout(context.Background(), tt.callerLimit)
+			defer cancel()
+
+			started := time.Now()
+			err := service.SendContext(ctx, Email{
+				To:      []string{"participant@example.test"},
+				Subject: "Everyone is free on Thursday",
+			})
+			elapsed := time.Since(started)
+
+			if err == nil {
+				t.Fatal("the send reported success against a server that never answered")
+			}
+			if elapsed > tt.callerLimit+2*time.Second {
+				t.Errorf("gave up after %v, want about %v: the caller's deadline was ignored", elapsed, tt.callerLimit)
+			}
+		})
+	}
+}
+
+// TestNewServiceAppliesDefaultTimeouts guards the defect itself: a zero timeout is not
+// "no limit configured", it is an unbounded connection attempt, and every caller of this
+// package is a goroutine nobody is waiting on.
+func TestNewServiceAppliesDefaultTimeouts(t *testing.T) {
+	tests := []struct {
+		name            string
+		cfg             Config
+		wantDialTimeout time.Duration
+		wantTimeout     time.Duration
+	}{
+		{
+			name:            "nothing configured",
+			cfg:             Config{Host: "smtp.example.test"},
+			wantDialTimeout: defaultDialTimeout,
+			wantTimeout:     defaultTimeout,
+		},
+		{
+			name:            "negative values are not taken literally",
+			cfg:             Config{Host: "smtp.example.test", DialTimeout: -1, Timeout: -1},
+			wantDialTimeout: defaultDialTimeout,
+			wantTimeout:     defaultTimeout,
+		},
+		{
+			name:            "explicit values win",
+			cfg:             Config{Host: "smtp.example.test", DialTimeout: time.Second, Timeout: 2 * time.Second},
+			wantDialTimeout: time.Second,
+			wantTimeout:     2 * time.Second,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			service := NewService(tt.cfg, discardLogger())
+
+			if service.dialTimeout != tt.wantDialTimeout {
+				t.Errorf("dialTimeout = %v, want %v", service.dialTimeout, tt.wantDialTimeout)
+			}
+			if service.timeout != tt.wantTimeout {
+				t.Errorf("timeout = %v, want %v", service.timeout, tt.wantTimeout)
+			}
+		})
+	}
+}
+
+func TestIsConfigured(t *testing.T) {
+	tests := []struct {
+		name string
+		host string
+		want bool
+	}{
+		{name: "a host is set", host: "smtp.example.test", want: true},
+		{name: "no host at all", host: "", want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			service := NewService(Config{Host: tt.host}, discardLogger())
+
+			if got := service.IsConfigured(); got != tt.want {
+				t.Errorf("IsConfigured() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestBuildFromHeader(t *testing.T) {
+	tests := []struct {
+		name string
+		cfg  Config
+		want string
+	}{
+		{
+			name: "a name and an address",
+			cfg:  Config{FromName: "WhenTo", FromAddress: "calendar@example.test"},
+			want: "WhenTo <calendar@example.test>",
+		},
+		{
+			name: "an address on its own",
+			cfg:  Config{FromAddress: "calendar@example.test"},
+			want: "calendar@example.test",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			service := NewService(tt.cfg, discardLogger())
+
+			if got := service.buildFromHeader(); got != tt.want {
+				t.Errorf("buildFromHeader() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/middleware/middleware.go
+++ b/pkg/middleware/middleware.go
@@ -6,14 +6,18 @@ package middleware
 
 import (
 	"context"
+	"errors"
 	"net/http"
 	"strings"
 	"time"
 
+	"github.com/go-chi/chi/v5"
 	"github.com/go-chi/chi/v5/middleware"
 	"github.com/google/uuid"
+	"github.com/redis/go-redis/v9"
 
 	"github.com/whento/pkg/cache"
+	"github.com/whento/pkg/httputil"
 	"github.com/whento/pkg/jwt"
 	"github.com/whento/pkg/logger"
 )
@@ -25,6 +29,15 @@ const (
 	UserEmailKey ctxKey = "user_email"
 	UserRoleKey  ctxKey = "user_role"
 )
+
+// errCodeUnavailable is returned when a request cannot be authorised because a
+// dependency is unreachable, as opposed to because it was refused.
+const errCodeUnavailable = "SERVICE_UNAVAILABLE"
+
+// unroutedLabel replaces the route in the access log when chi never matched
+// one (404s, or the middleware used outside a chi router). The raw path is
+// never a safe substitute: in this API the path itself carries the credential.
+const unroutedLabel = "unrouted"
 
 // RequestID adds a unique request ID to each request
 func RequestID(next http.Handler) http.Handler {
@@ -41,16 +54,28 @@ func RequestID(next http.Handler) http.Handler {
 	})
 }
 
-// Logger logs each request
+// Logger logs each request.
+//
+// It logs the chi route *pattern*, never the request path. Access to a
+// calendar is capability-based: the path is the credential
+// (/calendar/{token}/participant/{pid}, /magic-link/verify/{token},
+// /verify-email/{token}), so a log line carrying the path is a log line
+// carrying a replayable credential. The pattern keeps the placeholders and
+// drops the values. Neither the IP nor the User-Agent is logged, on purpose —
+// do not add them.
 func Logger(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		start := time.Now()
 		ww := middleware.NewWrapResponseWriter(w, r.ProtoMajor)
 
+		// The pattern is only filled in once chi has matched the route, which
+		// happens inside next.ServeHTTP; reading it from the deferred call is
+		// what makes it available. chi mutates the routing context in place,
+		// so the value is visible through the request we were handed.
 		defer func() {
 			logger.FromContext(r.Context()).Info("request",
 				"method", r.Method,
-				"path", r.URL.Path,
+				"route", routePattern(r),
 				"status", ww.Status(),
 				"duration_ms", time.Since(start).Milliseconds(),
 				"bytes", ww.BytesWritten(),
@@ -61,6 +86,17 @@ func Logger(next http.Handler) http.Handler {
 	})
 }
 
+// routePattern returns the chi route pattern for a request, or unroutedLabel
+// when no route matched. RouteContext and RoutePattern are both nil-safe, so
+// this also covers the middleware being used outside a chi router.
+func routePattern(r *http.Request) string {
+	pattern := chi.RouteContext(r.Context()).RoutePattern()
+	if pattern == "" {
+		return unroutedLabel
+	}
+	return pattern
+}
+
 // Recoverer recovers from panics
 func Recoverer(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -69,7 +105,7 @@ func Recoverer(next http.Handler) http.Handler {
 				logger.FromContext(r.Context()).Error("panic recovered",
 					"error", err,
 				)
-				http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+				httputil.Error(w, http.StatusInternalServerError, httputil.ErrCodeInternal, "Internal Server Error")
 			}
 		}()
 
@@ -121,31 +157,49 @@ func Auth(jwtManager *jwt.Manager, c cache.Cache) func(http.Handler) http.Handle
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			authHeader := r.Header.Get("Authorization")
 			if authHeader == "" {
-				http.Error(w, "Authorization header required", http.StatusUnauthorized)
+				httputil.Error(w, http.StatusUnauthorized, httputil.ErrCodeUnauthorized, "Authorization header required")
 				return
 			}
 
 			parts := strings.SplitN(authHeader, " ", 2)
 			if len(parts) != 2 || strings.ToLower(parts[0]) != "bearer" {
-				http.Error(w, "Invalid authorization header format", http.StatusUnauthorized)
+				httputil.Error(w, http.StatusUnauthorized, httputil.ErrCodeUnauthorized, "Invalid authorization header format")
 				return
 			}
 
 			claims, err := jwtManager.ValidateAccessToken(parts[1])
 			if err != nil {
-				http.Error(w, "Invalid or expired token", http.StatusUnauthorized)
+				httputil.Error(w, http.StatusUnauthorized, httputil.ErrCodeUnauthorized, "Invalid or expired token")
 				return
 			}
 
-			// Check if token was issued before a password change
+			// Check whether the token was issued before a password change. This
+			// is the only revocation mechanism the system has: access tokens are
+			// self-contained and cannot otherwise be withdrawn. A cache we cannot
+			// read therefore has to fail closed — treating an unreadable cache as
+			// "nothing revoked" silently revives every token a password change
+			// was supposed to kill, for as long as the outage lasts.
 			if c != nil && c.IsEnabled() {
 				var changedAt int64
 				key := cache.UserPasswordChangedKey(claims.UserID)
-				if err := c.Get(r.Context(), key, &changedAt); err == nil {
+				switch err := c.Get(r.Context(), key, &changedAt); {
+				case err == nil:
 					if claims.IssuedAt != nil && claims.IssuedAt.Unix() < changedAt {
-						http.Error(w, "Token invalidated by password change", http.StatusUnauthorized)
+						httputil.Error(w, http.StatusUnauthorized, httputil.ErrCodeUnauthorized, "Token invalidated by password change")
 						return
 					}
+				case errors.Is(err, redis.Nil):
+					// A miss is an answer: no password change is on record.
+				default:
+					// The request is refused, but with 503 rather than 401: the
+					// token may well be valid, we simply cannot prove it has not
+					// been revoked. A 401 would make every client discard a good
+					// session over a transient cache outage.
+					logger.FromContext(r.Context()).Error("token revocation check failed, refusing the request",
+						"error", err,
+					)
+					httputil.Error(w, http.StatusServiceUnavailable, errCodeUnavailable, "Unable to verify token revocation")
+					return
 				}
 			}
 
@@ -167,7 +221,7 @@ func RequireRole(roles ...string) func(http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			userRole, ok := r.Context().Value(UserRoleKey).(string)
 			if !ok {
-				http.Error(w, "Unauthorized", http.StatusUnauthorized)
+				httputil.Error(w, http.StatusUnauthorized, httputil.ErrCodeUnauthorized, "Unauthorized")
 				return
 			}
 
@@ -180,7 +234,7 @@ func RequireRole(roles ...string) func(http.Handler) http.Handler {
 			}
 
 			if !hasRole {
-				http.Error(w, "Forbidden", http.StatusForbidden)
+				httputil.Error(w, http.StatusForbidden, httputil.ErrCodeForbidden, "Forbidden")
 				return
 			}
 

--- a/pkg/middleware/middleware_test.go
+++ b/pkg/middleware/middleware_test.go
@@ -23,6 +23,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/go-chi/chi/v5"
+	"github.com/redis/go-redis/v9"
+
 	"github.com/whento/pkg/cache"
 	"github.com/whento/pkg/jwt"
 	"github.com/whento/pkg/logger"
@@ -190,6 +193,194 @@ func TestLoggerPassesTheRequestThrough(t *testing.T) {
 	if rec.Code != http.StatusOK {
 		t.Errorf("status = %d, want 200", rec.Code)
 	}
+}
+
+// captureLogs redirects the package logger into a buffer for the duration of one test.
+func captureLogs(t *testing.T) *bytes.Buffer {
+	t.Helper()
+
+	original := logger.Default()
+	t.Cleanup(func() { logger.SetDefault(original) })
+
+	var buf bytes.Buffer
+	logger.SetDefault(slog.New(slog.NewJSONHandler(&buf, nil)))
+
+	return &buf
+}
+
+// TestLoggerNeverLogsTheRequestPath is the whole point of logging a route pattern.
+// Access to a calendar is capability-based: whoever holds the link is the participant,
+// and the link is entirely contained in the path. A log line carrying the path is a
+// credential sitting in a log file, replayable by anyone who can read it — support
+// staff, a log shipper, a backup, an aggregator.
+func TestLoggerNeverLogsTheRequestPath(t *testing.T) {
+	const (
+		calendarToken  = "Xk3f9QvR2mNbT7wLpZ4sYd8H"
+		participantID  = "6f9619ff-8b86-d011-b42d-00c04fc964ff"
+		verifyToken    = "e1ee9c1f5f6c4a3b9d0e2f7a8b6c5d4e"
+		magicLinkToken = "a94a8fe5ccb19ba61c4c0873d391e987"
+	)
+
+	tests := []struct {
+		name      string
+		pattern   string
+		target    string
+		wantRoute string
+		secrets   []string
+	}{
+		{
+			name:      "a participant availability link",
+			pattern:   "/availabilities/calendar/{token}/participant/{pid}",
+			target:    "/availabilities/calendar/" + calendarToken + "/participant/" + participantID,
+			wantRoute: "/availabilities/calendar/{token}/participant/{pid}",
+			secrets:   []string{calendarToken, participantID},
+		},
+		{
+			name:      "a magic link",
+			pattern:   "/magic-link/verify/{token}",
+			target:    "/magic-link/verify/" + magicLinkToken,
+			wantRoute: "/magic-link/verify/{token}",
+			secrets:   []string{magicLinkToken},
+		},
+		{
+			name:      "an email verification link",
+			pattern:   "/verify-email/{token}",
+			target:    "/verify-email/" + verifyToken,
+			wantRoute: "/verify-email/{token}",
+			secrets:   []string{verifyToken},
+		},
+		{
+			// A query string is no safer than a path segment; nothing but the pattern
+			// is logged, so it cannot leak either.
+			name:      "a token in the query string",
+			pattern:   "/calendars/{token}",
+			target:    "/calendars/" + calendarToken + "?invite=" + verifyToken,
+			wantRoute: "/calendars/{token}",
+			secrets:   []string{calendarToken, verifyToken},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			buf := captureLogs(t)
+
+			router := chi.NewRouter()
+			router.Use(Logger)
+			router.Get(tt.pattern, func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(http.StatusOK)
+			})
+
+			rec := httptest.NewRecorder()
+			router.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, tt.target, nil))
+
+			if rec.Code != http.StatusOK {
+				t.Fatalf("status = %d, want 200 — the route did not match", rec.Code)
+			}
+
+			line := decodeLogLine(t, buf)
+			if got, _ := line["route"].(string); got != tt.wantRoute {
+				t.Errorf("route = %q, want %q", got, tt.wantRoute)
+			}
+			for _, secret := range tt.secrets {
+				if strings.Contains(buf.String(), secret) {
+					t.Errorf("the log line leaks %q: %s", secret, buf.String())
+				}
+			}
+			// The line is still worth keeping: it says what was called and how it went.
+			if got, _ := line["method"].(string); got != http.MethodGet {
+				t.Errorf("method = %q, want GET", got)
+			}
+			if got, ok := line["status"].(float64); !ok || int(got) != http.StatusOK {
+				t.Errorf("status = %v, want 200", line["status"])
+			}
+		})
+	}
+}
+
+// TestLoggerFallsBackWhenNoRouteMatched covers the case the deferred read cannot serve:
+// chi only fills the pattern in once it has matched a route, so a 404 has none. Falling
+// back to the raw path there would put every mistyped or probed credential in the log.
+func TestLoggerFallsBackWhenNoRouteMatched(t *testing.T) {
+	const stolenToken = "Xk3f9QvR2mNbT7wLpZ4sYd8H"
+
+	tests := []struct {
+		name  string
+		serve func(w http.ResponseWriter, r *http.Request)
+	}{
+		{
+			name: "a request no route matches",
+			serve: func(w http.ResponseWriter, r *http.Request) {
+				router := chi.NewRouter()
+				router.Use(Logger)
+				router.Get("/calendars/{token}", func(w http.ResponseWriter, _ *http.Request) {})
+				router.ServeHTTP(w, r)
+			},
+		},
+		{
+			// Logger is also usable outside a chi router, where there is no routing
+			// context at all. RouteContext and RoutePattern are both nil-safe.
+			name: "no chi router at all",
+			serve: func(w http.ResponseWriter, r *http.Request) {
+				Logger(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+					w.WriteHeader(http.StatusOK)
+				})).ServeHTTP(w, r)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			buf := captureLogs(t)
+
+			target := "/does/not/exist/" + stolenToken
+			tt.serve(httptest.NewRecorder(), httptest.NewRequest(http.MethodGet, target, nil))
+
+			line := decodeLogLine(t, buf)
+			if got, _ := line["route"].(string); got != unroutedLabel {
+				t.Errorf("route = %q, want %q", got, unroutedLabel)
+			}
+			if strings.Contains(buf.String(), stolenToken) {
+				t.Errorf("the fallback leaked the raw path: %s", buf.String())
+			}
+		})
+	}
+}
+
+// TestLoggerLogsNeitherIPNorUserAgent pins a deliberate omission. The owner's constraint
+// is that no personal data is stored, and an access log is storage like any other.
+func TestLoggerLogsNeitherIPNorUserAgent(t *testing.T) {
+	buf := captureLogs(t)
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.RemoteAddr = "198.51.100.23:44321"
+	req.Header.Set("User-Agent", "Mozilla/5.0 (a very distinguishing fingerprint)")
+
+	var reached bool
+	Logger(okHandler(&reached)).ServeHTTP(httptest.NewRecorder(), req)
+
+	for _, unwanted := range []string{"198.51.100.23", "Mozilla/5.0", "distinguishing"} {
+		if strings.Contains(buf.String(), unwanted) {
+			t.Errorf("the log line contains %q: %s", unwanted, buf.String())
+		}
+	}
+}
+
+func decodeLogLine(t *testing.T, buf *bytes.Buffer) map[string]any {
+	t.Helper()
+
+	raw := bytes.TrimSpace(buf.Bytes())
+	if len(raw) == 0 {
+		t.Fatal("nothing was logged")
+	}
+	// Only the request line is of interest; take the last one written.
+	lines := bytes.Split(raw, []byte("\n"))
+
+	var line map[string]any
+	if err := json.Unmarshal(lines[len(lines)-1], &line); err != nil {
+		t.Fatalf("the log line is not JSON: %v (%q)", err, buf.String())
+	}
+
+	return line
 }
 
 func TestCORS(t *testing.T) {
@@ -466,16 +657,24 @@ func newManagerWithExpiry(t *testing.T, accessExpiry time.Duration) *jwt.Manager
 }
 
 // stubCache answers Get from a fixed map. Everything else is a no-op, since Auth only
-// ever reads.
+// ever reads. A failure set on the stub is returned instead of a lookup, which is how
+// the outage cases below are written.
 type stubCache struct {
 	enabled bool
 	values  map[string]int64
+	failure error
 }
 
 func (c *stubCache) Get(_ context.Context, key string, dest interface{}) error {
+	if c.failure != nil {
+		return c.failure
+	}
+
 	value, ok := c.values[key]
 	if !ok {
-		return errors.New("miss")
+		// redis.Nil is the miss sentinel throughout this codebase, and Auth has to tell
+		// a miss (nothing revoked) from an outage (nothing known).
+		return redis.Nil
 	}
 	target, ok := dest.(*int64)
 	if !ok {
@@ -506,6 +705,7 @@ func TestAuthHonoursAPasswordChange(t *testing.T) {
 		name        string
 		cache       cache.Cache
 		wantReached bool
+		wantStatus  int
 	}{
 		{
 			name:        "no cache at all",
@@ -528,14 +728,28 @@ func TestAuthHonoursAPasswordChange(t *testing.T) {
 			wantReached: true,
 		},
 		{
-			name:        "the password changed after the token was issued",
-			cache:       &stubCache{enabled: true, values: map[string]int64{cache.UserPasswordChangedKey("user-1"): time.Now().Add(time.Hour).Unix()}},
-			wantReached: false,
+			name:       "the password changed after the token was issued",
+			cache:      &stubCache{enabled: true, values: map[string]int64{cache.UserPasswordChangedKey("user-1"): time.Now().Add(time.Hour).Unix()}},
+			wantStatus: http.StatusUnauthorized,
 		},
 		{
 			name:        "somebody else changed their password",
 			cache:       &stubCache{enabled: true, values: map[string]int64{cache.UserPasswordChangedKey("user-2"): time.Now().Add(time.Hour).Unix()}},
 			wantReached: true,
+		},
+		{
+			// The whole point of the check: an unreadable cache cannot answer "nothing
+			// was revoked". Letting the request through would quietly resurrect every
+			// token a password change had killed, for as long as the outage lasts.
+			name:       "the cache is unreachable",
+			cache:      &stubCache{enabled: true, failure: errors.New("dial tcp: connection refused")},
+			wantStatus: http.StatusServiceUnavailable,
+		},
+		{
+			// A stored value that cannot be decoded is an error, not a miss.
+			name:       "the stored value is unusable",
+			cache:      &stubCache{enabled: true, failure: errors.New("json: cannot unmarshal string into int64")},
+			wantStatus: http.StatusServiceUnavailable,
 		},
 	}
 
@@ -552,8 +766,8 @@ func TestAuthHonoursAPasswordChange(t *testing.T) {
 			if reached != tt.wantReached {
 				t.Errorf("reached = %v, want %v (status %d)", reached, tt.wantReached, rec.Code)
 			}
-			if !tt.wantReached && rec.Code != http.StatusUnauthorized {
-				t.Errorf("status = %d, want 401", rec.Code)
+			if !tt.wantReached && rec.Code != tt.wantStatus {
+				t.Errorf("status = %d, want %d", rec.Code, tt.wantStatus)
 			}
 		})
 	}
@@ -631,6 +845,143 @@ func TestContextKeysAreNotPlainStrings(t *testing.T) {
 
 	if reached || rec.Code != http.StatusUnauthorized {
 		t.Errorf("a plain string context value passed the role check (status %d)", rec.Code)
+	}
+}
+
+// TestErrorResponsesUseTheStandardEnvelope covers every refusal the middleware chain can
+// produce. A client that meets {"success":false,"error":{...}} everywhere else and bare
+// text/plain here has to special-case the middleware, and the frontend's axios client —
+// which unwraps the envelope — cannot show the reason at all.
+func TestErrorResponsesUseTheStandardEnvelope(t *testing.T) {
+	manager := newManager(t)
+	token, err := manager.GenerateAccessToken("user-1", "ada@example.test", "user")
+	if err != nil {
+		t.Fatalf("GenerateAccessToken: %v", err)
+	}
+
+	authed := func() *http.Request {
+		req := httptest.NewRequest(http.MethodGet, "/", nil)
+		req.Header.Set("Authorization", "Bearer "+token)
+		return req
+	}
+
+	tests := []struct {
+		name       string
+		handler    http.Handler
+		request    *http.Request
+		wantStatus int
+		wantCode   string
+	}{
+		{
+			name:       "no authorization header",
+			handler:    Auth(manager, nil)(okHandler(new(bool))),
+			request:    httptest.NewRequest(http.MethodGet, "/", nil),
+			wantStatus: http.StatusUnauthorized,
+			wantCode:   "UNAUTHORIZED",
+		},
+		{
+			name:    "a malformed authorization header",
+			handler: Auth(manager, nil)(okHandler(new(bool))),
+			request: func() *http.Request {
+				req := httptest.NewRequest(http.MethodGet, "/", nil)
+				req.Header.Set("Authorization", "Basic nope")
+				return req
+			}(),
+			wantStatus: http.StatusUnauthorized,
+			wantCode:   "UNAUTHORIZED",
+		},
+		{
+			name:    "an invalid token",
+			handler: Auth(manager, nil)(okHandler(new(bool))),
+			request: func() *http.Request {
+				req := httptest.NewRequest(http.MethodGet, "/", nil)
+				req.Header.Set("Authorization", "Bearer not-a-jwt")
+				return req
+			}(),
+			wantStatus: http.StatusUnauthorized,
+			wantCode:   "UNAUTHORIZED",
+		},
+		{
+			name: "a token killed by a password change",
+			handler: Auth(manager, &stubCache{
+				enabled: true,
+				values:  map[string]int64{cache.UserPasswordChangedKey("user-1"): time.Now().Add(time.Hour).Unix()},
+			})(okHandler(new(bool))),
+			request:    authed(),
+			wantStatus: http.StatusUnauthorized,
+			wantCode:   "UNAUTHORIZED",
+		},
+		{
+			name:       "a revocation check that could not run",
+			handler:    Auth(manager, &stubCache{enabled: true, failure: errors.New("connection refused")})(okHandler(new(bool))),
+			request:    authed(),
+			wantStatus: http.StatusServiceUnavailable,
+			wantCode:   errCodeUnavailable,
+		},
+		{
+			name:       "a request that never authenticated",
+			handler:    RequireRole("admin")(okHandler(new(bool))),
+			request:    httptest.NewRequest(http.MethodGet, "/", nil),
+			wantStatus: http.StatusUnauthorized,
+			wantCode:   "UNAUTHORIZED",
+		},
+		{
+			name:    "the wrong role",
+			handler: RequireRole("admin")(okHandler(new(bool))),
+			request: httptest.NewRequest(http.MethodGet, "/", nil).WithContext(
+				context.WithValue(context.Background(), UserRoleKey, "user"),
+			),
+			wantStatus: http.StatusForbidden,
+			wantCode:   "FORBIDDEN",
+		},
+		{
+			name: "a recovered panic",
+			handler: Recoverer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+				panic("boom")
+			})),
+			request:    httptest.NewRequest(http.MethodGet, "/", nil),
+			wantStatus: http.StatusInternalServerError,
+			wantCode:   "INTERNAL_ERROR",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rec := httptest.NewRecorder()
+			tt.handler.ServeHTTP(rec, tt.request)
+
+			if rec.Code != tt.wantStatus {
+				t.Fatalf("status = %d, want %d", rec.Code, tt.wantStatus)
+			}
+			if got := rec.Header().Get("Content-Type"); !strings.HasPrefix(got, "application/json") {
+				t.Errorf("Content-Type = %q, want application/json", got)
+			}
+
+			// Decoded against the wire shape rather than httputil's struct: what matters
+			// is what a client actually receives.
+			var body struct {
+				Success bool `json:"success"`
+				Error   *struct {
+					Code    string `json:"code"`
+					Message string `json:"message"`
+				} `json:"error"`
+			}
+			if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+				t.Fatalf("the body is not JSON: %v (%q)", err, rec.Body.String())
+			}
+			if body.Success {
+				t.Error("success = true on an error response")
+			}
+			if body.Error == nil {
+				t.Fatalf("no error object in %q", rec.Body.String())
+			}
+			if body.Error.Code != tt.wantCode {
+				t.Errorf("error code = %q, want %q", body.Error.Code, tt.wantCode)
+			}
+			if body.Error.Message == "" {
+				t.Error("the error carries no message")
+			}
+		})
 	}
 }
 

--- a/pkg/middleware/ratelimit.go
+++ b/pkg/middleware/ratelimit.go
@@ -6,6 +6,10 @@ package middleware
 
 import (
 	"context"
+	"crypto/hmac"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
 	"net"
 	"net/http"
@@ -15,6 +19,8 @@ import (
 
 	"github.com/redis/go-redis/v9"
 	"golang.org/x/time/rate"
+
+	"github.com/whento/pkg/httputil"
 )
 
 // trustedProxyIPs holds exact trusted proxy IPs.
@@ -113,7 +119,11 @@ func (rl *RateLimiter) Limit(cfg RateLimitConfig) func(http.Handler) http.Handle
 				return
 			}
 
-			allowed, remaining, resetAt, backend, err := rl.check(r.Context(), key, cfg.Requests, cfg.Window)
+			// The raw key identifies a person: an IP address, a user id, or a
+			// request path that in this API carries a calendar token and a
+			// participant UUID. None of it may be written to Redis or held in
+			// the in-memory map, so only its digest ever reaches a backend.
+			allowed, remaining, resetAt, backend, err := rl.check(r.Context(), hashRateLimitKey(key), cfg.Requests, cfg.Window)
 			if err != nil {
 				// Should not happen: memory backend never errors. Allow the
 				// request rather than block on an unexpected internal error.
@@ -128,7 +138,7 @@ func (rl *RateLimiter) Limit(cfg RateLimitConfig) func(http.Handler) http.Handle
 
 			if !allowed {
 				w.Header().Set("Retry-After", fmt.Sprintf("%d", resetAt-time.Now().Unix()))
-				http.Error(w, "Rate limit exceeded", http.StatusTooManyRequests)
+				httputil.Error(w, http.StatusTooManyRequests, httputil.ErrCodeRateLimited, "Rate limit exceeded")
 				return
 			}
 
@@ -283,6 +293,49 @@ func (b *memoryBackend) stop() {
 	b.once.Do(func() { close(b.done) })
 }
 
+// rateLimitKeySalt keys the HMAC that turns a rate limit key into a bucket
+// name. It is random per process, so a stolen Redis dump cannot be matched
+// back to an IP, a user id or a calendar token by hashing candidates: without
+// the salt there is nothing to compare against.
+var rateLimitKeySalt = newRateLimitKeySalt()
+
+func newRateLimitKeySalt() []byte {
+	salt := make([]byte, 32)
+	if _, err := rand.Read(salt); err != nil {
+		// crypto/rand does not fail on any platform Go supports. Refusing to
+		// start beats silently limiting with a predictable all-zero salt.
+		panic("middleware: cannot generate the rate limit key salt: " + err.Error())
+	}
+	return salt
+}
+
+// SetRateLimitKeySalt pins the salt used to derive bucket names, which several
+// instances sharing one Redis must do to share their buckets: with the default
+// per-process random salt each instance hashes the same client to a different
+// bucket, so N instances grant N times the configured allowance. Pass a secret
+// with at least as much entropy as the limit is worth, and call this before
+// serving any request.
+func SetRateLimitKeySalt(secret string) {
+	if secret == "" {
+		return
+	}
+	sum := sha256.Sum256([]byte(secret))
+	rateLimitKeySalt = sum[:]
+}
+
+// hashRateLimitKey derives the stored bucket name from a rate limit key.
+//
+// The key itself is personal data — an IP address, a user id, or a path such
+// as /calendar/{token}/participant/{pid} whose values are the credential — and
+// the owner's constraint is that none of it is stored. 128 bits of a salted
+// HMAC keeps collisions out of reach (a collision would merge two clients'
+// budgets) while storing nothing that can be read back.
+func hashRateLimitKey(key string) string {
+	mac := hmac.New(sha256.New, rateLimitKeySalt)
+	mac.Write([]byte(key))
+	return hex.EncodeToString(mac.Sum(nil)[:16])
+}
+
 // IPKeyFunc returns the real client IP as rate limit key.
 // X-Forwarded-For and X-Real-IP are only trusted when the direct
 // connection comes from a configured trusted proxy.
@@ -344,7 +397,10 @@ func UserKeyFunc(r *http.Request) string {
 	return GetUserID(r.Context())
 }
 
-// CombinedKeyFunc combines path and IP for endpoint-specific limiting
+// CombinedKeyFunc combines path and IP for endpoint-specific limiting.
+// The path is deliberately the exact one, not the route pattern, so that two
+// calendars do not share a budget. It is never stored as such: Limit hashes
+// the key before any backend sees it (see hashRateLimitKey).
 func CombinedKeyFunc(r *http.Request) string {
 	return fmt.Sprintf("%s:%s", r.URL.Path, IPKeyFunc(r))
 }

--- a/pkg/middleware/ratelimit_keys_test.go
+++ b/pkg/middleware/ratelimit_keys_test.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 )
 
 // The key function decides *whose* budget a request spends. Getting it wrong is not a
@@ -211,5 +212,184 @@ func TestCombinedKeyFunc(t *testing.T) {
 	other.RemoteAddr = "203.0.113.7:54321"
 	if CombinedKeyFunc(other) == CombinedKeyFunc(req) {
 		t.Error("two different paths from one IP produced the same key")
+	}
+}
+
+// The tests below lock the behaviour that chi's RealIP middleware used to break. RealIP
+// overwrote r.RemoteAddr with whatever X-Forwarded-For said, before this package ever
+// looked at it — so IPKeyFunc read the attacker's header as if it were the peer address
+// and the trusted-proxy configuration decided nothing at all. Rotating one header per
+// request then bought an unlimited number of login attempts.
+
+func TestForgedForwardedHeadersDoNotChangeTheKey(t *testing.T) {
+	tests := []struct {
+		name    string
+		proxies []string
+		remote  string
+		want    string
+	}{
+		{
+			name:   "nothing is trusted",
+			remote: "203.0.113.7:54321",
+			want:   "203.0.113.7",
+		},
+		{
+			// A deployment does sit behind a proxy, but this caller is not it. The
+			// header is only as trustworthy as the hop that set it.
+			name:    "a proxy is configured but the caller is not it",
+			proxies: []string{"10.0.0.1", "172.17.0.0/16"},
+			remote:  "203.0.113.7:54321",
+			want:    "203.0.113.7",
+		},
+	}
+
+	forgeries := []string{
+		"1.1.1.1",
+		"2.2.2.2",
+		"10.0.0.1",             // claiming to be the trusted proxy itself
+		"203.0.113.8, 1.1.1.1", // a chain the attacker wrote end to end
+		"not-an-ip",
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			withTrustedProxies(t, tt.proxies)
+
+			for _, forged := range forgeries {
+				req := httptest.NewRequest(http.MethodPost, "/api/v1/auth/login", nil)
+				req.RemoteAddr = tt.remote
+				req.Header.Set("X-Forwarded-For", forged)
+				req.Header.Set("X-Real-IP", "9.9.9.9")
+
+				if got := IPKeyFunc(req); got != tt.want {
+					t.Errorf("X-Forwarded-For %q produced key %q, want %q", forged, got, tt.want)
+				}
+			}
+		})
+	}
+}
+
+func TestATrustedProxyIsStillHonoured(t *testing.T) {
+	withTrustedProxies(t, []string{"10.0.0.1", "172.17.0.0/16"})
+
+	tests := []struct {
+		name      string
+		remote    string
+		forwarded string
+		realIP    string
+		want      string
+	}{
+		{
+			name:      "an exact proxy address",
+			remote:    "10.0.0.1:1234",
+			forwarded: "198.51.100.5",
+			want:      "198.51.100.5",
+		},
+		{
+			name:   "a proxy inside a trusted range, via X-Real-IP",
+			remote: "172.17.0.9:1234",
+			realIP: "198.51.100.6",
+			want:   "198.51.100.6",
+		},
+		{
+			// Only the entry the trusted proxy appended counts; the rest of the chain
+			// came from the client.
+			name:      "the entry the proxy appended",
+			remote:    "10.0.0.1:1234",
+			forwarded: "1.1.1.1, 198.51.100.7",
+			want:      "198.51.100.7",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodPost, "/api/v1/auth/login", nil)
+			req.RemoteAddr = tt.remote
+			if tt.forwarded != "" {
+				req.Header.Set("X-Forwarded-For", tt.forwarded)
+			}
+			if tt.realIP != "" {
+				req.Header.Set("X-Real-IP", tt.realIP)
+			}
+
+			// Without this, every user behind the proxy shares one bucket and a single
+			// noisy client locks out a whole office.
+			if got := IPKeyFunc(req); got != tt.want {
+				t.Errorf("key = %q, want the forwarded client %q", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestRateLimitSurvivesHeaderRotation is the end-to-end form of the same guarantee: the
+// limit has to bite even when every request carries a different forged header.
+func TestRateLimitSurvivesHeaderRotation(t *testing.T) {
+	withTrustedProxies(t, []string{"10.0.0.1"})
+
+	rl := NewRateLimiter(nil)
+	defer rl.Stop()
+
+	handler := rl.Limit(RateLimitConfig{
+		Requests: 2,
+		Window:   time.Minute,
+		KeyFunc:  IPKeyFunc,
+	})(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	statuses := make([]int, 0, 3)
+	for _, forged := range []string{"1.1.1.1", "2.2.2.2", "3.3.3.3"} {
+		req := httptest.NewRequest(http.MethodPost, "/api/v1/auth/login", nil)
+		req.RemoteAddr = "203.0.113.7:54321"
+		req.Header.Set("X-Forwarded-For", forged)
+
+		rec := httptest.NewRecorder()
+		handler.ServeHTTP(rec, req)
+		statuses = append(statuses, rec.Code)
+	}
+
+	want := []int{http.StatusOK, http.StatusOK, http.StatusTooManyRequests}
+	for i, status := range statuses {
+		if status != want[i] {
+			t.Fatalf("request %d returned %d, want %d (statuses: %v)", i+1, status, want[i], statuses)
+		}
+	}
+}
+
+// TestRateLimitSeparatesClientsBehindATrustedProxy is the symmetric case: with a real
+// proxy in front, two genuinely different clients must not share a budget.
+func TestRateLimitSeparatesClientsBehindATrustedProxy(t *testing.T) {
+	withTrustedProxies(t, []string{"10.0.0.1"})
+
+	rl := NewRateLimiter(nil)
+	defer rl.Stop()
+
+	handler := rl.Limit(RateLimitConfig{
+		Requests: 1,
+		Window:   time.Minute,
+		KeyFunc:  IPKeyFunc,
+	})(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	call := func(client string) int {
+		req := httptest.NewRequest(http.MethodPost, "/api/v1/auth/login", nil)
+		req.RemoteAddr = "10.0.0.1:1234"
+		req.Header.Set("X-Forwarded-For", client)
+
+		rec := httptest.NewRecorder()
+		handler.ServeHTTP(rec, req)
+
+		return rec.Code
+	}
+
+	if got := call("198.51.100.5"); got != http.StatusOK {
+		t.Fatalf("the first client got %d, want 200", got)
+	}
+	if got := call("198.51.100.6"); got != http.StatusOK {
+		t.Fatalf("a second client behind the same proxy got %d, want 200", got)
+	}
+	if got := call("198.51.100.5"); got != http.StatusTooManyRequests {
+		t.Fatalf("the first client's second request got %d, want 429", got)
 	}
 }

--- a/pkg/middleware/ratelimit_test.go
+++ b/pkg/middleware/ratelimit_test.go
@@ -5,10 +5,14 @@
 package middleware
 
 import (
+	"bytes"
 	"context"
+	"encoding/hex"
+	"encoding/json"
 	"errors"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 )
@@ -101,15 +105,19 @@ func TestMemoryBackend_Sweep(t *testing.T) {
 }
 
 // fakePrimary stands in for redisBackend so we can exercise failure paths
-// without a real Redis instance.
+// without a real Redis instance. It records the keys it was handed, which is
+// what the privacy tests below inspect: those keys are exactly what a real
+// Redis would have persisted.
 type fakePrimary struct {
 	err     error
 	calls   int
 	allowed bool
+	keys    []string
 }
 
-func (f *fakePrimary) Allow(_ context.Context, _ string, limit int, _ time.Duration) (bool, int, int64, error) {
+func (f *fakePrimary) Allow(_ context.Context, key string, limit int, _ time.Duration) (bool, int, int64, error) {
 	f.calls++
+	f.keys = append(f.keys, key)
 	if f.err != nil {
 		return false, 0, 0, f.err
 	}
@@ -276,5 +284,239 @@ func TestRateLimiter_Middleware_BackendHeader(t *testing.T) {
 				t.Fatalf("X-RateLimit-Backend = %q, want %q", got, tc.want)
 			}
 		})
+	}
+}
+
+// The rate limiter is the one component that sees every request from every visitor, so
+// whatever it writes down is a record of who came and when. The owner's constraint is
+// that nothing personal is stored: not an IP, not a user id, and above all not a
+// participant link, which in this API is the credential itself.
+
+// withKeySalt pins the key salt for one test and restores it afterwards. The salt is
+// process-wide, so tests touching it cannot run in parallel.
+func withKeySalt(t *testing.T, secret string) {
+	t.Helper()
+
+	previous := rateLimitKeySalt
+	t.Cleanup(func() { rateLimitKeySalt = previous })
+
+	SetRateLimitKeySalt(secret)
+}
+
+func TestRateLimiterStoresNothingIdentifying(t *testing.T) {
+	const (
+		calendarToken = "Xk3f9QvR2mNbT7wLpZ4sYd8H"
+		participantID = "6f9619ff-8b86-d011-b42d-00c04fc964ff"
+		clientIP      = "203.0.113.7"
+	)
+
+	tests := []struct {
+		name    string
+		key     string
+		secrets []string
+	}{
+		{
+			name:    "an IP address",
+			key:     clientIP,
+			secrets: []string{clientIP},
+		},
+		{
+			name:    "a user id",
+			key:     "018f3b6c-7c9a-7d2e-9b17-1c2d3e4f5a6b",
+			secrets: []string{"018f3b6c-7c9a-7d2e-9b17-1c2d3e4f5a6b"},
+		},
+		{
+			// CombinedKeyFunc produces exactly this: the participant link, whose token
+			// and UUID together are the whole authorisation, joined to the caller's IP.
+			name:    "a participant link joined to an IP",
+			key:     "/api/v1/availabilities/calendar/" + calendarToken + "/participant/" + participantID + ":" + clientIP,
+			secrets: []string{calendarToken, participantID, clientIP},
+		},
+		{
+			name:    "a magic link",
+			key:     "/api/v1/magic-link/verify/a94a8fe5ccb19ba61c4c0873d391e987:" + clientIP,
+			secrets: []string{"a94a8fe5ccb19ba61c4c0873d391e987", clientIP},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rl := NewRateLimiter(nil)
+			defer rl.Stop()
+			primary := &fakePrimary{allowed: true}
+			rl.primary = primary
+
+			handler := rl.Limit(RateLimitConfig{
+				Requests: 5,
+				Window:   time.Minute,
+				KeyFunc:  func(*http.Request) string { return tt.key },
+			})(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(http.StatusOK)
+			}))
+
+			rec := httptest.NewRecorder()
+			handler.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/x", nil))
+
+			if len(primary.keys) != 1 {
+				t.Fatalf("the backend saw %d keys, want 1", len(primary.keys))
+			}
+			stored := primary.keys[0]
+			for _, secret := range tt.secrets {
+				if strings.Contains(stored, secret) {
+					t.Errorf("the stored key %q contains %q", stored, secret)
+				}
+			}
+			// A digest, not a truncation or an encoding: reversing it must need the salt.
+			if len(stored) != 32 {
+				t.Errorf("stored key = %q (%d chars), want a 32-char digest", stored, len(stored))
+			}
+			if _, err := hex.DecodeString(stored); err != nil {
+				t.Errorf("stored key = %q, want hex: %v", stored, err)
+			}
+		})
+	}
+}
+
+// TestMemoryFallbackStoresNothingIdentifying closes the other half of the hole: when
+// Redis is down the keys live in this process's map instead, where a heap dump or a
+// debugger reads them just as easily.
+func TestMemoryFallbackStoresNothingIdentifying(t *testing.T) {
+	const clientIP = "203.0.113.7"
+
+	rl := NewRateLimiter(nil)
+	defer rl.Stop()
+
+	handler := rl.Limit(RateLimitConfig{
+		Requests: 5,
+		Window:   time.Minute,
+		KeyFunc:  func(*http.Request) string { return clientIP },
+	})(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/x", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+
+	rl.memory.mu.Lock()
+	defer rl.memory.mu.Unlock()
+	if len(rl.memory.entries) != 1 {
+		t.Fatalf("the memory backend holds %d entries, want 1", len(rl.memory.entries))
+	}
+	for key := range rl.memory.entries {
+		if strings.Contains(key, clientIP) {
+			t.Errorf("the in-memory key %q contains the caller's IP", key)
+		}
+	}
+}
+
+func TestHashRateLimitKey(t *testing.T) {
+	withKeySalt(t, "a fixed salt for this test")
+
+	tests := []struct {
+		name string
+		a    string
+		b    string
+		same bool
+	}{
+		// Determinism is what makes the limit work at all: the same caller has to land
+		// in the same bucket on every request.
+		{name: "the same key twice", a: "203.0.113.7", b: "203.0.113.7", same: true},
+		{name: "two IPs", a: "203.0.113.7", b: "203.0.113.8"},
+		{name: "two endpoints for one IP", a: "/login:203.0.113.7", b: "/register:203.0.113.7"},
+		{name: "two calendars", a: "/calendar/aaa:203.0.113.7", b: "/calendar/bbb:203.0.113.7"},
+		// Neighbouring keys must not collapse into one bucket, or one visitor's traffic
+		// would spend another's budget.
+		{name: "a prefix of another key", a: "203.0.113.7", b: "203.0.113.70"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := hashRateLimitKey(tt.a) == hashRateLimitKey(tt.b); got != tt.same {
+				t.Errorf("hash(%q) == hash(%q) is %v, want %v", tt.a, tt.b, got, tt.same)
+			}
+		})
+	}
+}
+
+// TestHashRateLimitKeyDependsOnTheSalt is what stops an attacker with a copy of the
+// Redis keyspace from recovering the inputs: the IPv4 space is small enough to hash
+// exhaustively, so an unsalted digest of an IP is the IP.
+func TestHashRateLimitKeyDependsOnTheSalt(t *testing.T) {
+	withKeySalt(t, "salt one")
+	first := hashRateLimitKey("203.0.113.7")
+
+	withKeySalt(t, "salt two")
+	second := hashRateLimitKey("203.0.113.7")
+
+	if first == second {
+		t.Error("the digest does not depend on the salt, so it can be brute-forced offline")
+	}
+
+	// A default salt is random per process, so it must not be all zeroes either.
+	if bytes.Equal(newRateLimitKeySalt(), make([]byte, 32)) {
+		t.Error("the generated salt is all zeroes")
+	}
+	if bytes.Equal(newRateLimitKeySalt(), newRateLimitKeySalt()) {
+		t.Error("two generated salts are identical, so they are not random")
+	}
+}
+
+// TestSetRateLimitKeySaltIgnoresAnEmptySecret keeps a missing configuration value from
+// silently replacing the random salt with a known constant.
+func TestSetRateLimitKeySaltIgnoresAnEmptySecret(t *testing.T) {
+	withKeySalt(t, "the configured salt")
+	before := hashRateLimitKey("203.0.113.7")
+
+	SetRateLimitKeySalt("")
+
+	if hashRateLimitKey("203.0.113.7") != before {
+		t.Error("an empty secret changed the salt")
+	}
+}
+
+// TestRateLimitedResponseUsesTheEnvelope pins the 429 to the same {data, error} shape as
+// every other response, so a client can read the reason instead of a bare text/plain body.
+func TestRateLimitedResponseUsesTheEnvelope(t *testing.T) {
+	rl := NewRateLimiter(nil)
+	defer rl.Stop()
+
+	handler := rl.Limit(RateLimitConfig{
+		Requests: 1,
+		Window:   time.Minute,
+		KeyFunc:  func(*http.Request) string { return "ip" },
+	})(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	handler.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest(http.MethodGet, "/x", nil))
+
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/x", nil))
+
+	if rec.Code != http.StatusTooManyRequests {
+		t.Fatalf("status = %d, want 429", rec.Code)
+	}
+	// The headers are what a well-behaved client backs off on; hashing the key must not
+	// have disturbed them.
+	for _, header := range []string{"X-RateLimit-Limit", "X-RateLimit-Remaining", "X-RateLimit-Reset", "Retry-After"} {
+		if rec.Header().Get(header) == "" {
+			t.Errorf("%s is missing from the 429", header)
+		}
+	}
+
+	var body struct {
+		Success bool `json:"success"`
+		Error   *struct {
+			Code string `json:"code"`
+		} `json:"error"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("the body is not JSON: %v (%q)", err, rec.Body.String())
+	}
+	if body.Success || body.Error == nil || body.Error.Code != "RATE_LIMITED" {
+		t.Errorf("body = %q, want the standard envelope with RATE_LIMITED", rec.Body.String())
 	}
 }


### PR DESCRIPTION
First of five stacked PRs from a full technical audit. **Merge in order** — each is based on the previous one, so this must land first.

None of these six were visible from the outside, and none had a test that would have caught them.

## What is fixed

**Rate limiting was bypassable.** chi's `RealIP` ran as the first global middleware and overwrote `r.RemoteAddr` with a client-supplied header *before* `IPKeyFunc` checked whether the connection came from a trusted proxy. Every per-IP limit fell to header rotation, and `TRUSTED_PROXIES` was dead configuration.

**The SSE stream could not work at all.** `WriteTimeout` is 15s, the heartbeat is 25s, and nothing rearmed the write deadline — so the first keep-alive always failed and browsers reconnected forever on the 3s retry hint. The seven existing tests used `httptest.NewRecorder`, which never exercises a real `http.Server`. That is why nobody saw it.

**Request logs carried reusable credentials.** Participant access is capability-based, so the path *is* the secret: logging `r.URL.Path` wrote calendar tokens, participant ids, magic links and email-verification tokens in clear. Logging the chi route pattern keeps the operational signal and drops the values. Rate-limit buckets leaked the same values plus the IP into Redis, and are now stored under a salted HMAC.

**JWT signing keys did not survive a redeploy** — no volume was mounted on `/app/keys`, so every container recreation minted a new pair and logged every user out.

**Binary versioning was a silent no-op.** The `-X` flags aimed at symbols package `main` never declared, and Go ignores those without warning.

**Range validation answered 500 on user input**, and three detached goroutines dropped notification failures into an empty block with no timeout and no `recover`, where a panic would have taken the process down.

Also closes the fail-open revocation check (a Redis outage silently revalidated tokens a password change should have killed), routes 401/403/429 through the standard JSON envelope, propagates the request context into the refresh-token write, and fixes four vue-i18n calls that passed a default message where the library expects interpolation values.

## Verification

Every fix ships with a regression test, because the existing suite covered none of them. The SSE one fails without the fix with `the stream died 302ms after it opened, with a WriteTimeout of 300ms`.

- `make lint` — 0 issues, both modules, both build tags
- `make format-check` — clean
- `go build` / `go test` — selfhosted and cloud, both green
- frontend: `vue-tsc`, ESLint, Prettier, 386 tests — green

## Two decisions worth reviewing

1. **A Redis outage now returns 503** on authenticated requests rather than accepting possibly-revoked tokens. 503 rather than 401 so clients do not discard a valid session over a transient blip — but it is a behaviour change during an incident.
2. **The version is not exposed on `/api/health`** — that would disclose the exact build to unauthenticated callers. It is in the startup log and the Swagger spec instead.