### PR TITLE
docs: correct the licensing claims #99 left behind

### DIFF
--- a/README.md
+++ b/README.md
@@ -326,7 +326,6 @@ whento/
 | Frontend                | Vue 3, Vite 8, TypeScript, Tailwind CSS 4, Pinia 4 |
 | Database                | PostgreSQL 16, Redis 7                             |
 | Auth                    | JWT RS256 (asymmetric keys), bcrypt                |
-| Licensing (Self-hosted) | Ed25519 cryptographic signatures                   |
 | i18n                    | vue-i18n (FR/EN)                                   |
 | iCalendar               | arran4/golang-ical                                 |
 
@@ -782,8 +781,9 @@ Please ensure:
 
 - **Community Support** — GitHub Discussions
 - **Bug Reports** — GitHub Issues
-- **Email Support** — Available for Pro/Power subscribers (Cloud) or Pro/Enterprise license holders (Self-hosted)
-- **Priority Support** — Available for Power subscribers (Cloud) or Enterprise license holders (Self-hosted)
+- **Commercial Support** — Included with a [commercial license](LICENSE-COMMERCIAL), which is
+  only needed to offer WhenTo as a service to third parties. Running it, hosted or
+  self-hosted, needs no licence and comes with community support.
 
 ---
 

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -24,7 +24,7 @@
 //	@description				Rate limit headers are included in responses: `X-RateLimit-Limit`, `X-RateLimit-Remaining`, `X-RateLimit-Reset`
 //	@description
 //	@description				## Deployment Modes
-//	@description				WhenTo supports two deployment modes: **Cloud** (SaaS with Stripe subscriptions) and **Self-hosted** (Ed25519 cryptographic licenses). Some endpoints are only available in specific deployment modes.
+//	@description				WhenTo supports two deployment modes: **Cloud** (hosted, three calendars per account) and **Self-hosted** (unlimited). Both are free and neither requires a licence key. Some endpoints are only available in specific deployment modes.
 //
 //	@contact.name				WhenTo Support
 //	@contact.url				https://github.com/When-To/whento

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -183,7 +183,7 @@ Two orderings there are load-bearing rather than cosmetic:
 `GET /api/v1/calendars` →
 
 1. global middleware above;
-2. `middleware.Auth(jwtManager, cacheStore)` — validates the Ed25519-signed JWT
+2. `middleware.Auth(jwtManager, cacheStore)` — validates the RS256-signed JWT
    and puts the user id and role in the request context;
 3. `routeLimiter` bucket `perUser(100, time.Minute)`, keyed on the authenticated
    user id (which only means anything *below* `Auth` — above it the key is empty
@@ -242,7 +242,7 @@ what a calendar is, it belongs in `internal/`.
 | `dberr` | Classifies PostgreSQL errors by SQLSTATE via `errors.As` on `*pgconn.PgError` — never by message text, which is localised and reworded between major versions. |
 | `email` | SMTP sending; reports `IsConfigured()` so features degrade instead of erroring. |
 | `httputil` | The `{success, data, error}` response envelope and the error codes. |
-| `jwt` | Ed25519 access/refresh tokens. The signing method is pinned, with a test guarding against algorithm confusion. |
+| `jwt` | RS256 access/refresh tokens. The signing method is pinned, with a test guarding against algorithm confusion. |
 | `logger` | `log/slog` setup, `Fingerprint` for correlating without identifying, and the AST guard described below. |
 | `metrics` | Prometheus collectors and the exposition handler. Labels are method, chi route *pattern*, status, build variant — nothing else. |
 | `middleware` | `RequestID`, `Logger`, `Metrics`, `Recoverer`, `SecurityHeaders`, `LimitRequestSize`, `CORS`, `Auth`, `RequireRole`, the rate limiter and its key functions, `SetTrustedProxies`. |


### PR DESCRIPTION
Follow-up to #99, which merged before I finished sweeping. Documentation only, three files.

## The one that matters: published API docs

The Swagger description announced:

> WhenTo supports two deployment modes: **Cloud** (SaaS with Stripe subscriptions) and **Self-hosted** (Ed25519 cryptographic licenses).

Neither exists. This is the API documentation people read before integrating, and it advertises a payment system and a licence system that were removed from the code.

`docs/swagger/` is git-ignored and rebuilt by CI, so the annotation in `cmd/main.go` is the only thing to change — regenerating locally confirms it propagates.

## README

- Email support offered to "Pro/Power subscribers (Cloud) or Pro/Enterprise license holders (Self-hosted)", priority support to "Power subscribers or Enterprise license holders" — tiers nobody can buy. Replaced with what is actually on offer: community support for everyone, commercial support with the commercial licence, which is only needed to serve WhenTo to third parties.
- `| Licensing (Self-hosted) | Ed25519 cryptographic signatures |` removed from the tech stack table.

## A different error, same root

`docs/architecture.md` calls the JWTs Ed25519-signed, in two places. They are **RS256** and always have been — `pkg/jwt` signs with `jwt.SigningMethodRS256` and pins it with a test guarding against algorithm confusion, and the README's own auth row already says RS256.

The licence system is the likely source of the confusion, since it was the thing using Ed25519. Security documentation naming the wrong signing algorithm is worth correcting whatever the cause.

Builds and `go test ./cmd/` pass; `make swagger` regenerates cleanly.