### PR TITLE
fix(auth): keep the access token out of persistent storage

### DIFF
--- a/cmd/routes_auth.go
+++ b/cmd/routes_auth.go
@@ -24,7 +24,12 @@ func registerAuthRoutes(r chi.Router, d *deps, h *handlers) {
 		r.Group(func(r chi.Router) {
 			l.on(r, perPathIP(5, time.Minute)).Post("/login", h.auth.Login)
 			l.on(r, perPathIP(3, time.Minute)).Post("/register", h.auth.Register)
-			l.on(r, perPathIP(5, time.Minute)).Post("/refresh", h.auth.Refresh)
+			// Higher than its neighbours because the access token now lives only in
+			// memory: every cold page load spends one refresh, where it used to take
+			// one only after the token expired. At five a minute, reloading a few
+			// times in a row signed the user out. Guessing the value this protects is
+			// not the threat — it is an RSA-signed JWT — so the headroom costs nothing.
+			l.on(r, perPathIP(30, time.Minute)).Post("/refresh", h.auth.Refresh)
 			r.Post("/logout", h.auth.Logout)
 
 			// Password reset (public - no auth required)

--- a/frontend/src/api/client.test.ts
+++ b/frontend/src/api/client.test.ts
@@ -108,23 +108,49 @@ describe('apiClient', () => {
 
   afterEach(() => {
     vi.restoreAllMocks();
+    // restoreAllMocks does not undo stubGlobal, and a stubbed navigator carrying a
+    // fake Web Lock would follow us into the next test.
+    vi.unstubAllGlobals();
   });
 
   describe('tokens', () => {
-    it('persists and restores the access token', () => {
+    it('keeps the access token out of storage entirely', () => {
       apiClient.setToken('a-token');
-      expect(localStorage.getItem('access_token')).toBe('a-token');
 
-      apiClient.clearToken();
-      expect(localStorage.getItem('access_token')).toBeNull();
+      // The whole point of the change: a script that can read stored data must not
+      // find the token there. Only the flag survives, and it is not a credential.
+      expect(Object.values(localStorage)).not.toContain('a-token');
+      expect(localStorage.getItem('whento.session')).toBe('1');
+    });
 
-      localStorage.setItem('access_token', 'restored');
-      apiClient.loadToken();
+    it('uses the in-memory token for requests', async () => {
+      apiClient.setToken('a-token');
 
       const seen = withAdapter(() => ok({}));
-      return apiClient.get('/anything').then(() => {
-        expect(seen[0].auth).toBe('Bearer restored');
-      });
+      await apiClient.get('/anything');
+
+      expect(seen[0].auth).toBe('Bearer a-token');
+    });
+
+    it('drops the token and the flag on clear', async () => {
+      apiClient.setToken('a-token');
+      apiClient.clearToken();
+
+      expect(apiClient.hasSession()).toBe(false);
+      expect(localStorage.getItem('whento.session')).toBeNull();
+
+      const seen = withAdapter(() => ok({}));
+      await apiClient.get('/anything');
+
+      expect(seen[0].auth).toBeUndefined();
+    });
+
+    it('reports a session so a cold load knows to refresh', () => {
+      expect(apiClient.hasSession()).toBe(false);
+
+      apiClient.setToken('a-token');
+
+      expect(apiClient.hasSession()).toBe(true);
     });
 
     it('sends no Authorization header when there is no token', async () => {
@@ -245,8 +271,34 @@ describe('apiClient', () => {
 
       await expect(apiClient.get('/calendars')).rejects.toBeTruthy();
 
-      expect(localStorage.getItem('access_token')).toBeNull();
+      expect(apiClient.hasSession()).toBe(false);
       expect(window.location.href).toBe('/login');
+    });
+
+    it('skips the call when another tab refreshed while we queued', async () => {
+      apiClient.setToken('expired');
+
+      // Stand in for the Web Lock: while the second tab waits its turn, the winning
+      // tab's token arrives over the channel. Spending the cookie again here would
+      // rotate away the token we were just handed and sign both tabs out.
+      const locks = {
+        request: async (_name: string, fn: () => Promise<void>) => {
+          apiClient.setToken('from-another-tab');
+          return fn();
+        },
+      };
+      vi.stubGlobal('navigator', { ...navigator, locks });
+
+      const seen = withAdapter((config, callNumber) => {
+        if (config.url === '/auth/refresh') return ok({ access_token: 'rotated-away' });
+        return callNumber === 0 ? unauthorized() : ok({ ok: true });
+      });
+
+      await expect(apiClient.get('/calendars')).resolves.toEqual({ ok: true });
+
+      expect(seen.filter(r => r.url === '/auth/refresh')).toHaveLength(0);
+      const replay = seen.filter(r => r.url === '/calendars');
+      expect(replay[replay.length - 1].auth).toBe('Bearer from-another-tab');
     });
 
     it('does not redirect away from a public route', async () => {
@@ -259,7 +311,7 @@ describe('apiClient', () => {
 
       await expect(apiClient.get('/calendars')).rejects.toBeTruthy();
 
-      expect(localStorage.getItem('access_token')).toBeNull();
+      expect(apiClient.hasSession()).toBe(false);
       expect(window.location.href).toBe('');
     });
   });

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -8,11 +8,21 @@ import axios, { type AxiosInstance, type AxiosError, type InternalAxiosRequestCo
 import type { ApiResponse, ApiError } from '@/types';
 import router from '@/router';
 
+/** Marks that this browser has a session; never holds the token itself. */
+const SESSION_FLAG = 'whento.session';
+
+/** Names the cross-tab channel and the cross-tab lock. */
+const AUTH_CHANNEL = 'whento.auth';
+const REFRESH_LOCK = 'whento.refresh';
+
+type AuthMessage = { type: 'token'; token: string } | { type: 'logout' };
+
 class ApiClient {
   private client: AxiosInstance;
   private accessToken: string | null = null;
   /** The one refresh in progress, shared by every caller that needs it. */
   private refreshInFlight: Promise<void> | null = null;
+  private channel: BroadcastChannel | null = null;
 
   constructor() {
     this.client = axios.create({
@@ -25,6 +35,42 @@ class ApiClient {
     });
 
     this.setupInterceptors();
+    this.setupChannel();
+  }
+
+  /**
+   * Share tokens and sign-outs with the other tabs on this origin.
+   *
+   * Refresh tokens are single-use — the backend deletes the old one before issuing the
+   * next (auth_service.go, `RefreshToken`). Tabs each hold their own in-memory access
+   * token, so restoring a window full of pinned tabs used to fire one `/auth/refresh`
+   * per tab against the same cookie: the first rotated it and the rest got a 401 and a
+   * forced sign-out. Whichever tab wins the lock now passes its result to the others.
+   *
+   * Nothing is persisted — the channel is same-origin and in-memory, so this does not
+   * put the token back within reach of stored-data reads.
+   */
+  private setupChannel() {
+    if (typeof BroadcastChannel === 'undefined') {
+      return;
+    }
+
+    this.channel = new BroadcastChannel(AUTH_CHANNEL);
+    this.channel.onmessage = (event: MessageEvent<AuthMessage>) => {
+      const message = event.data;
+      if (message?.type === 'token') {
+        // Set directly rather than through setToken, which would echo it back.
+        this.accessToken = message.token;
+        localStorage.setItem(SESSION_FLAG, '1');
+      } else if (message?.type === 'logout') {
+        this.accessToken = null;
+        localStorage.removeItem(SESSION_FLAG);
+      }
+    };
+  }
+
+  private broadcast(message: AuthMessage) {
+    this.channel?.postMessage(message);
   }
 
   private setupInterceptors() {
@@ -82,6 +128,7 @@ class ApiClient {
 
   private forceLogout() {
     this.clearToken();
+    this.broadcast({ type: 'logout' });
     // Only redirect to login if current route is not public
     const currentRoute = router.currentRoute.value;
     const isPublicRoute = currentRoute.meta.public === true;
@@ -105,19 +152,24 @@ class ApiClient {
 
   setToken(token: string) {
     this.accessToken = token;
-    localStorage.setItem('access_token', token);
+    // A flag, not a secret. The token itself never leaves memory: anything persisted
+    // is readable by any script that gets to run on the page, which is exactly what
+    // CodeQL's js/clear-text-storage-of-sensitive-data flagged when the JWT lived
+    // here. All this records is "there was a session in this browser", so a cold load
+    // knows whether to spend a `/auth/refresh` before deciding the visitor is
+    // anonymous. The refresh cookie is what actually proves the session.
+    localStorage.setItem(SESSION_FLAG, '1');
+    this.broadcast({ type: 'token', token });
   }
 
   clearToken() {
     this.accessToken = null;
-    localStorage.removeItem('access_token');
+    localStorage.removeItem(SESSION_FLAG);
   }
 
-  loadToken() {
-    const token = localStorage.getItem('access_token');
-    if (token) {
-      this.accessToken = token;
-    }
+  /** Whether this browser had a session, and so whether a cold load should refresh. */
+  hasSession(): boolean {
+    return localStorage.getItem(SESSION_FLAG) !== null;
   }
 
   /**
@@ -125,12 +177,13 @@ class ApiClient {
    *
    * Every request that 401s calls this, and a page load fires several at once — the
    * calendar alone issues three. Without the shared promise each of them started its
-   * own `/auth/refresh`, so one expired token produced a burst of refreshes against an
-   * endpoint rate limited to 5 per minute per IP. The later ones then raced: refresh
-   * rotates the token, so whichever landed last could invalidate the token an earlier
-   * one had just stored, logging the user out mid-session.
+   * own `/auth/refresh`, so one expired token produced a burst of refreshes against a
+   * rate-limited endpoint. The later ones then raced: refresh rotates the token, so
+   * whichever landed last could invalidate the token an earlier one had just stored,
+   * logging the user out mid-session.
    *
    * Callers all await the same in-flight request and continue with the token it stored.
+   * `performRefresh` extends the same guarantee across tabs.
    */
   async refreshToken(): Promise<void> {
     if (this.refreshInFlight) {
@@ -145,11 +198,42 @@ class ApiClient {
   }
 
   private async performRefresh(): Promise<void> {
-    const response = await this.client.post<ApiResponse<{ access_token: string }>>('/auth/refresh');
-    const newToken = response.data.data?.access_token;
-    if (newToken) {
-      this.setToken(newToken);
+    // Whatever we were holding when we decided a refresh was needed. If it has
+    // changed by the time the lock is ours, another tab refreshed while we queued
+    // and its token is already ours via the channel — spending the cookie again
+    // would rotate away the token we just received.
+    const staleToken = this.accessToken;
+
+    // Serialise across tabs as well as within one. Web Locks queue rather than fail,
+    // so a tab that arrives second waits here instead of racing the first onto a
+    // refresh cookie that is already spent.
+    return this.withRefreshLock(async () => {
+      if (this.accessToken !== staleToken) {
+        return;
+      }
+
+      const response =
+        await this.client.post<ApiResponse<{ access_token: string }>>('/auth/refresh');
+      const newToken = response.data.data?.access_token;
+      if (newToken) {
+        this.setToken(newToken);
+      }
+    });
+  }
+
+  /**
+   * Run `fn` while holding the cross-tab refresh lock.
+   *
+   * jsdom implements neither `navigator.locks` nor a stand-in for it, so the tests run
+   * the callback directly. That is the honest fallback: a single tab is exactly the
+   * case the lock is not needed for, and `refreshInFlight` still serialises within it.
+   */
+  private withRefreshLock(fn: () => Promise<void>): Promise<void> {
+    if (typeof navigator === 'undefined' || !navigator.locks) {
+      return fn();
     }
+
+    return navigator.locks.request(REFRESH_LOCK, fn);
   }
 
   // Generic HTTP methods

--- a/frontend/src/router/index.test.ts
+++ b/frontend/src/router/index.test.ts
@@ -25,7 +25,7 @@ const authApi = {
 const apiClient = {
   setToken: vi.fn(),
   clearToken: vi.fn(),
-  loadToken: vi.fn(),
+  hasSession: vi.fn(() => false),
 };
 
 vi.mock('@/api/auth', () => ({ authApi }));
@@ -72,6 +72,9 @@ async function navigate(to: RouteLocationNormalized) {
 beforeEach(() => {
   vi.clearAllMocks();
   localStorage.clear();
+  // clearAllMocks clears calls, not implementations: without this a test that
+  // opts into a session leaves every later test signed in.
+  apiClient.hasSession.mockReturnValue(false);
   setActivePinia(createPinia());
 });
 
@@ -125,7 +128,7 @@ describe('authGuard', () => {
       // gave up after fifty attempts. A slow `/auth/me` therefore either blocked
       // navigation for five seconds or, worse, timed out and evaluated `requiresAuth`
       // against an empty store — bouncing a signed-in user to /login.
-      localStorage.setItem('access_token', 'stored');
+      apiClient.hasSession.mockReturnValue(true);
       const gate = deferred<User>();
       authApi.getMe.mockReturnValue(gate.promise);
 
@@ -144,7 +147,7 @@ describe('authGuard', () => {
     });
 
     it('lets a slow restore through however long it takes', async () => {
-      localStorage.setItem('access_token', 'stored');
+      apiClient.hasSession.mockReturnValue(true);
       const gate = deferred<User>();
       authApi.getMe.mockReturnValue(gate.promise);
 
@@ -164,7 +167,7 @@ describe('authGuard', () => {
     });
 
     it('starts the restore itself when main.ts has not', async () => {
-      localStorage.setItem('access_token', 'stored');
+      apiClient.hasSession.mockReturnValue(true);
       authApi.getMe.mockResolvedValue(USER);
 
       await navigate(target({ requiresAuth: true }, '/dashboard'));
@@ -174,7 +177,7 @@ describe('authGuard', () => {
     });
 
     it('does not re-restore on a second navigation', async () => {
-      localStorage.setItem('access_token', 'stored');
+      apiClient.hasSession.mockReturnValue(true);
       authApi.getMe.mockResolvedValue(USER);
 
       await navigate(target({ requiresAuth: true }, '/dashboard'));
@@ -195,7 +198,7 @@ describe('authGuard', () => {
     });
 
     it('lets a signed-in user through', async () => {
-      localStorage.setItem('access_token', 'stored');
+      apiClient.hasSession.mockReturnValue(true);
       authApi.getMe.mockResolvedValue(USER);
 
       const next = await navigate(target({ requiresAuth: true }, '/dashboard'));
@@ -204,7 +207,7 @@ describe('authGuard', () => {
     });
 
     it('redirects when the stored token turns out to be stale', async () => {
-      localStorage.setItem('access_token', 'stale');
+      apiClient.hasSession.mockReturnValue(true);
       authApi.getMe.mockRejectedValue({ code: 'UNAUTHORIZED' });
 
       const next = await navigate(target({ requiresAuth: true }, '/dashboard'));
@@ -218,7 +221,7 @@ describe('authGuard', () => {
 
   describe('requiresAdmin', () => {
     it('sends a non-admin back to the dashboard', async () => {
-      localStorage.setItem('access_token', 'stored');
+      apiClient.hasSession.mockReturnValue(true);
       authApi.getMe.mockResolvedValue(USER);
 
       const next = await navigate(target({ requiresAuth: true, requiresAdmin: true }, '/admin'));
@@ -227,7 +230,7 @@ describe('authGuard', () => {
     });
 
     it('lets an admin through', async () => {
-      localStorage.setItem('access_token', 'stored');
+      apiClient.hasSession.mockReturnValue(true);
       authApi.getMe.mockResolvedValue(ADMIN);
 
       const next = await navigate(target({ requiresAuth: true, requiresAdmin: true }, '/admin'));
@@ -244,7 +247,7 @@ describe('authGuard', () => {
 
   describe('hideForAuth', () => {
     it('keeps a signed-in user off the login page', async () => {
-      localStorage.setItem('access_token', 'stored');
+      apiClient.hasSession.mockReturnValue(true);
       authApi.getMe.mockResolvedValue(USER);
 
       const next = await navigate(target({ public: true, hideForAuth: true }, '/login'));
@@ -278,7 +281,7 @@ describe('authGuard', () => {
   });
 
   it('calls next exactly once on every path', async () => {
-    localStorage.setItem('access_token', 'stored');
+    apiClient.hasSession.mockReturnValue(true);
     authApi.getMe.mockResolvedValue(USER);
 
     for (const meta of [

--- a/frontend/src/stores/auth.test.ts
+++ b/frontend/src/stores/auth.test.ts
@@ -25,7 +25,7 @@ const authApi = {
 const apiClient = {
   setToken: vi.fn(),
   clearToken: vi.fn(),
-  loadToken: vi.fn(),
+  hasSession: vi.fn(() => false),
 };
 
 vi.mock('@/api/auth', () => ({ authApi }));
@@ -68,6 +68,9 @@ function freshStore() {
 beforeEach(() => {
   vi.clearAllMocks();
   localStorage.clear();
+  // clearAllMocks clears calls, not implementations: without this a test that
+  // opts into a session leaves every later test signed in.
+  apiClient.hasSession.mockReturnValue(false);
 });
 
 describe('auth store', () => {
@@ -270,8 +273,30 @@ describe('auth store', () => {
     });
   });
 
+  describe('the MFA temp token', () => {
+    it('holds it in memory and never in storage', () => {
+      const store = freshStore();
+
+      store.setTempToken('half-signed-in');
+
+      expect(store.tempToken).toBe('half-signed-in');
+      // It authorises finishing a sign-in, so persisting it is the same defect as
+      // persisting the access token.
+      expect(Object.values(localStorage)).not.toContain('half-signed-in');
+    });
+
+    it('clears on demand, so a cancelled second factor leaves nothing behind', () => {
+      const store = freshStore();
+      store.setTempToken('half-signed-in');
+
+      store.clearTempToken();
+
+      expect(store.tempToken).toBeNull();
+    });
+  });
+
   describe('initializeAuth', () => {
-    it('marks itself initialized without a call when there is no token', async () => {
+    it('marks itself initialized without a call when there is no session', async () => {
       const store = freshStore();
 
       await store.initializeAuth();
@@ -281,14 +306,16 @@ describe('auth store', () => {
       expect(store.isAuthenticated).toBe(false);
     });
 
-    it('restores the session from a stored token', async () => {
-      localStorage.setItem('access_token', 'stored');
+    it('restores the session from the refresh cookie', async () => {
+      apiClient.hasSession.mockReturnValue(true);
       authApi.getMe.mockResolvedValue(USER);
       const store = freshStore();
 
       await store.initializeAuth();
 
-      expect(apiClient.loadToken).toHaveBeenCalled();
+      // No token is loaded from anywhere: /auth/me goes out bare, 401s, and the
+      // client's interceptor spends the httpOnly cookie to replay it.
+      expect(apiClient.setToken).not.toHaveBeenCalled();
       expect(store.user).toEqual(USER);
       expect(store.initialized).toBe(true);
     });
@@ -296,7 +323,7 @@ describe('auth store', () => {
     it('completes, and surfaces no error, when the stored token is stale', async () => {
       // An expired token is not a failure the user should read about: they are simply
       // signed out, and the guard sends them to /login if the route needs a session.
-      localStorage.setItem('access_token', 'stale');
+      apiClient.hasSession.mockReturnValue(true);
       authApi.getMe.mockRejectedValue({ code: 'UNAUTHORIZED' });
       const store = freshStore();
 
@@ -309,7 +336,7 @@ describe('auth store', () => {
     });
 
     it('runs once however many callers ask', async () => {
-      localStorage.setItem('access_token', 'stored');
+      apiClient.hasSession.mockReturnValue(true);
       authApi.getMe.mockResolvedValue(USER);
       const store = freshStore();
 
@@ -321,7 +348,7 @@ describe('auth store', () => {
     it('holds every concurrent caller until the one fetch completes', async () => {
       // Pinia wraps actions, so the promise objects handed back are not identical;
       // what has to hold is that they all wait on the same single `/auth/me`.
-      localStorage.setItem('access_token', 'stored');
+      apiClient.hasSession.mockReturnValue(true);
       const gate = deferred<User>();
       authApi.getMe.mockReturnValue(gate.promise);
       const store = freshStore();
@@ -345,7 +372,7 @@ describe('auth store', () => {
     });
 
     it('does not re-run after it has settled', async () => {
-      localStorage.setItem('access_token', 'stored');
+      apiClient.hasSession.mockReturnValue(true);
       authApi.getMe.mockResolvedValue(USER);
       const store = freshStore();
 
@@ -357,7 +384,7 @@ describe('auth store', () => {
 
     it('gives each Pinia instance its own initialisation', async () => {
       // Module-scoped state here would leak the first test's session into the next.
-      localStorage.setItem('access_token', 'stored');
+      apiClient.hasSession.mockReturnValue(true);
       authApi.getMe.mockResolvedValue(USER);
 
       await freshStore().initializeAuth();
@@ -370,7 +397,7 @@ describe('auth store', () => {
   describe('whenReady', () => {
     it('starts the restore itself when nobody has', async () => {
       // The guard must not depend on main.ts having run first.
-      localStorage.setItem('access_token', 'stored');
+      apiClient.hasSession.mockReturnValue(true);
       authApi.getMe.mockResolvedValue(USER);
       const store = freshStore();
 
@@ -381,7 +408,7 @@ describe('auth store', () => {
     });
 
     it('does not resolve before the session is known, however slow that is', async () => {
-      localStorage.setItem('access_token', 'stored');
+      apiClient.hasSession.mockReturnValue(true);
       const gate = deferred<User>();
       authApi.getMe.mockReturnValue(gate.promise);
       const store = freshStore();

--- a/frontend/src/stores/auth.ts
+++ b/frontend/src/stores/auth.ts
@@ -139,22 +139,47 @@ export const useAuthStore = defineStore('auth', () => {
   }
 
   /**
-   * Restore the session from the stored access token.
+   * The five-minute token that carries a half-finished login from the password (or
+   * passkey) step to the second factor.
+   *
+   * In memory rather than in localStorage: it authorises completing a sign-in, so
+   * persisting it is the same defect as persisting the access token, and it only has
+   * to survive a `router.push` — an SPA navigation, which keeps module state. A hard
+   * reload on /verify-mfa loses it, and that view sends the visitor back to /login.
+   */
+  const tempToken = ref<string | null>(null);
+
+  function setTempToken(token: string) {
+    tempToken.value = token;
+  }
+
+  function clearTempToken() {
+    tempToken.value = null;
+  }
+
+  /**
+   * Restore the session from the httpOnly refresh cookie.
+   *
+   * A cold load starts with no access token — it only ever lives in memory — so
+   * `/auth/me` 401s and the client's interceptor spends the refresh cookie and
+   * replays the call. That is the same path an expired token has always taken, so
+   * there is no second refresh implementation to keep honest here.
+   *
+   * The session flag is what keeps an anonymous visitor from paying for that round
+   * trip on every public page.
    *
    * Idempotent: concurrent and repeat callers all get the same promise, so the
    * router guard calling it never triggers a second `/auth/me`.
    */
   function initializeAuth(): Promise<void> {
     initPromise ??= (async () => {
-      apiClient.loadToken();
-      const token = localStorage.getItem('access_token');
-      if (token) {
+      if (apiClient.hasSession()) {
         try {
           await fetchUser();
         } catch {
-          // Token expired or invalid. Not an error the user needs to see: they are
-          // simply signed out, and the guard will send them to /login if the route
-          // needs a session.
+          // The refresh cookie is gone or expired. Not an error the user needs to
+          // see: they are simply signed out, and the guard will send them to /login
+          // if the route needs a session.
           apiClient.clearToken();
           clearError();
         }
@@ -180,6 +205,7 @@ export const useAuthStore = defineStore('auth', () => {
     loading,
     error,
     initialized,
+    tempToken,
 
     // Getters
     isAuthenticated,
@@ -195,6 +221,8 @@ export const useAuthStore = defineStore('auth', () => {
     forgotPassword,
     resetPassword,
     setTokens,
+    setTempToken,
+    clearTempToken,
     initializeAuth,
     whenReady,
     clearError,

--- a/frontend/src/views/Login.vue
+++ b/frontend/src/views/Login.vue
@@ -325,7 +325,7 @@ async function handleSubmit() {
 
     // Check if 2FA is required
     if (response?.require_mfa && response?.temp_token) {
-      localStorage.setItem('temp_token', response.temp_token);
+      authStore.setTempToken(response.temp_token);
       router.push('/verify-mfa');
       return;
     }
@@ -416,7 +416,7 @@ async function loginWithDiscoverablePasskey() {
 
     // Check if 2FA is required
     if (response.require_mfa && response.temp_token) {
-      localStorage.setItem('temp_token', response.temp_token);
+      authStore.setTempToken(response.temp_token);
       router.push('/verify-mfa');
       return;
     }

--- a/frontend/src/views/VerifyMFA.vue
+++ b/frontend/src/views/VerifyMFA.vue
@@ -140,10 +140,9 @@ const isCodeValid = computed(() => {
 });
 
 onMounted(async () => {
-  // Check if temp token exists
-  const tempToken = localStorage.getItem('temp_token');
-  if (!tempToken) {
-    // No temp token, redirect to login
+  // The temp token lives in the store, so it survives the router.push that got us
+  // here but not a hard reload — in which case the login has to start over.
+  if (!authStore.tempToken) {
     router.push('/login');
     return;
   }
@@ -161,12 +160,12 @@ function toggleCodeType() {
 }
 
 function backToLogin() {
-  localStorage.removeItem('temp_token');
+  authStore.clearTempToken();
   router.push('/login');
 }
 
 async function handleVerify() {
-  const tempToken = localStorage.getItem('temp_token');
+  const tempToken = authStore.tempToken;
   if (!tempToken) {
     router.push('/login');
     return;
@@ -183,7 +182,7 @@ async function handleVerify() {
     const response = await mfaApi.verify(tempToken, normalizedCode);
 
     // Clear temp token
-    localStorage.removeItem('temp_token');
+    authStore.clearTempToken();
 
     // Store real JWT tokens
     authStore.setTokens(response.access_token);

--- a/internal/auth/handlers/auth_handler.go
+++ b/internal/auth/handlers/auth_handler.go
@@ -211,6 +211,14 @@ func (h *AuthHandler) Register(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
+	// Same as Login: the refresh token is generated and stored either way, and
+	// without the cookie a freshly registered account had nothing to restore its
+	// session from once the access token stopped being persisted.
+	if resp.RefreshToken != "" {
+		setRefreshTokenCookie(w, r, resp.RefreshToken)
+		resp.RefreshToken = ""
+	}
+
 	httputil.JSON(w, http.StatusCreated, resp)
 }
 

--- a/internal/auth/handlers/auth_handler_http_test.go
+++ b/internal/auth/handlers/auth_handler_http_test.go
@@ -507,6 +507,44 @@ func TestTheRefreshTokenNeverReachesTheBody(t *testing.T) {
 	}
 }
 
+// TestRegisterSetsTheRefreshCookie guards the session of a brand-new account. Register
+// generates and stores a refresh token like Login does, but used to drop it on the floor
+// instead of setting the cookie. That went unnoticed only because the access token was
+// persisted in localStorage; once it lives in memory alone, the cookie is the only thing
+// that carries a freshly registered user across a reload.
+func TestRegisterSetsTheRefreshCookie(t *testing.T) {
+	r := newRig(t, rigOptions{allowedRegister: true, users: &mockUserRepository{count: 1}})
+
+	rec := httptest.NewRecorder()
+	req := post("/api/v1/auth/register",
+		`{"email":"ada@example.test","password":"Correct-Horse-9","display_name":"Ada"}`)
+	r.handler.Register(rec, req)
+
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("status = %d, want 201 (%q)", rec.Code, rec.Body.String())
+	}
+
+	var cookie *http.Cookie
+	for _, c := range rec.Result().Cookies() {
+		if c.Name == "refresh_token" {
+			cookie = c
+		}
+	}
+	if cookie == nil {
+		t.Fatal("register set no refresh_token cookie, so the session dies on the first reload")
+	}
+	if cookie.Value == "" {
+		t.Fatal("the refresh_token cookie is empty")
+	}
+	if !cookie.HttpOnly {
+		t.Error("the refresh token cookie is not HttpOnly, so any script can read it")
+	}
+	// Same rule as Login: the cookie carries it, the body never does.
+	if strings.Contains(rec.Body.String(), cookie.Value) {
+		t.Errorf("the refresh token is in the JSON body:\n%s", rec.Body.String())
+	}
+}
+
 func TestTheCookieIsNotSecureOverPlainHTTP(t *testing.T) {
 	// Marking it Secure over plain HTTP would make it unusable on a local install
 	// served without TLS, which is the default for a self-hosted first run.

--- a/internal/auth/models/password_reset.go
+++ b/internal/auth/models/password_reset.go
@@ -21,10 +21,15 @@ type ForgotPasswordResponse struct {
 	Message string `json:"message"`
 }
 
-// ResetPasswordResponse includes tokens for auto-login after password reset
+// ResetPasswordResponse includes tokens for auto-login after password reset.
+//
+// RefreshToken leaves over the httpOnly cookie the handler sets, never over JSON —
+// `json:"-"` here is what keeps a seven-day credential out of reach of page scripts,
+// matching AuthResponse. Serialising it made reset-password the one endpoint that
+// handed its refresh token to anything that could read a response body.
 type ResetPasswordResponse struct {
 	Message      string        `json:"message"`
 	AccessToken  string        `json:"access_token"`
-	RefreshToken string        `json:"refresh_token"`
+	RefreshToken string        `json:"-"`
 	User         *UserResponse `json:"user"`
 }

--- a/internal/auth/models/password_reset_test.go
+++ b/internal/auth/models/password_reset_test.go
@@ -1,0 +1,49 @@
+// WhenTo - Collaborative event calendar for self-hosted environments
+// Copyright (C) 2025 WhenTo Contributors
+// SPDX-License-Identifier: BSL-1.1
+
+package models
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// TestResetPasswordResponseKeepsTheRefreshTokenOutOfJSON pins the one thing the struct
+// tag is there for. Reset-password auto-signs the user in, so it carries the same pair
+// of tokens Login does — and used to be the only endpoint that serialised the refresh
+// token, handing a seven-day credential to anything that could read a response body.
+// The handler sets it as an httpOnly cookie; that is the only way it should travel.
+func TestResetPasswordResponseKeepsTheRefreshTokenOutOfJSON(t *testing.T) {
+	const secret = "a-refresh-token-worth-seven-days"
+
+	resp := &ResetPasswordResponse{
+		Message:      "Password reset successfully",
+		AccessToken:  "an-access-token",
+		RefreshToken: secret,
+		User:         &UserResponse{ID: "u-1", Email: "ada@example.test"},
+	}
+
+	encoded, err := json.Marshal(resp)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	if strings.Contains(string(encoded), secret) {
+		t.Errorf("the refresh token is in the JSON body:\n%s", encoded)
+	}
+	if strings.Contains(string(encoded), "refresh_token") {
+		t.Errorf("the response still carries a refresh_token field:\n%s", encoded)
+	}
+
+	// The access token still has to reach the client — it is short-lived and the
+	// front end holds it in memory only.
+	var decoded map[string]any
+	if err := json.Unmarshal(encoded, &decoded); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if decoded["access_token"] != "an-access-token" {
+		t.Errorf("access_token = %v, want it preserved", decoded["access_token"])
+	}
+}


### PR DESCRIPTION
Closes CodeQL alert [#2](https://github.com/When-To/whento/security/code-scanning/2) — `js/clear-text-storage-of-sensitive-data` (high).

## The alert

`localStorage.setItem('access_token', token)` in `frontend/src/api/client.ts` persisted the JWT in clear, where any script that gets to run on the page can read it. The refresh token was already an httpOnly `SameSite=Strict` cookie, so the clean foundation existed — only the access token reached past it.

CodeQL named `/auth/reset-password` as the taint source, and that turned out to be a second defect in its own right: `ResetPasswordResponse` was the one response struct without `json:"-"` on its refresh token, so that endpoint handed a seven-day credential to anything that could read a response body.

## What changed

The access token lives in the `ApiClient` instance and nowhere else. `localStorage` keeps a bare `whento.session` flag — a boolean, not a credential — so a cold load knows whether to spend a refresh before deciding the visitor is anonymous, and a participant on a public calendar link pays nothing.

Restoring a session needs no new code path: `/auth/me` goes out bare, 401s, and the existing interceptor spends the cookie and replays it. That is the same path an expired token has always taken.

### Three consequences, each handled

**Cross-tab races.** Refresh tokens are single-use (`RefreshToken` deletes before regenerating), so a window of pinned tabs booting at once would race on the same cookie and sign all but one out. A Web Lock serialises the refresh across tabs; a `BroadcastChannel` hands the result to those that queued. Nothing is persisted — the channel is same-origin and in-memory. The race predates this change (it fired whenever the access token expired), but a memory-only token would have made it a daily occurrence rather than a quarter-hourly one.

**Rate limit.** `/auth/refresh` is now spent on every cold load rather than only after an expiry, and 5/min/IP signed people out after a few reloads. Raised to 30. What protects the endpoint is an RSA-signed credential, not the limiter.

**Register set no cookie.** It generated and stored a refresh token, then dropped it. Harmless while the access token was persisted; without that, a freshly registered account lost its session on the first reload.

### Also in scope

- `ResetPasswordResponse.RefreshToken` → `json:"-"`. The handler already sets the cookie.
- The MFA `temp_token` moves from `localStorage` to the store. Same class of defect as the access token — it authorises finishing a sign-in — and it only has to survive a `router.push`. A hard reload on `/verify-mfa` now sends the visitor back to `/login`, which is correct.

## What this does and does not buy

It removes the token from persistent storage, so it is no longer reachable by anything that reads stored data after the fact — a one-shot injection, a malicious extension, a shared machine. It does **not** make an actively-running XSS harmless: script executing on the page can still call the API as the user. That is a CSP problem, not a storage one.

## Tests

- `client.test.ts` — the token is absent from storage, the flag is present, the in-memory token reaches the `Authorization` header, and a refresh is skipped when another tab won the lock.
- `auth.test.ts` — the session restores from the cookie with no token load; the temp token stays out of storage.
- `auth_handler_http_test.go` — `TestRegisterSetsTheRefreshCookie`, mirroring the existing Login assertions.
- `password_reset_test.go` — the refresh token cannot be marshalled into the response.

`make format-check`, frontend type-check/lint/684 unit tests, both build variants, and `make test` all pass locally.