### PR TITLE
docs: drop the licence tiers that no longer exist

### DIFF
--- a/LICENSE-COMMERCIAL
+++ b/LICENSE-COMMERCIAL
@@ -13,6 +13,23 @@ You need a commercial license if you want to:
 2. **Resell WhenTo** as part of your product or service offering
 3. **Use WhenTo beyond your organization's internal use** in a commercial context
 
+## What Does Not Require a Commercial License
+
+The only thing a commercial license buys is the right the Business Source
+License withholds: serving WhenTo to third parties. Running it is free, and
+there is nothing to buy, unlock or activate in order to run it fully.
+
+- **Self-hosting is unrestricted.** No license key, no activation, no calendar
+  limit, and nothing to renew. The software does not check for a license file
+  and has no code path that could refuse to run without one.
+- **The hosted service at whento.be is free of charge.** No paid plan, no
+  subscription and no payment details. Each account may create up to three
+  calendars; that allowance is the same for everyone and is not for sale.
+
+Neither of those is a tier of anything. Self-hosting for yourself or for your
+organization's internal use is covered by the Additional Use Grant in
+[LICENSE](LICENSE) and needs nothing from this document.
+
 ## What's Included
 
 A commercial license grants you:
@@ -63,26 +80,6 @@ Even with a commercial license:
 - ❌ Use for illegal purposes
 - ❌ Resell the commercial license itself
 
-## Self-Hosted Licenses (Ed25519 Cryptographic Licenses)
-
-For self-hosted deployments with increased calendar limits:
-
-| Tier       | Calendar Limit | Price          | Support       |
-| ---------- | -------------- | -------------- | ------------- |
-| Community  | 30 calendars   | FREE           | Community     |
-| Pro        | 300 calendars  | 100€ (+ VAT)   | 1 year email  |
-| Enterprise | Unlimited      | 250€ (+ VAT)   | 2 years email |
-
-**Support renewals**: 60€/year after initial period
-
-These licenses are:
-
-- ✅ Perpetual (no expiration)
-- ✅ Cryptographically signed (Ed25519)
-- ✅ Offline validation (no phone-home)
-
-See [cmd/licensegen/README.md](cmd/licensegen/README.md) for technical details.
-
 ## Term and Termination
 
 - Commercial licenses are valid for 12 months from purchase
@@ -111,7 +108,7 @@ This Agreement shall be governed by the laws of France.
 For commercial licensing inquiries:
 
 - Email: contact@whento.be
-- Website: https://whento.be/pricing
+- Website: https://whento.be
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -739,7 +739,7 @@ WhenTo is licensed under the [Business Source License 1.1](LICENSE):
 | Use Case                                   | Free?  | License Required?                         |
 | ------------------------------------------ | ------ | ----------------------------------------- |
 | Self-host for personal use                 | ✅ Yes | No                                        |
-| Self-host for your organization (internal) | ✅ Yes | No (or Pro/Enterprise for more calendars) |
+| Self-host for your organization (internal) | ✅ Yes | No                                        |
 | Offer as SaaS to customers                 | ❌ No  | Yes (Commercial license)                  |
 | Fork and modify for yourself               | ✅ Yes | No                                        |
 | Resell as a product                        | ❌ No  | Yes (Commercial license)                  |


### PR DESCRIPTION
Follows the removal of the self-hosted licence system and the cloud subscriptions. Documentation only — no code.

## What the code says now

| | Allowance | Mechanism |
|---|---|---|
| Self-hosted | Unlimited | `SelfHostedCalendarLimit = 0`, no licence file |
| Hosted (whento.be) | 3 calendars per account | `CloudCalendarLimit = 3`, same for everyone |

`cmd/licensegen` and `pkg/license` are gone; both quota services now carry the number as a constant and say in comments why the dependency disappeared.

## What the docs still said

`LICENSE-COMMERCIAL` advertised a Community / Pro / Enterprise ladder of self-hosted **calendar limits** — 30 / 300 / unlimited at 100€ and 250€, "perpetual, Ed25519-signed, offline validation" — and linked to `cmd/licensegen/README.md`, a **dead link**. The README's licensing table sent people to "Pro/Enterprise for more calendars".

Both described something nobody can buy and the software has no code left to enforce. Anyone reading the repo would have concluded the free self-hosted build was capped at 30 calendars, which is the opposite of the truth.

## What replaces it

A short section stating what is actually the case: self-hosting is unrestricted with no key and nothing to renew, and the hosted service is free with a flat three-calendar allowance that is not for sale. The wording matches what the app's own terms of service already say (`legal.terms.pricing` in the locale files), so the repo and the product now agree.

## Deliberately untouched

**The commercial licence itself.** The BSL still withholds the right to serve WhenTo to third parties (Additional Use Grant in `LICENSE`, change date 2035-12-03), so that offer is still real and its Startup / Business / Enterprise tiers are a business decision, not something the removed code ever implemented.

Two things worth your eye, since they are judgement calls rather than facts:

- `https://whento.be/pricing` became `https://whento.be` — there is no pricing route in the frontend. Point it wherever is right.
- The tier prices and support promises are carried over verbatim. Worth a read if they moved with the rest.

Still says "This is a template. For a legally binding commercial license, please contact us." — this aligns the document with the software, it is not legal advice.