### PR TITLE
fix(frontend): bundle Inter instead of fetching it from Google

### DIFF
--- a/docs/logging-and-privacy.md
+++ b/docs/logging-and-privacy.md
@@ -337,3 +337,25 @@ The last row is the one people forget. Every verification, magic-link, reset and
 notification email goes through the SMTP provider configured in `SMTP_HOST`, and
 that provider sees recipient addresses and the links themselves. Choose it as
 carefully as you chose where to host the database.
+
+## No third-party requests from the browser
+
+The application makes no request to a host it does not control. This matters as
+much as what the server logs: a stylesheet, a font or a script fetched from
+another origin hands that origin the visitor's IP address, User-Agent and
+referring page, on every page load, before any consent is possible.
+
+Inter used to be fetched from `fonts.googleapis.com` as a render-blocking
+stylesheet. It is bundled now (`@fontsource-variable/inter`, imported from
+`src/main.ts`), served from the same origin as the application. Two things were
+wrong with the old arrangement, and only one of them was about privacy:
+
+- every visitor's address reached Google, which is precisely what the rest of
+  this document promises does not happen to an address;
+- a self-hosted instance on a network that cannot reach Google waited for that
+  request to time out before painting anything. An 18-second first paint was
+  observed in exactly that situation.
+
+Both are closed by the same change, and neither can come back quietly: a new
+external `<link>` or `@import` would show up in the network panel of any page
+load, and there is nothing in the build that fetches one.

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -13,10 +13,13 @@
     <link rel="alternate" hreflang="fr" href="https://whento.be/?lang=fr" />
     <link rel="alternate" hreflang="x-default" href="https://whento.be/" />
 
-    <!-- Fonts -->
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800&display=swap" rel="stylesheet">
+    <!--
+      Inter is bundled, not fetched from fonts.googleapis.com. That request was a
+      render-blocking stylesheet on a third-party host: a self-hosted instance
+      behind a firewall waited for it to time out before painting anything, and
+      every visitor's IP address went to Google — which is the one thing this
+      product promises not to do with an address. See docs/adr/0005.
+    -->
 
     <!--
       Resolve the theme before the first paint.

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,6 +8,7 @@
       "name": "whento-frontend",
       "version": "0.1.0",
       "dependencies": {
+        "@fontsource-variable/inter": "^5.3.0",
         "@vueuse/core": "^14.4.0",
         "axios": "^1.19.0",
         "countries-and-timezones": "^3.10.0",
@@ -535,6 +536,15 @@
       "integrity": "sha512-5Aap/GaRupgNx/feGBwLLTVv8OQFfv3pq2lPRzPg9R+IOBnDgghTGW7l7EuVXOvg5cc/xSAlRW8rBrjIC3Nvqw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@fontsource-variable/inter": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/@fontsource-variable/inter/-/inter-5.3.0.tgz",
+      "integrity": "sha512-OupL48va4JNofb97w6NYeF9S7W/kHNKM0Er8Dem5nqi4jeOLrVJDoE8tZEpnMJmtkvNbB1EIPPwHcdkF6b1oUA==",
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
+      }
     },
     "node_modules/@humanfs/core": {
       "version": "0.19.2",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -27,6 +27,7 @@
     "format:check": "prettier --check \"{src,dev,e2e,e2e-backend,scripts}/**/*.{vue,ts,js,mjs,css,json}\" \"*.{ts,js,json}\""
   },
   "dependencies": {
+    "@fontsource-variable/inter": "^5.3.0",
     "@vueuse/core": "^14.4.0",
     "axios": "^1.19.0",
     "countries-and-timezones": "^3.10.0",

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -4,6 +4,13 @@
  * SPDX-License-Identifier: BSL-1.1
  */
 
+// Self-hosted Inter — see the note in index.html. Imported here rather than from
+// style.css because Tailwind v4 processes that file's @import itself and drops
+// this one, which silently produced a stylesheet naming a font it never shipped.
+// The variable file covers 100-900, so the six static weights the old
+// fonts.googleapis.com link fetched are now one request against our own origin.
+import '@fontsource-variable/inter';
+
 import { createApp } from 'vue';
 import { createPinia } from 'pinia';
 import App from './App.vue';

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -55,8 +55,13 @@
   --color-danger-900: #7f1d1d;
 
   /* Font Family */
-  --font-sans: Inter, system-ui, sans-serif;
-  --font-display: 'Cal Sans', Inter, system-ui, sans-serif;
+  /* 'Inter Variable' is the family @fontsource-variable/inter registers; plain
+     Inter stays behind it so a system-installed copy still wins over the
+     fallback. 'Cal Sans' was never loaded by anything and resolved to Inter
+     already — kept as a first choice in case it is ever bundled, but it is not
+     a missing dependency. */
+  --font-sans: 'Inter Variable', Inter, system-ui, sans-serif;
+  --font-display: 'Cal Sans', 'Inter Variable', Inter, system-ui, sans-serif;
 
   /* Box Shadows */
   --shadow-soft: 0 2px 15px -3px rgb(0 0 0 / 0.07), 0 10px 20px -2px rgb(0 0 0 / 0.04);


### PR DESCRIPTION
Found while looking at a network trace: `fonts.googleapis.com` taking **18.78 s** for 0 bytes, as a render-blocking stylesheet in `<head>`.

Two problems, only one of them about performance.

**It sent every visitor's IP to a third party.** On every page load, before any consent is possible — along with the User-Agent and the referring page. The audit series spent a whole phase taking addresses out of the logs and out of Redis, and wrote the constraint down in ADR 0005, while the home page handed them to Google before any of that code ran.

**It made first paint depend on reaching an external host.** A self-hosted instance on a network that cannot get there waits for the request to time out before rendering anything. That is the 18 seconds in the trace.

## The change

Bundled with `@fontsource-variable/inter`, served from the application's own origin. One variable file covers the 100–900 range the theme uses, so the six static weights the old link requested are now a single request, split by character set: **48 kB of Latin** for a French or English reader, and the Cyrillic, Greek and Vietnamese subsets are never fetched.

`--font-sans` gains `'Inter Variable'` ahead of plain `Inter`, so a system-installed copy still wins over the fallback. `'Cal Sans'` in `--font-display` was never loaded by anything and already resolved to Inter — left as a first choice, but it is not a missing dependency.

## One trap worth knowing about

I first put the `@import` in `style.css`. **Tailwind v4 processes that file's imports itself and silently dropped it.** The build succeeded and produced a stylesheet naming `'Inter Variable'` with zero `@font-face` rules and zero font files — the family resolved to the system fallback and nothing failed.

It is imported from `main.ts` now, and the check is on the artefact rather than on the build exiting 0: **7 woff2 files emitted**, one `@font-face` block in the bundled CSS, and **0 `<link>` to googleapis or gstatic in `dist/index.html`**.

## Verification

`vue-tsc`, `eslint --max-warnings 0`, Prettier, 678 unit tests, 31 Playwright tests — all green on a clean `npm ci` from this branch.

`docs/logging-and-privacy.md` gains a section stating the property this establishes: the application makes no request to a host it does not control.