### PR TITLE
chore(ci): pin Go 1.26.6 so govulncheck sees the patched stdlib

### DIFF
--- a/.github/workflows/build-cloud.yml
+++ b/.github/workflows/build-cloud.yml
@@ -30,7 +30,13 @@ concurrency:
   cancel-in-progress: false
 
 env:
-  GO_VERSION: '1.26'
+  # Patch-exact rather than the '1.26' it used to be. The 2026-08-13 Go security
+  # release fixed six stdlib advisories (GO-2026-6218, -6091, -6090, -6089, -6088,
+  # -5972) in 1.26.6, and govulncheck reports them against every build until the
+  # toolchain moves. actions/go-versions had not published 1.26.6 yet, so a floating
+  # minor still resolved to the vulnerable 1.26.5; naming the patch makes setup-go
+  # fetch it from go.dev directly. Safe to float again once the manifest catches up.
+  GO_VERSION: '1.26.6'
   NODE_VERSION: '24'
 
 jobs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,13 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 env:
-  GO_VERSION: '1.26'
+  # Patch-exact rather than the '1.26' it used to be. The 2026-08-13 Go security
+  # release fixed six stdlib advisories (GO-2026-6218, -6091, -6090, -6089, -6088,
+  # -5972) in 1.26.6, and govulncheck reports them against every build until the
+  # toolchain moves. actions/go-versions had not published 1.26.6 yet, so a floating
+  # minor still resolved to the vulnerable 1.26.5; naming the patch makes setup-go
+  # fetch it from go.dev directly. Safe to float again once the manifest catches up.
+  GO_VERSION: '1.26.6'
   NODE_VERSION: '24'
   # Must match the version the Dockerfiles install, or migrations are validated with a
   # different binary from the one that applies them in production.

--- a/.github/workflows/release-selfhosted.yml
+++ b/.github/workflows/release-selfhosted.yml
@@ -37,7 +37,13 @@ concurrency:
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
-  GO_VERSION: '1.26'
+  # Patch-exact rather than the '1.26' it used to be. The 2026-08-13 Go security
+  # release fixed six stdlib advisories (GO-2026-6218, -6091, -6090, -6089, -6088,
+  # -5972) in 1.26.6, and govulncheck reports them against every build until the
+  # toolchain moves. actions/go-versions had not published 1.26.6 yet, so a floating
+  # minor still resolved to the vulnerable 1.26.5; naming the patch makes setup-go
+  # fetch it from go.dev directly. Safe to float again once the manifest catches up.
+  GO_VERSION: '1.26.6'
   NODE_VERSION: '24'
 
 jobs:

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -31,7 +31,13 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 env:
-  GO_VERSION: '1.26'
+  # Patch-exact rather than the '1.26' it used to be. The 2026-08-13 Go security
+  # release fixed six stdlib advisories (GO-2026-6218, -6091, -6090, -6089, -6088,
+  # -5972) in 1.26.6, and govulncheck reports them against every build until the
+  # toolchain moves. actions/go-versions had not published 1.26.6 yet, so a floating
+  # minor still resolved to the vulnerable 1.26.5; naming the patch makes setup-go
+  # fetch it from go.dev directly. Safe to float again once the manifest catches up.
+  GO_VERSION: '1.26.6'
 
 jobs:
   # The cheapest useful Go check there is: it reports only vulnerabilities that are


### PR DESCRIPTION
Unblocks CI on `main` and on every open pull request. Nothing here is about application code.

## What happened

The 2026-08-13 Go security release (published 21:43 UTC) fixed six standard-library advisories in **1.26.6**:

| Advisory | Package |
|---|---|
| GO-2026-6218 | `net/url` — quadratic complexity in `resolvePath` |
| GO-2026-6091 | `html/template` — JavaScript regexp context tracking |
| GO-2026-6090 | `crypto/tls` — post-handshake message limit |
| GO-2026-6089 | `net/http` — `ReadHeaderTimeout` on the unencrypted HTTP/2 check |
| GO-2026-6088 | `encoding/xml` — recursion depth guard |
| GO-2026-5972 | stdlib |

govulncheck traces all six as reachable here — through `ListenAndServe`, `pgx` row scanning, `totp.Generate` — so the job goes red on any branch, whatever it changes. The last green run on `main` was at 21:47, before the advisory database had propagated.

## Why the pin is patch-exact

The workflows asked for `'1.26'` and let `setup-go` choose the newest patch, which is normally the right call. But `actions/go-versions` has not published 1.26.6 yet:

```
go.dev/dl:                 ['go1.26.6', 'go1.26.5', 'go1.26.4', ...]
actions/go-versions:       ['1.26.5', '1.26.4', '1.26.3', ...]
```

so a floating minor still resolves to the vulnerable 1.26.5. Naming the patch makes `setup-go` fall back to fetching it from go.dev directly.

Applied to `ci.yml`, `security.yml`, `build-cloud.yml` and `release-selfhosted.yml`, each carrying a comment saying it can go back to floating once the manifest catches up.

## Not in scope

The `golang:1.26-alpine` and devcontainer images are pinned by digest and still carry 1.26.5. That is Dependabot's lane, and it affects the shipped binary rather than the scan — worth a follow-up, but not something to fold into a CI unblock.

`actionlint` passes on all four files.