### PR TITLE
fix(auth): propagate a deliberate sign-out to the other tabs

### DIFF
--- a/frontend/src/api/client.test.ts
+++ b/frontend/src/api/client.test.ts
@@ -178,6 +178,32 @@ describe('apiClient', () => {
     });
   });
 
+  describe('signing out across tabs', () => {
+    it('tells the other tabs when the user signs out', () => {
+      const posted: unknown[] = [];
+      vi.spyOn(BroadcastChannel.prototype, 'postMessage').mockImplementation(m => posted.push(m));
+      apiClient.setToken('a-token');
+
+      apiClient.signOut();
+
+      expect(apiClient.hasSession()).toBe(false);
+      expect(posted).toContainEqual({ type: 'logout' });
+    });
+
+    it('stays quiet when a request merely fails', () => {
+      const posted: unknown[] = [];
+      vi.spyOn(BroadcastChannel.prototype, 'postMessage').mockImplementation(m => posted.push(m));
+      apiClient.setToken('a-token');
+      posted.length = 0;
+
+      // The error paths — a refused /auth/me, a failed restore — go through
+      // clearToken. A transient failure in one tab must not sign the others out.
+      apiClient.clearToken();
+
+      expect(posted).toEqual([]);
+    });
+  });
+
   describe('the 401 refresh', () => {
     it('refreshes once and replays the original request', async () => {
       apiClient.setToken('expired');

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -63,8 +63,13 @@ class ApiClient {
         this.accessToken = message.token;
         localStorage.setItem(SESSION_FLAG, '1');
       } else if (message?.type === 'logout') {
-        this.accessToken = null;
-        localStorage.removeItem(SESSION_FLAG);
+        // Another tab signed out. Dropping the token here is not enough: this tab
+        // would keep rendering the account it no longer has a session for —
+        // calendars, settings, the lot — until its next request happened to 401.
+        // On a shared machine that is the thing signing out is meant to prevent.
+        // No re-broadcast: the tab that sent this already told everyone.
+        this.clearToken();
+        this.redirectToLogin();
       }
     };
   }
@@ -127,9 +132,26 @@ class ApiClient {
   }
 
   private forceLogout() {
+    this.signOut();
+    this.redirectToLogin();
+  }
+
+  /**
+   * End the session in this tab and in every other one.
+   *
+   * The deliberate sign-out goes through here rather than through clearToken, which
+   * stays local on purpose: the error paths call it too — a refused /auth/me, a
+   * failed restore — and a transient failure in one tab must not sign the others out.
+   * Choosing to log out is different, and has to reach them all at once.
+   */
+  signOut() {
     this.clearToken();
     this.broadcast({ type: 'logout' });
-    // Only redirect to login if current route is not public
+  }
+
+  private redirectToLogin() {
+    // Only redirect to login if current route is not public: a participant following
+    // a calendar link has no account to sign back in to.
     const currentRoute = router.currentRoute.value;
     const isPublicRoute = currentRoute.meta.public === true;
 

--- a/frontend/src/stores/auth.test.ts
+++ b/frontend/src/stores/auth.test.ts
@@ -26,6 +26,7 @@ const apiClient = {
   setToken: vi.fn(),
   clearToken: vi.fn(),
   hasSession: vi.fn(() => false),
+  signOut: vi.fn(),
 };
 
 vi.mock('@/api/auth', () => ({ authApi }));
@@ -190,7 +191,7 @@ describe('auth store', () => {
       await store.logout();
 
       expect(store.user).toBeNull();
-      expect(apiClient.clearToken).toHaveBeenCalled();
+      expect(apiClient.signOut).toHaveBeenCalled();
     });
 
     it('drops the session even when the call fails, and surfaces no error', async () => {
@@ -202,7 +203,7 @@ describe('auth store', () => {
       await expect(store.logout()).resolves.toBeUndefined();
 
       expect(store.user).toBeNull();
-      expect(apiClient.clearToken).toHaveBeenCalled();
+      expect(apiClient.signOut).toHaveBeenCalled();
       expect(store.error).toBeNull();
       expect(store.loading).toBe(false);
     });
@@ -217,6 +218,9 @@ describe('auth store', () => {
 
       expect(store.user).toBeNull();
       expect(apiClient.clearToken).toHaveBeenCalled();
+      // Local only. A refused /auth/me is not a decision to sign out, and must not
+      // reach the other tabs on this browser.
+      expect(apiClient.signOut).not.toHaveBeenCalled();
     });
   });
 

--- a/frontend/src/stores/auth.ts
+++ b/frontend/src/stores/auth.ts
@@ -85,7 +85,9 @@ export const useAuthStore = defineStore('auth', () => {
       clearError();
     } finally {
       user.value = null;
-      apiClient.clearToken();
+      // signOut rather than clearToken: the other tabs on this browser share the
+      // refresh cookie the backend just revoked, and have to be told.
+      apiClient.signOut();
     }
   }
 


### PR DESCRIPTION
A gap in #95, found reviewing my own work rather than from a failure. Frontend only.

## What was wrong

#95 added a `BroadcastChannel` so tabs could share a session, but only `forceLogout` ever used it — the path taken when a *refresh fails*. A **deliberate** sign-out went through `clearToken`, which is local:

```
App.vue handleLogout → authStore.logout() → apiClient.clearToken()   // local only
```

So clicking "log out" revoked the refresh cookie on the server and cleared the tab you clicked in, and left every other tab on that browser holding a working in-memory access token. They stayed usable until it expired — **up to fifteen minutes** — which is most of what signing out is for on a shared machine.

The receiving side had the same shape of problem in miniature: on a `logout` message it dropped the token but kept rendering. That tab would go on showing calendars and account settings for a session it no longer had, until some request happened to 401.

## The fix

`signOut()` clears and broadcasts. Tabs that receive it clear **and** go to `/login`, without re-broadcasting — the sender already told everyone.

`clearToken()` stays local, deliberately. The error paths call it too — a refused `/auth/me`, a failed session restore — and a transient failure in one tab must not sign the others out. That distinction is the whole design, so it is pinned from both sides:

- `signOut()` posts `{type: 'logout'}` and drops the session flag
- `clearToken()` posts nothing
- `fetchUser`'s failure path calls `clearToken` and **not** `signOut`

## Why it did not show up in testing

The tab you click in behaves correctly, and the others recover on their own within fifteen minutes. Nothing errors, nothing logs. You only see it by opening two tabs, signing out in one, and going back to the other inside the window.

I listed exactly this as manual verification step 5 when planning #95 and then did not implement the half that makes it true.

## Tests

`686 passed` across 35 files, plus type-check, lint and format-check.