### PR TITLE
fix(email): accept only bare mailbox addresses as recipients

### DIFF
--- a/pkg/email/service.go
+++ b/pkg/email/service.go
@@ -281,7 +281,20 @@ func (s *Service) buildMessage(email Email) ([]byte, error) {
 		if err != nil {
 			return nil, fmt.Errorf("smtp: invalid recipient address: %w", err)
 		}
-		recipients = append(recipients, parsed.String())
+		// ParseAddress cannot return a CR or LF in either field — it would not have
+		// parsed. Checked anyway, because the cost is a comparison and the thing on
+		// the other side of it is an attacker-authored Bcc header.
+		if strings.ContainsAny(parsed.Name, "\r\n") || strings.ContainsAny(parsed.Address, "\r\n") {
+			return nil, fmt.Errorf("smtp: invalid recipient address")
+		}
+		// Bare mailboxes only. Every caller passes an address a user typed into a
+		// validated field — never "Name <addr>" — so refusing the display-name form
+		// costs nothing and keeps free text out of the To header entirely. A caller
+		// that wants to personalise has the body for it.
+		if parsed.Name != "" {
+			return nil, fmt.Errorf("smtp: recipient must be a bare address, not a display name")
+		}
+		recipients = append(recipients, parsed.Address)
 	}
 
 	subject, err := encodeHeaderValue(email.Subject)

--- a/pkg/email/service_test.go
+++ b/pkg/email/service_test.go
@@ -460,6 +460,22 @@ func TestBuildMessageRefusesHeaderInjection(t *testing.T) {
 			},
 		},
 		{
+			// A display name is free text, and free text has no business in a header
+			// when every caller has a validated bare address to hand.
+			name: "a recipient carrying a display name",
+			email: Email{
+				To:      []string{`"Ada" <ada@example.test>`},
+				Subject: "Hello",
+			},
+		},
+		{
+			name: "a display name is not a way to smuggle a header either",
+			email: Email{
+				To:      []string{`"Ada\r\nBcc: victim@example.test" <ada@example.test>`},
+				Subject: "Hello",
+			},
+		},
+		{
 			name:  "no recipient",
 			email: Email{Subject: "Hello"},
 		},
@@ -502,7 +518,7 @@ func TestBuildMessageHeaders(t *testing.T) {
 		}
 
 		want := "From: \"WhenTo\" <calendar@example.test>\r\n" +
-			"To: <ada@example.test>, <grace@example.test>\r\n" +
+			"To: ada@example.test, grace@example.test\r\n" +
 			"Subject: Verify your WhenTo email address\r\n" +
 			"MIME-Version: 1.0\r\n" +
 			"Content-Type: text/html; charset=UTF-8\r\n" +


### PR DESCRIPTION
Follow-up on CodeQL alert [#3](https://github.com/When-To/whento/security/code-scanning/3), which **survived** the fix in #98. This takes the Copilot Autofix suggestion, which is better than what I shipped — and explains why the alert still cannot fully close.

## Why the alert is still open

I pulled the SARIF from the analysis on `main`. Four taint paths remain:

| # | Path | Can it be fixed? |
|---|---|---|
| 1, 3, 4 | recipient address → `mail.ParseAddress` → `.String()` → `To` header | Yes — this PR |
| 2 | `DisplayName` → `ReplaceVar` → `template.Execute` → mail **body** | **No.** That is the feature |

Path 2 is a personalised email containing the name of the person it is addressed to. No sanitizer model removes that flow without also removing the personalisation. What matters there is that the value is *escaped*, which the `html/template` switch in #98 guarantees and `email_body_test.go` pins.

## What this changes

```go
if strings.ContainsAny(parsed.Name, "\r\n") || strings.ContainsAny(parsed.Address, "\r\n") { … }
if parsed.Name != "" { … }
recipients = append(recipients, parsed.Address)
```

**The CR/LF check reads as redundant** — `ParseAddress` could not have returned an address containing one, since it would not have parsed. It is there for two reasons: an explicit guard is the shape CodeQL's taint analysis recognises as a barrier (which is why Autofix proposes it), and the cost is one comparison against an attacker-authored `Bcc` header.

**Refusing the display-name form is the substantive half.** Every caller passes an address a user typed into a field carrying the `email` validation tag — `recipient.Email`, `user.Email`, `emailAddress` — never `"Name <addr>"`. Rejecting that form costs nothing and keeps free text out of the `To` header altogether. A caller that wants to personalise has the body for it.

Emitting `parsed.Address` rather than `parsed.String()` drops the angle brackets, so `To` goes back to the bare addr-spec.

## Tests

Two cases added to `TestBuildMessageRefusesHeaderInjection`: a plain display name, and a display name carrying a folded `Bcc`. The `To` header expectation in `TestBuildMessageHeaders` returns to `ada@example.test`.

## After merge

Once the scan runs on `main` I will re-read the SARIF. If only path 2 remains, the alert should be closed as a false positive with the reasoning above written into the dismissal — the code is correct, and the query is flagging an inherent property of personalised email.

A CodeQL model pack was considered and dropped: killing path 2 would mean declaring `html/template` rendering a barrier repo-wide, which disarms the query everywhere for the sake of one alert.