### PR TITLE
feat(auth): give refresh token rotation a grace window, and detect reuse

### DIFF
--- a/internal/auth/handlers/auth_handler_test.go
+++ b/internal/auth/handlers/auth_handler_test.go
@@ -6,6 +6,7 @@ package handlers_test
 
 import (
 	"context"
+	"time"
 
 	"github.com/google/uuid"
 
@@ -118,6 +119,14 @@ func (m *mockTokenRepository) DeleteByHash(ctx context.Context, tokenHash string
 }
 
 func (m *mockTokenRepository) DeleteByUserID(ctx context.Context, userID uuid.UUID) error {
+	return m.err
+}
+
+func (m *mockTokenRepository) Consume(context.Context, string) (bool, error) {
+	return m.err == nil, m.err
+}
+
+func (m *mockTokenRepository) DeleteConsumedBefore(context.Context, uuid.UUID, time.Time) error {
 	return m.err
 }
 

--- a/internal/auth/models/user.go
+++ b/internal/auth/models/user.go
@@ -48,6 +48,10 @@ type RefreshToken struct {
 	TokenHash string    `json:"-"`
 	ExpiresAt time.Time `json:"expires_at"`
 	CreatedAt time.Time `json:"created_at"`
+	// ConsumedAt is nil while the token is live, and set at the moment rotation
+	// replaced it. A consumed token is not simply gone: presented again inside the
+	// grace window it is a racing client, and outside it, a replay.
+	ConsumedAt *time.Time `json:"-"`
 }
 
 // IsAdmin checks if user has admin role

--- a/internal/auth/repository/token_repository.go
+++ b/internal/auth/repository/token_repository.go
@@ -58,7 +58,7 @@ func (r *TokenRepository) Create(ctx context.Context, token *models.RefreshToken
 // GetByHash retrieves a refresh token by its hash
 func (r *TokenRepository) GetByHash(ctx context.Context, tokenHash string) (*models.RefreshToken, error) {
 	query := `
-		SELECT id, user_id, token_hash, expires_at, created_at
+		SELECT id, user_id, token_hash, expires_at, created_at, consumed_at
 		FROM refresh_tokens
 		WHERE token_hash = $1`
 
@@ -69,6 +69,7 @@ func (r *TokenRepository) GetByHash(ctx context.Context, tokenHash string) (*mod
 		&token.TokenHash,
 		&token.ExpiresAt,
 		&token.CreatedAt,
+		&token.ConsumedAt,
 	)
 
 	if err != nil {
@@ -83,6 +84,45 @@ func (r *TokenRepository) GetByHash(ctx context.Context, tokenHash string) (*mod
 	}
 
 	return token, nil
+}
+
+// Consume marks a refresh token as rotated, and reports whether this call is the one
+// that did it.
+//
+// The `consumed_at IS NULL` in the WHERE clause is what makes concurrent refreshes
+// decidable rather than racy: two callers presenting the same token both run this
+// statement, and exactly one sees a row affected. The loser learns it lost instead of
+// finding the row deleted and having to guess whether that was a race or a replay.
+func (r *TokenRepository) Consume(ctx context.Context, tokenHash string) (bool, error) {
+	query := `
+		UPDATE refresh_tokens
+		SET consumed_at = NOW()
+		WHERE token_hash = $1 AND consumed_at IS NULL`
+
+	result, err := r.pool.Exec(ctx, query, tokenHash)
+	if err != nil {
+		return false, fmt.Errorf("failed to consume token: %w", err)
+	}
+
+	return result.RowsAffected() == 1, nil
+}
+
+// DeleteConsumedBefore drops a user's spent tokens once they are past the grace window.
+//
+// Without it the table would keep one row per refresh — roughly one every fifteen
+// minutes per active session — for the seven days until it expired. They are of no use
+// after the window: a replay that late is answered by revoking the whole family, which
+// does not need the individual row to say so.
+func (r *TokenRepository) DeleteConsumedBefore(ctx context.Context, userID uuid.UUID, cutoff time.Time) error {
+	query := `
+		DELETE FROM refresh_tokens
+		WHERE user_id = $1 AND consumed_at IS NOT NULL AND consumed_at < $2`
+
+	if _, err := r.pool.Exec(ctx, query, userID, cutoff); err != nil {
+		return fmt.Errorf("failed to purge consumed tokens: %w", err)
+	}
+
+	return nil
 }
 
 // DeleteByHash deletes a refresh token by its hash

--- a/internal/auth/repository/token_repository_db_test.go
+++ b/internal/auth/repository/token_repository_db_test.go
@@ -72,6 +72,102 @@ func TestRefreshTokenRoundTrip(t *testing.T) {
 	}
 }
 
+// TestConsumeIsWonByExactlyOneCaller is the property the whole grace window rests on.
+// The UPDATE carries `consumed_at IS NULL`, so two callers presenting the same token
+// cannot both believe they rotated it — which is what lets the loser be told apart from
+// somebody replaying a stolen cookie.
+func TestConsumeIsWonByExactlyOneCaller(t *testing.T) {
+	pool := dbtest.Pool(t)
+	users := repository.NewUserRepository(pool)
+	tokens := repository.NewTokenRepository(pool)
+	ctx := dbtest.Context(t)
+
+	user := newUser(t, pool)
+	if err := users.Create(ctx, user); err != nil {
+		t.Fatalf("create user: %v", err)
+	}
+
+	hash := repository.HashToken(uuid.NewString())
+	token := &models.RefreshToken{
+		UserID:    user.ID,
+		TokenHash: hash,
+		ExpiresAt: time.Now().Add(24 * time.Hour),
+	}
+	token.ID = uuid.New()
+	if err := tokens.Create(ctx, token); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	won, err := tokens.Consume(ctx, hash)
+	if err != nil {
+		t.Fatalf("Consume: %v", err)
+	}
+	if !won {
+		t.Fatal("the first caller did not win the rotation")
+	}
+
+	again, err := tokens.Consume(ctx, hash)
+	if err != nil {
+		t.Fatalf("Consume (second): %v", err)
+	}
+	if again {
+		t.Error("a second caller also believed it rotated the token")
+	}
+
+	// The row survives, and says when it was spent. That is what the grace window
+	// reads to tell a racing tab from a replay.
+	stored, err := tokens.GetByHash(ctx, hash)
+	if err != nil {
+		t.Fatalf("GetByHash after Consume: %v", err)
+	}
+	if stored.ConsumedAt == nil {
+		t.Error("the token was rotated but carries no consumed_at")
+	}
+}
+
+// TestDeleteConsumedBeforeSparesLiveTokens keeps the purge from ending sessions. It runs
+// on every refresh, so a predicate that missed would sign people out wholesale.
+func TestDeleteConsumedBeforeSparesLiveTokens(t *testing.T) {
+	pool := dbtest.Pool(t)
+	users := repository.NewUserRepository(pool)
+	tokens := repository.NewTokenRepository(pool)
+	ctx := dbtest.Context(t)
+
+	user := newUser(t, pool)
+	if err := users.Create(ctx, user); err != nil {
+		t.Fatalf("create user: %v", err)
+	}
+
+	live := repository.HashToken(uuid.NewString())
+	spent := repository.HashToken(uuid.NewString())
+	for _, hash := range []string{live, spent} {
+		token := &models.RefreshToken{
+			UserID:    user.ID,
+			TokenHash: hash,
+			ExpiresAt: time.Now().Add(24 * time.Hour),
+		}
+		token.ID = uuid.New()
+		if err := tokens.Create(ctx, token); err != nil {
+			t.Fatalf("Create: %v", err)
+		}
+	}
+	if _, err := tokens.Consume(ctx, spent); err != nil {
+		t.Fatalf("Consume: %v", err)
+	}
+
+	// A cutoff in the future, so the just-consumed row is unambiguously past it.
+	if err := tokens.DeleteConsumedBefore(ctx, user.ID, time.Now().Add(time.Minute)); err != nil {
+		t.Fatalf("DeleteConsumedBefore: %v", err)
+	}
+
+	if _, err := tokens.GetByHash(ctx, spent); !errors.Is(err, repository.ErrTokenNotFound) {
+		t.Errorf("the consumed token survived the purge: %v", err)
+	}
+	if _, err := tokens.GetByHash(ctx, live); err != nil {
+		t.Errorf("the purge took a live token with it: %v", err)
+	}
+}
+
 func TestUnknownRefreshTokenIsASentinel(t *testing.T) {
 	pool := dbtest.Pool(t)
 	tokens := repository.NewTokenRepository(pool)

--- a/internal/auth/service/auth_service.go
+++ b/internal/auth/service/auth_service.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/whento/pkg/cache"
 	"github.com/whento/pkg/jwt"
+	"github.com/whento/pkg/logger"
 	"github.com/whento/pkg/validator"
 	"github.com/whento/whento/internal/auth/models"
 	"github.com/whento/whento/internal/auth/repository"
@@ -59,9 +60,20 @@ type UserRepository interface {
 type TokenRepository interface {
 	Create(ctx context.Context, token *models.RefreshToken) error
 	GetByHash(ctx context.Context, tokenHash string) (*models.RefreshToken, error)
+	// Consume marks a token rotated and reports whether this call won the race.
+	Consume(ctx context.Context, tokenHash string) (bool, error)
+	DeleteConsumedBefore(ctx context.Context, userID uuid.UUID, cutoff time.Time) error
 	DeleteByHash(ctx context.Context, tokenHash string) error
 	DeleteByUserID(ctx context.Context, userID uuid.UUID) error
 }
+
+// refreshGraceWindow is how long a rotated refresh token keeps working.
+//
+// Long enough to cover what honest clients actually do — two tabs waking together, a
+// retry after a response was lost, a tab restored from sleep — and far too short to be
+// a useful window for someone replaying a stolen cookie, who has no reason to be within
+// seconds of the legitimate holder.
+const refreshGraceWindow = 30 * time.Second
 
 // MFARepository defines the interface for MFA repository operations
 type MFARepository interface {
@@ -231,7 +243,16 @@ func (s *AuthService) incrementLoginAttempts(ctx context.Context, key string) {
 	_ = s.cache.Set(ctx, key, attempts, loginLockoutWindow)
 }
 
-// RefreshToken refreshes the access token using a refresh token
+// RefreshToken rotates a refresh token, tolerating a racing client and refusing a
+// replay.
+//
+// Rotation used to delete the row, which made the two indistinguishable: a second
+// caller found nothing and was signed out, whether it was the user's other tab or
+// somebody with a stolen cookie. Consuming the row keeps the difference legible.
+//
+//	live                      → rotate
+//	consumed, inside window   → rotate again; this is the other tab, or a retry
+//	consumed, outside window  → reuse: revoke every session this user has
 func (s *AuthService) RefreshToken(ctx context.Context, refreshToken string) (*models.AuthResponse, error) {
 	// Validate refresh token format
 	userID, err := s.jwtManager.ValidateRefreshToken(refreshToken)
@@ -253,12 +274,42 @@ func (s *AuthService) RefreshToken(ctx context.Context, refreshToken string) (*m
 		return nil, ErrUserNotFound
 	}
 
-	// Delete old refresh token
-	_ = s.tokenRepo.DeleteByHash(ctx, tokenHash)
-
-	// Verify stored token matches user
+	// Verify stored token matches user, before anything is written. The previous
+	// order deleted first and checked after, so a token belonging to somebody else
+	// was destroyed on the way to being rejected.
 	if storedToken.UserID != user.ID {
 		return nil, ErrInvalidToken
+	}
+
+	if storedToken.ConsumedAt != nil {
+		if time.Since(*storedToken.ConsumedAt) > refreshGraceWindow {
+			// Used, superseded, and used again. No honest client does that, so the
+			// cookie is assumed to be in someone else's hands and every session goes.
+			// The user signs in again; whoever else held it gets nothing.
+			if err := s.tokenRepo.DeleteByUserID(ctx, user.ID); err != nil {
+				logger.FromContext(ctx).Error("failed to revoke sessions after refresh token reuse",
+					"error", err, "user_ref", logger.Fingerprint(user.ID.String()))
+			}
+			// The one place a stolen refresh cookie becomes visible. Warn, not Info:
+			// somebody should be able to alert on it.
+			logger.FromContext(ctx).Warn("refresh token reused after rotation; revoked every session for the user",
+				"user_ref", logger.Fingerprint(user.ID.String()),
+				"consumed_ago", time.Since(*storedToken.ConsumedAt).String())
+
+			return nil, ErrInvalidToken
+		}
+		// Inside the window: the other tab beat this one to it by a moment. Issuing a
+		// fresh pair is what keeps both of them signed in. Returning the *same* pair
+		// is not an option — only the hash was ever stored.
+	} else if _, err := s.tokenRepo.Consume(ctx, tokenHash); err != nil {
+		return nil, fmt.Errorf("failed to consume refresh token: %w", err)
+	}
+
+	// Spent tokens past the window are of no further use; dropping them here keeps
+	// the table from growing by one row per refresh for the life of the session.
+	if err := s.tokenRepo.DeleteConsumedBefore(ctx, user.ID, time.Now().Add(-refreshGraceWindow)); err != nil {
+		logger.FromContext(ctx).Error("failed to purge consumed refresh tokens",
+			"error", err, "user_ref", logger.Fingerprint(user.ID.String()))
 	}
 
 	// Generate new tokens

--- a/internal/auth/service/auth_service_context_test.go
+++ b/internal/auth/service/auth_service_context_test.go
@@ -40,6 +40,10 @@ type contextTokenRepo struct {
 
 	creates   int
 	createCtx context.Context
+	// persisted counts the writes that actually landed. Row counts are no longer a
+	// proxy for that: rotation consumes the previous token rather than deleting it,
+	// so a refresh leaves the old row in place on purpose.
+	persisted int
 }
 
 var _ TokenRepository = (*contextTokenRepo)(nil)
@@ -52,7 +56,22 @@ func (r *contextTokenRepo) Create(ctx context.Context, token *models.RefreshToke
 		return err
 	}
 
-	return r.fakeTokenRepo.Create(ctx, token)
+	if err := r.fakeTokenRepo.Create(ctx, token); err != nil {
+		return err
+	}
+	r.persisted++
+
+	return nil
+}
+
+// Consume refuses on a dead context, as the pgx-backed Exec would. Without this the
+// fake would rotate a token for a request that no longer exists.
+func (r *contextTokenRepo) Consume(ctx context.Context, hash string) (bool, error) {
+	if err := ctx.Err(); err != nil {
+		return false, err
+	}
+
+	return r.fakeTokenRepo.Consume(ctx, hash)
 }
 
 type contextFixture struct {
@@ -230,8 +249,8 @@ func TestAuthFlowsAbortTheRefreshTokenWriteOnADeadContext(t *testing.T) {
 					if !errors.Is(err, dead.want) {
 						t.Errorf("error = %v, want it to wrap %v", err, dead.want)
 					}
-					if len(f.tokens.stored) != 0 {
-						t.Errorf("%d refresh token(s) persisted despite the dead context", len(f.tokens.stored))
+					if f.tokens.persisted != 0 {
+						t.Errorf("%d refresh token(s) persisted despite the dead context", f.tokens.persisted)
 					}
 				})
 			}
@@ -259,8 +278,8 @@ func TestAuthFlowsStoreTheRefreshTokenUnderTheRequestContext(t *testing.T) {
 				t.Errorf("Create ran under a context carrying %v, want %q: the request context was not propagated",
 					got, requestCtxMarker)
 			}
-			if len(f.tokens.stored) != 1 {
-				t.Errorf("%d refresh token(s) stored, want 1", len(f.tokens.stored))
+			if f.tokens.persisted != 1 {
+				t.Errorf("%d refresh token(s) persisted, want 1", f.tokens.persisted)
 			}
 		})
 	}

--- a/internal/auth/service/auth_service_flows_test.go
+++ b/internal/auth/service/auth_service_flows_test.go
@@ -182,6 +182,30 @@ func (f *fakeTokenRepo) DeleteByUserID(_ context.Context, userID uuid.UUID) erro
 	return nil
 }
 
+// Consume mirrors the SQL: the UPDATE carries `consumed_at IS NULL`, so only the first
+// caller sees a row affected and the rest learn they lost the race.
+func (f *fakeTokenRepo) Consume(_ context.Context, hash string) (bool, error) {
+	token, ok := f.stored[hash]
+	if !ok || token.ConsumedAt != nil {
+		return false, nil
+	}
+
+	now := time.Now()
+	token.ConsumedAt = &now
+
+	return true, nil
+}
+
+func (f *fakeTokenRepo) DeleteConsumedBefore(_ context.Context, userID uuid.UUID, cutoff time.Time) error {
+	for hash, token := range f.stored {
+		if token.UserID == userID && token.ConsumedAt != nil && token.ConsumedAt.Before(cutoff) {
+			delete(f.stored, hash)
+		}
+	}
+
+	return nil
+}
+
 type fakeMFARepo struct {
 	mfa *mfaModels.UserMFA
 	err error
@@ -701,9 +725,97 @@ func TestRefreshTokenRotates(t *testing.T) {
 	if second.RefreshToken == first.RefreshToken {
 		t.Error("the refresh token was not rotated")
 	}
-	// The old one is deleted, so replaying it fails.
+}
+
+// TestRefreshTokenToleratesARace is the reason the grace window exists. Two tabs waking
+// together, or a retry after a lost response, both present the token that was just
+// rotated. Rotation used to delete the row, so the second one found nothing and the user
+// was signed out of a perfectly good session.
+func TestRefreshTokenToleratesARace(t *testing.T) {
+	fixture := newFixture(t, nil)
+	user := fixture.withUser(t, "user@example.com", "Str0ng!Passw0rd", models.RoleUser)
+
+	first, err := fixture.service.Login(context.Background(), &models.LoginRequest{
+		Email: user.Email, Password: "Str0ng!Passw0rd",
+	})
+	if err != nil {
+		t.Fatalf("Login: %v", err)
+	}
+
+	if _, err := fixture.service.RefreshToken(context.Background(), first.RefreshToken); err != nil {
+		t.Fatalf("the first refresh failed: %v", err)
+	}
+
+	// The straggler, moments later.
+	late, err := fixture.service.RefreshToken(context.Background(), first.RefreshToken)
+	if err != nil {
+		t.Fatalf("a refresh inside the grace window was refused: %v", err)
+	}
+	if late.AccessToken == "" {
+		t.Error("the racing caller got no access token")
+	}
+	// Tolerating the race must not mean tolerating the reuse it is meant to catch.
+	if len(fixture.tokens.deletedByUserIDs) != 0 {
+		t.Error("a race inside the window revoked the user's sessions")
+	}
+}
+
+// TestRefreshTokenDetectsReuse is the other half. A token used, superseded, and used
+// again well after the fact is not a race — nothing legitimate does that — so the
+// assumption is that the cookie is in someone else's hands.
+func TestRefreshTokenDetectsReuse(t *testing.T) {
+	fixture := newFixture(t, nil)
+	user := fixture.withUser(t, "user@example.com", "Str0ng!Passw0rd", models.RoleUser)
+
+	first, err := fixture.service.Login(context.Background(), &models.LoginRequest{
+		Email: user.Email, Password: "Str0ng!Passw0rd",
+	})
+	if err != nil {
+		t.Fatalf("Login: %v", err)
+	}
+
+	if _, err := fixture.service.RefreshToken(context.Background(), first.RefreshToken); err != nil {
+		t.Fatalf("the first refresh failed: %v", err)
+	}
+
+	// Age the consumption past the window rather than sleeping through it.
+	stale := time.Now().Add(-refreshGraceWindow - time.Second)
+	fixture.tokens.stored[repository.HashToken(first.RefreshToken)].ConsumedAt = &stale
+
 	if _, err := fixture.service.RefreshToken(context.Background(), first.RefreshToken); !errors.Is(err, ErrInvalidToken) {
-		t.Errorf("the spent refresh token was accepted again: %v", err)
+		t.Errorf("a replayed refresh token was accepted: %v", err)
+	}
+	// Refusing this one request is not enough: whoever holds the cookie would simply
+	// wait for the next rotation. Every session the user has goes.
+	if len(fixture.tokens.deletedByUserIDs) != 1 || fixture.tokens.deletedByUserIDs[0] != user.ID {
+		t.Errorf("reuse did not revoke the user's sessions: %v", fixture.tokens.deletedByUserIDs)
+	}
+}
+
+// TestRefreshTokenChecksOwnershipBeforeWriting guards an ordering that used to be the
+// other way round: the row was deleted and only then checked against the user, so a
+// token belonging to somebody else was destroyed on its way to being rejected.
+func TestRefreshTokenChecksOwnershipBeforeWriting(t *testing.T) {
+	fixture := newFixture(t, nil)
+	owner := fixture.withUser(t, "owner@example.com", "Str0ng!Passw0rd", models.RoleUser)
+
+	issued, err := fixture.service.Login(context.Background(), &models.LoginRequest{
+		Email: owner.Email, Password: "Str0ng!Passw0rd",
+	})
+	if err != nil {
+		t.Fatalf("Login: %v", err)
+	}
+
+	// Re-point the stored row at a different user, so the token no longer matches the
+	// subject of its own JWT.
+	hash := repository.HashToken(issued.RefreshToken)
+	fixture.tokens.stored[hash].UserID = uuid.New()
+
+	if _, err := fixture.service.RefreshToken(context.Background(), issued.RefreshToken); !errors.Is(err, ErrInvalidToken) {
+		t.Errorf("a token belonging to another user was accepted: %v", err)
+	}
+	if fixture.tokens.stored[hash].ConsumedAt != nil {
+		t.Error("the token was consumed before the ownership check")
 	}
 }
 

--- a/internal/mfa/handlers/mfa_handler_test.go
+++ b/internal/mfa/handlers/mfa_handler_test.go
@@ -263,6 +263,12 @@ func (s *stubAuthTokenRepo) GetByHash(context.Context, string) (*authModels.Refr
 func (s *stubAuthTokenRepo) DeleteByHash(context.Context, string) error      { return nil }
 func (s *stubAuthTokenRepo) DeleteByUserID(context.Context, uuid.UUID) error { return nil }
 
+func (s *stubAuthTokenRepo) Consume(context.Context, string) (bool, error) { return true, nil }
+
+func (s *stubAuthTokenRepo) DeleteConsumedBefore(context.Context, uuid.UUID, time.Time) error {
+	return nil
+}
+
 type stubAuthMFARepo struct{ record *models.UserMFA }
 
 func (s *stubAuthMFARepo) GetByUserID(context.Context, uuid.UUID) (*models.UserMFA, error) {

--- a/migrations/common/015_refresh_token_grace_window.down.sql
+++ b/migrations/common/015_refresh_token_grace_window.down.sql
@@ -1,0 +1,16 @@
+-- Restore refresh_tokens to the shape 001_init left it in.
+--
+-- Consumed rows go with the column. They are spent tokens: the code this rolls back to
+-- would have deleted them at rotation anyway, so dropping them loses nothing a session
+-- depends on. Live tokens — consumed_at IS NULL — are untouched, so nobody is signed
+-- out by the rollback.
+DELETE FROM refresh_tokens WHERE consumed_at IS NOT NULL;
+
+DROP INDEX IF EXISTS idx_refresh_tokens_consumed;
+
+-- 001_init created no index on token_hash. Dropping it returns lookup to a sequential
+-- scan, which is what the rolled-back code expects.
+DROP INDEX IF EXISTS idx_refresh_tokens_hash;
+
+ALTER TABLE refresh_tokens
+    DROP COLUMN IF EXISTS consumed_at;

--- a/migrations/common/015_refresh_token_grace_window.up.sql
+++ b/migrations/common/015_refresh_token_grace_window.up.sql
@@ -1,0 +1,31 @@
+-- Give refresh token rotation a grace window, and make reuse detectable.
+--
+-- Rotation used to be a delete: RefreshToken removed the row and issued a new pair.
+-- That makes every concurrent refresh a loser-takes-nothing race. Two tabs waking at
+-- the same moment, a retry after a dropped response, a tab restored from sleep — all
+-- present the same cookie, the first wins, and the rest get "unknown token" and a
+-- forced sign-out. Nothing distinguishes that from an attacker replaying a stolen
+-- cookie, because in both cases the row is simply gone.
+--
+-- Marking the row consumed instead keeps the evidence. A replay inside the window is
+-- the race, and is answered with a fresh pair. A replay outside it is a token that
+-- was used, superseded, and used again — which no honest client does.
+
+-- consumed_at is NULL for a live token and set at the moment of rotation. It is not a
+-- soft delete: the row stays useful precisely because it records that it was spent.
+ALTER TABLE refresh_tokens
+    ADD COLUMN IF NOT EXISTS consumed_at TIMESTAMP WITH TIME ZONE;
+
+-- GetByHash reads with QueryRow, which silently takes the first row of however many
+-- match. Nothing enforced that only one could: 001_init created no constraint on
+-- token_hash at all. A SHA-256 collision is not the worry — a bug inserting twice is,
+-- and it would have gone unnoticed while quietly picking an arbitrary row. This is
+-- also the index that lookup has always deserved; it was doing a sequential scan.
+CREATE UNIQUE INDEX IF NOT EXISTS idx_refresh_tokens_hash ON refresh_tokens(token_hash);
+
+-- Consumed rows are purged once they fall out of the grace window, so this index only
+-- ever covers the handful of rows still inside it. Partial, because the live tokens
+-- that make up the rest of the table are not what the purge is looking for.
+CREATE INDEX IF NOT EXISTS idx_refresh_tokens_consumed
+    ON refresh_tokens(user_id, consumed_at)
+    WHERE consumed_at IS NOT NULL;


### PR DESCRIPTION
The fix underneath the cross-tab workaround in #95. Adds migration `015`.

## The problem

Rotation deleted the row and issued a new pair, so **every concurrent refresh was a loser-takes-nothing race**. Two tabs waking together, a retry after a dropped response, a tab restored from sleep — all present the same cookie, the first wins, and the rest are told the token is unknown and signed out.

Worse, nothing distinguished that from somebody replaying a stolen cookie. In both cases the row was gone, so the system could neither forgive the first nor notice the second. `DeleteByHash`'s return value was discarded, which threw away `RowsAffected() == 0` — the natural reuse signal.

## The shape

| Token presented | Response |
|---|---|
| live | rotate |
| consumed, inside 30s | **rotate again** — the other tab, or a retry |
| consumed, outside 30s | **reuse** — revoke every session the user has |

`Consume` carries `consumed_at IS NULL` in its `WHERE`, so of two callers presenting the same token exactly one sees a row affected. That is what makes the race *decidable* rather than a guess.

The grace path issues a **fresh** pair rather than replaying the original response — only the hash was ever stored, so the first response cannot be reproduced. That is enough: what the racing tab needs is a working session, not that exact token.

**Reuse is the case worth having.** A token used, superseded, and used again is something no honest client does, so the cookie is assumed to be in someone else's hands: every session goes and the user signs in again. Logged at `Warn` with a fingerprinted user reference, because it is the only point in the system where a stolen refresh cookie becomes visible at all.

## Two fixes riding along

Both in the code this rewrites, both found while reading it:

- **The ownership check ran after the delete.** A refresh token belonging to another user was destroyed on its way to being rejected. It now runs before any write, and a test pins the ordering.
- **`token_hash` had no unique index**, while `GetByHash` reads with `QueryRow` — it would have silently taken the first of however many rows matched. A duplicate insert would have gone unnoticed while arbitrarily picking one. It also means the lookup stops being a sequential scan.

Consumed rows are purged past the window, so the table does not grow by one row per refresh held for the seven days until expiry.

## Verified

- **Migration applied against a live database**, then rolled back and re-applied: `14 → 15 → 14 → 15`, clean each way. The down migration deletes only consumed rows, so a rollback signs nobody out.
- `make test` — 39 packages, no failures, **including the DB-backed repository tests** (`TestConsumeIsWonByExactlyOneCaller`, `TestDeleteConsumedBeforeSparesLiveTokens`).
- `go test -race ./internal/auth/...` clean.
- Both build variants, format-check.

`TestRefreshTokenRotates` lost its replay assertion — it encoded the old "the row is deleted" invariant, which is now false by design. Three tests replace it: the race is tolerated, reuse revokes the family, and ownership is checked before writing.

Two context tests moved from counting rows to counting **writes that landed**: a refresh now deliberately leaves the previous row in place, so row count stopped being a proxy for "did the write happen".