### PR TITLE
fix(security): stop allowing Google as a style and font origin

### DIFF
--- a/pkg/middleware/middleware.go
+++ b/pkg/middleware/middleware.go
@@ -321,12 +321,19 @@ func SecurityHeaders(next http.Handler) http.Handler {
 			w.Header().Set("Strict-Transport-Security", "max-age=63072000; includeSubDomains; preload")
 		}
 
-		// Content Security Policy - restricts resources the page can load
-		// This is a strict policy, adjust based on your needs
+		// Content Security Policy - restricts resources the page can load.
+		//
+		// No external origin is allowed to serve code, styles or fonts. Inter used to
+		// come from fonts.googleapis.com and the two Google hosts were listed here for
+		// it; it is bundled now, so the allowance outlived what it was for. An origin
+		// nobody fetches from is one more place a compromise could serve from.
+		//
+		// 'unsafe-inline' stays in style-src, and is not about fonts: the Swagger UI
+		// handler emits a <style> block and inline style attributes of its own.
 		csp := "default-src 'self'; " +
 			"script-src 'self'; " +
-			"style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; " +
-			"font-src 'self' https://fonts.gstatic.com; " +
+			"style-src 'self' 'unsafe-inline'; " +
+			"font-src 'self'; " +
 			"img-src 'self' data: https:; " +
 			"connect-src 'self'; " +
 			"frame-ancestors 'none'; " +

--- a/pkg/middleware/middleware_test.go
+++ b/pkg/middleware/middleware_test.go
@@ -1097,7 +1097,16 @@ func TestSecurityHeaders(t *testing.T) {
 	// frame-ancestors 'none' is what actually stops framing in modern browsers;
 	// X-Frame-Options above is the fallback for older ones.
 	csp := rec.Header().Get("Content-Security-Policy")
-	for _, directive := range []string{"default-src 'self'", "frame-ancestors 'none'", "base-uri 'self'", "form-action 'self'"} {
+	for _, directive := range []string{
+		"default-src 'self'",
+		"frame-ancestors 'none'",
+		"base-uri 'self'",
+		"form-action 'self'",
+		// Spelled out rather than merely "not Google", so that reintroducing an
+		// external origin has to fail a test rather than pass one by omission.
+		"style-src 'self' 'unsafe-inline'",
+		"font-src 'self'",
+	} {
 		if !strings.Contains(csp, directive) {
 			t.Errorf("the CSP is missing %q: %q", directive, csp)
 		}
@@ -1105,6 +1114,13 @@ func TestSecurityHeaders(t *testing.T) {
 	// A script-src that allowed inline code would make the CSP decorative.
 	if strings.Contains(csp, "script-src 'self' 'unsafe-inline'") {
 		t.Errorf("the CSP allows inline scripts: %q", csp)
+	}
+	// Inter is bundled and served from this origin. Nothing should reach out to
+	// Google — or to any other host — for a stylesheet or a font.
+	for _, host := range []string{"fonts.googleapis.com", "fonts.gstatic.com"} {
+		if strings.Contains(csp, host) {
+			t.Errorf("the CSP still allows %s: %q", host, csp)
+		}
 	}
 }
 


### PR DESCRIPTION
Two lines of CSP, plus the assertions that should have been guarding them.

## What

Inter used to be fetched from `fonts.googleapis.com`, and the CSP listed both Google hosts for it. #94 bundled the font — the allowance outlived what it was for.

```
style-src 'self' 'unsafe-inline' https://fonts.googleapis.com  →  style-src 'self' 'unsafe-inline'
font-src  'self' https://fonts.gstatic.com                     →  font-src  'self'
```

The font files are same-origin Vite assets now (`@fontsource-variable/inter` ships relative `@font-face` URLs, built to `dist/assets/inter-*-wght-normal-*.woff2`), so `font-src 'self'` covers them. An origin nobody fetches from is one more place a compromise could serve from.

**`'unsafe-inline'` stays in `style-src`**, and that is not about fonts: the Swagger UI handler emits a `<style>` block and inline `style=` attributes. Dropping it would break the API docs' chrome — a separate decision from this one.

## The test was not guarding this

`TestSecurityHeaders` asserted only `default-src`, `frame-ancestors`, `base-uri` and `form-action`. Removing these two sources would have passed either way, and so would adding a new external origin tomorrow.

It now spells out the `style-src` and `font-src` it expects, and fails on either Google host **by name**. Reintroducing an external origin should break a test rather than slip through on omission.

## Two things found next door, deliberately not fixed here

- **Swagger UI is already broken in production.** Its initialisation is an inline `<script>`, which `script-src 'self'` blocks, so `/swagger/*` most likely renders an empty `<div id="swagger-ui">`. This predates the change and is orthogonal to fonts, but anyone touching this CSP should know. Fixing it means either a per-route policy or a nonce — worth deciding on its own.
- **`web/dist/index.html` still has the Google `<link rel="preconnect">` tags.** It is an untracked, stale build artifact (`.gitignore` has `**/dist/`; only `web/embed.go` is tracked), regenerated by any frontend build. Worth confirming the deploy pipeline rebuilds it rather than shipping that copy — under this CSP it would be blocked, and today it is still fetching Google Fonts.

`pkg` suite green, both build variants compile, format-check clean.