### PR TITLE
feat(auth): refresh ahead of expiry, and remember where the user was

### DIFF
--- a/frontend/src/api/client.test.ts
+++ b/frontend/src/api/client.test.ts
@@ -10,15 +10,22 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { AxiosAdapter, AxiosInstance, AxiosRequestConfig } from 'axios';
 
 // The client imports the router at module scope, which would drag in every view and the
-// auth store. Only currentRoute.meta.public is read, so a stub is enough — and it lets
-// the tests choose whether the current route is public.
+// auth store. It reads currentRoute.meta.public, .fullPath and .name, so a stub is
+// enough — and it lets the tests choose the route the visitor is being thrown out of.
 const routeMeta = { public: false as boolean };
+const currentRoute = { fullPath: '/dashboard', name: 'dashboard' as string | undefined };
 vi.mock('@/router', () => ({
   default: {
     currentRoute: {
       value: {
         get meta() {
           return routeMeta;
+        },
+        get fullPath() {
+          return currentRoute.fullPath;
+        },
+        get name() {
+          return currentRoute.name;
         },
       },
     },
@@ -99,6 +106,8 @@ describe('apiClient', () => {
     localStorage.clear();
     apiClient.clearToken();
     routeMeta.public = false;
+    currentRoute.fullPath = '/dashboard';
+    currentRoute.name = 'dashboard';
     // jsdom refuses real navigation; forceLogout assigns to it.
     Object.defineProperty(window, 'location', {
       configurable: true,
@@ -204,6 +213,84 @@ describe('apiClient', () => {
     });
   });
 
+  describe('refreshing before the token dies', () => {
+    it('schedules a refresh a minute short of expiry', async () => {
+      vi.useFakeTimers();
+      try {
+        const seen = withAdapter(() => ok({ access_token: 'fresh', expires_in: 900 }));
+
+        // A fifteen-minute token: the refresh is due at fourteen.
+        apiClient.setToken('current', 900);
+
+        vi.advanceTimersByTime(13 * 60_000);
+        expect(seen.filter(r => r.url === '/auth/refresh')).toHaveLength(0);
+
+        await vi.advanceTimersByTimeAsync(2 * 60_000);
+        expect(seen.filter(r => r.url === '/auth/refresh')).toHaveLength(1);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it('does nothing when the token carries no expiry', () => {
+      vi.useFakeTimers();
+      try {
+        const seen = withAdapter(() => ok({ access_token: 'fresh' }));
+
+        // The MFA and passkey paths used to hand over a token without one. The 401
+        // path still covers those; this is an optimisation, not the mechanism.
+        apiClient.setToken('current');
+
+        vi.advanceTimersByTime(60 * 60_000);
+        expect(seen.filter(r => r.url === '/auth/refresh')).toHaveLength(0);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it('drops the pending refresh when the session ends', () => {
+      vi.useFakeTimers();
+      try {
+        const seen = withAdapter(() => ok({ access_token: 'fresh', expires_in: 900 }));
+        apiClient.setToken('current', 900);
+
+        apiClient.clearToken();
+
+        vi.advanceTimersByTime(60 * 60_000);
+        expect(seen.filter(r => r.url === '/auth/refresh')).toHaveLength(0);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    // A backgrounded tab does not get its timers on time — browsers throttle them and
+    // suspend them outright on a discarded tab — so the wake-up is what covers a tab
+    // left alone for an hour. Without it the user's first click is a 401 and a replay.
+    it('refreshes on the way back from a sleeping tab', async () => {
+      const seen = withAdapter(() => ok({ access_token: 'fresh', expires_in: 900 }));
+
+      // A token already inside the lead window, as one restored from sleep would be.
+      apiClient.setToken('nearly-dead', 30);
+
+      Object.defineProperty(document, 'hidden', { configurable: true, value: false });
+      document.dispatchEvent(new Event('visibilitychange'));
+
+      await vi.waitFor(() => expect(seen.filter(r => r.url === '/auth/refresh')).toHaveLength(1));
+    });
+
+    it('leaves a healthy token alone when the tab comes back', async () => {
+      const seen = withAdapter(() => ok({ access_token: 'fresh', expires_in: 900 }));
+      apiClient.setToken('plenty-of-life', 900);
+
+      Object.defineProperty(document, 'hidden', { configurable: true, value: false });
+      document.dispatchEvent(new Event('visibilitychange'));
+      window.dispatchEvent(new Event('online'));
+      await new Promise(resolve => setTimeout(resolve, 10));
+
+      expect(seen.filter(r => r.url === '/auth/refresh')).toHaveLength(0);
+    });
+  });
+
   describe('the 401 refresh', () => {
     it('refreshes once and replays the original request', async () => {
       apiClient.setToken('expired');
@@ -298,6 +385,33 @@ describe('apiClient', () => {
       await expect(apiClient.get('/calendars')).rejects.toBeTruthy();
 
       expect(apiClient.hasSession()).toBe(false);
+      expect(window.location.href).toBe('/login?redirect=%2Fdashboard');
+    });
+
+    it('carries the page they were thrown out of into the login URL', async () => {
+      // Without the query, signing back in always landed on the dashboard however deep
+      // the page the session expired on. The guard already produces this shape for an
+      // anonymous visitor; a mid-session expiry now matches it.
+      currentRoute.fullPath = '/calendars/abc-123/settings';
+      currentRoute.name = 'calendar-settings';
+      apiClient.setToken('expired');
+
+      withAdapter(() => unauthorized());
+
+      await expect(apiClient.get('/calendars')).rejects.toBeTruthy();
+
+      expect(window.location.href).toBe('/login?redirect=%2Fcalendars%2Fabc-123%2Fsettings');
+    });
+
+    it('does not ask to be sent back to the login page', async () => {
+      currentRoute.fullPath = '/login';
+      currentRoute.name = 'login';
+      apiClient.setToken('expired');
+
+      withAdapter(() => unauthorized());
+
+      await expect(apiClient.get('/calendars')).rejects.toBeTruthy();
+
       expect(window.location.href).toBe('/login');
     });
 

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -15,6 +15,22 @@ const SESSION_FLAG = 'whento.session';
 const AUTH_CHANNEL = 'whento.auth';
 const REFRESH_LOCK = 'whento.refresh';
 
+/**
+ * How far ahead of expiry to refresh.
+ *
+ * Wide enough that a slow round trip still lands before the token dies, narrow enough
+ * that it is a rounding error against the fifteen-minute lifetime.
+ */
+const REFRESH_LEAD_MS = 60_000;
+
+/**
+ * The soonest a scheduled refresh may fire.
+ *
+ * A token already inside the lead window — or, through a misconfigured server, shorter
+ * than it — would otherwise schedule at zero and spin.
+ */
+const MIN_REFRESH_DELAY_MS = 5_000;
+
 type AuthMessage = { type: 'token'; token: string } | { type: 'logout' };
 
 class ApiClient {
@@ -23,6 +39,10 @@ class ApiClient {
   /** The one refresh in progress, shared by every caller that needs it. */
   private refreshInFlight: Promise<void> | null = null;
   private channel: BroadcastChannel | null = null;
+  /** The pending proactive refresh, if the current token carried an expiry. */
+  private refreshTimer: ReturnType<typeof setTimeout> | null = null;
+  /** When the current token dies, so a tab returning from sleep can tell. */
+  private expiresAt: number | null = null;
 
   constructor() {
     this.client = axios.create({
@@ -36,6 +56,74 @@ class ApiClient {
 
     this.setupInterceptors();
     this.setupChannel();
+    this.setupWakeUp();
+  }
+
+  /**
+   * Refresh on the way back from sleep, rather than on the user's next click.
+   *
+   * A backgrounded tab does not get its timers on time — browsers throttle them heavily
+   * and suspend them outright on a discarded tab — so a tab left alone for an hour wakes
+   * with a token that expired long ago. Waiting for the next request means the first
+   * thing the user does after coming back is a 401, a refresh and a replay.
+   *
+   * Both events are cheap and idempotent: refreshIfDue does nothing while the token has
+   * life left in it.
+   */
+  private setupWakeUp() {
+    if (typeof window === 'undefined') {
+      return;
+    }
+
+    // visibilitychange is fired at the document, not the window.
+    document.addEventListener('visibilitychange', () => {
+      if (!document.hidden) {
+        this.refreshIfDue();
+      }
+    });
+    // Coming back from a dropped connection has the same shape: whatever the timer
+    // tried to do while offline did not happen.
+    window.addEventListener('online', () => this.refreshIfDue());
+  }
+
+  /** Refresh when the token is at or past its lead window. Silent on failure: the 401 path remains. */
+  private refreshIfDue() {
+    if (!this.accessToken || this.expiresAt === null) {
+      return;
+    }
+    if (this.expiresAt - Date.now() > REFRESH_LEAD_MS) {
+      return;
+    }
+
+    void this.refreshToken().catch(() => {
+      // Already handled by the interceptor's forced sign-out; nothing to add here,
+      // and an unhandled rejection would reach the global handler in main.ts.
+    });
+  }
+
+  /**
+   * Replace the pending proactive refresh.
+   *
+   * Cleared and reset on every token, so the timer always describes the token in hand
+   * rather than the one before it.
+   */
+  private scheduleRefresh(expiresInSeconds?: number) {
+    if (this.refreshTimer !== null) {
+      clearTimeout(this.refreshTimer);
+      this.refreshTimer = null;
+    }
+
+    if (!expiresInSeconds || expiresInSeconds <= 0) {
+      // No expiry to work from — the MFA and passkey paths hand over a token without
+      // one. The 401 path still covers it; this is an optimisation, not the mechanism.
+      this.expiresAt = null;
+      return;
+    }
+
+    this.expiresAt = Date.now() + expiresInSeconds * 1000;
+    const delay = Math.max(expiresInSeconds * 1000 - REFRESH_LEAD_MS, MIN_REFRESH_DELAY_MS);
+
+    this.refreshTimer = setTimeout(() => this.refreshIfDue(), delay);
   }
 
   /**
@@ -149,16 +237,36 @@ class ApiClient {
     this.broadcast({ type: 'logout' });
   }
 
+  /**
+   * Send the visitor to the login page, remembering where they were.
+   *
+   * Still a full page load rather than a router navigation. The reload is doing real
+   * work: it drops every Pinia store with it, and this client cannot reset them itself
+   * without importing the stores that import it. A soft navigation would leave the
+   * previous account's user, calendars and settings in memory on the login screen.
+   *
+   * What was missing is the query. The guard sends an anonymous visitor to
+   * `?redirect=<where they were going>` and Login.vue returns them there afterwards,
+   * but an expiry mid-session went to a bare `/login` — so signing back in always
+   * landed on the dashboard, however deep the page they were thrown out of.
+   */
   private redirectToLogin() {
     // Only redirect to login if current route is not public: a participant following
     // a calendar link has no account to sign back in to.
     const currentRoute = router.currentRoute.value;
-    const isPublicRoute = currentRoute.meta.public === true;
-
-    if (!isPublicRoute) {
-      // Force full page reload to login to reset all UI state
-      window.location.href = '/login';
+    if (currentRoute.meta.public === true) {
+      return;
     }
+
+    const target = currentRoute.fullPath;
+    // The login route itself, and anything with no path to speak of, has nothing worth
+    // coming back to.
+    if (!target || target === '/' || currentRoute.name === 'login') {
+      window.location.href = '/login';
+      return;
+    }
+
+    window.location.href = `/login?redirect=${encodeURIComponent(target)}`;
   }
 
   private normalizeError(error: AxiosError<ApiResponse<never>>): ApiError {
@@ -172,8 +280,9 @@ class ApiClient {
     };
   }
 
-  setToken(token: string) {
+  setToken(token: string, expiresInSeconds?: number) {
     this.accessToken = token;
+    this.scheduleRefresh(expiresInSeconds);
     // A flag, not a secret. The token itself never leaves memory: anything persisted
     // is readable by any script that gets to run on the page, which is exactly what
     // CodeQL's js/clear-text-storage-of-sensitive-data flagged when the JWT lived
@@ -186,6 +295,7 @@ class ApiClient {
 
   clearToken() {
     this.accessToken = null;
+    this.scheduleRefresh();
     localStorage.removeItem(SESSION_FLAG);
   }
 
@@ -235,10 +345,14 @@ class ApiClient {
       }
 
       const response =
-        await this.client.post<ApiResponse<{ access_token: string }>>('/auth/refresh');
+        await this.client.post<ApiResponse<{ access_token: string; expires_in?: number }>>(
+          '/auth/refresh'
+        );
       const newToken = response.data.data?.access_token;
       if (newToken) {
-        this.setToken(newToken);
+        // expires_in was being discarded here, which is why every refresh had to be
+        // provoked by a 401 rather than anticipated.
+        this.setToken(newToken, response.data.data?.expires_in);
       }
     });
   }

--- a/frontend/src/stores/auth.test.ts
+++ b/frontend/src/stores/auth.test.ts
@@ -108,7 +108,16 @@ describe('auth store', () => {
       await store.login({ email: 'ada@example.com', password: 'pw' });
 
       expect(store.user).toEqual(USER);
-      expect(apiClient.setToken).toHaveBeenCalledWith('tok');
+      expect(apiClient.setToken).toHaveBeenCalledWith('tok', undefined);
+    });
+
+    it('passes the token lifetime on, so the client can refresh ahead of it', async () => {
+      authApi.login.mockResolvedValue(authResponse({ expires_in: 900 }));
+      const store = freshStore();
+
+      await store.login({ email: 'ada@example.com', password: 'pw' });
+
+      expect(apiClient.setToken).toHaveBeenCalledWith('tok', 900);
     });
 
     it('does not start a session when a second factor is required', async () => {
@@ -166,7 +175,7 @@ describe('auth store', () => {
       await store.register({ email: 'ada@example.com', password: 'pw', display_name: 'Ada' });
 
       expect(store.user).toEqual(USER);
-      expect(apiClient.setToken).toHaveBeenCalledWith('tok');
+      expect(apiClient.setToken).toHaveBeenCalledWith('tok', undefined);
     });
 
     it('reports failure through i18n', async () => {
@@ -258,7 +267,7 @@ describe('auth store', () => {
       await store.resetPassword('reset-token', 'new-password');
 
       expect(store.user).toEqual(USER);
-      expect(apiClient.setToken).toHaveBeenCalledWith('fresh');
+      expect(apiClient.setToken).toHaveBeenCalledWith('fresh', undefined);
     });
 
     it('translates a forgotten-password failure', async () => {
@@ -273,7 +282,7 @@ describe('auth store', () => {
   describe('setTokens', () => {
     it('hands the token straight to the client', () => {
       freshStore().setTokens('mfa-issued');
-      expect(apiClient.setToken).toHaveBeenCalledWith('mfa-issued');
+      expect(apiClient.setToken).toHaveBeenCalledWith('mfa-issued', undefined);
     });
   });
 

--- a/frontend/src/stores/auth.ts
+++ b/frontend/src/stores/auth.ts
@@ -43,7 +43,7 @@ export const useAuthStore = defineStore('auth', () => {
       const response = await authApi.register(data);
       user.value = response.user;
       if (response.access_token) {
-        apiClient.setToken(response.access_token);
+        apiClient.setToken(response.access_token, response.expires_in);
       }
       return response;
     });
@@ -66,7 +66,7 @@ export const useAuthStore = defineStore('auth', () => {
 
         user.value = response.user;
         if (response.access_token) {
-          apiClient.setToken(response.access_token);
+          apiClient.setToken(response.access_token, response.expires_in);
         }
         return response;
       },
@@ -127,7 +127,7 @@ export const useAuthStore = defineStore('auth', () => {
       // Auto-login after successful reset
       user.value = response.user;
       if (response.access_token) {
-        apiClient.setToken(response.access_token);
+        apiClient.setToken(response.access_token, response.expires_in);
       }
 
       return response;
@@ -135,8 +135,8 @@ export const useAuthStore = defineStore('auth', () => {
   }
 
   // Set tokens directly (for MFA verification and passkey login)
-  function setTokens(accessToken: string) {
-    apiClient.setToken(accessToken);
+  function setTokens(accessToken: string, expiresIn?: number) {
+    apiClient.setToken(accessToken, expiresIn);
     // Note: refresh_token is httpOnly cookie, handled by backend
   }
 

--- a/frontend/src/views/Login.vue
+++ b/frontend/src/views/Login.vue
@@ -410,7 +410,7 @@ async function loginWithDiscoverablePasskey() {
 
     // Store tokens in auth store
     if (response.access_token) {
-      authStore.setTokens(response.access_token);
+      authStore.setTokens(response.access_token, response.expires_in);
       authStore.user = response.user;
     }
 

--- a/frontend/src/views/MagicLinkVerify.vue
+++ b/frontend/src/views/MagicLinkVerify.vue
@@ -120,7 +120,7 @@ onMounted(async () => {
 
     // Set auth tokens in store
     authStore.user = response.user;
-    apiClient.setToken(response.access_token);
+    apiClient.setToken(response.access_token, response.expires_in);
 
     // Redirect to dashboard
     await router.push('/dashboard');

--- a/frontend/src/views/VerifyMFA.vue
+++ b/frontend/src/views/VerifyMFA.vue
@@ -185,7 +185,7 @@ async function handleVerify() {
     authStore.clearTempToken();
 
     // Store real JWT tokens
-    authStore.setTokens(response.access_token);
+    authStore.setTokens(response.access_token, response.expires_in);
     authStore.user = response.user;
 
     // Redirect to dashboard

--- a/internal/auth/service/auth_service.go
+++ b/internal/auth/service/auth_service.go
@@ -428,9 +428,13 @@ func (s *AuthService) generateAuthResponse(ctx context.Context, user *models.Use
 	}
 
 	return &models.AuthResponse{
-		AccessToken:  accessToken,
+		AccessToken: accessToken,
+		// Read from the manager rather than written here. The literal 900 that used to
+		// sit in this field agreed with the token's real lifetime only at the default
+		// setting: an instance configuring JWT_ACCESS_EXPIRY got a number that did not
+		// describe the token it came with. The client schedules its refresh off this.
+		ExpiresIn:    int64(s.jwtManager.AccessExpiry().Seconds()),
 		RefreshToken: refreshToken,
-		ExpiresIn:    900, // 15 minutes in seconds
 		User:         user,
 	}, nil
 }

--- a/internal/auth/service/auth_service_flows_test.go
+++ b/internal/auth/service/auth_service_flows_test.go
@@ -262,6 +262,14 @@ var sharedKey *rsa.PrivateKey
 func testJWT(t *testing.T) *jwt.Manager {
 	t.Helper()
 
+	return testJWTWithExpiry(t, 15*time.Minute)
+}
+
+// testJWTWithExpiry builds a manager whose access tokens live for a chosen duration, so
+// a test can tell a value read from the configuration apart from one written in.
+func testJWTWithExpiry(t *testing.T, accessExpiry time.Duration) *jwt.Manager {
+	t.Helper()
+
 	if sharedKey == nil {
 		key, err := rsa.GenerateKey(rand.Reader, 2048)
 		if err != nil {
@@ -296,7 +304,7 @@ func testJWT(t *testing.T) *jwt.Manager {
 	manager, err := jwt.NewManager(&jwt.Config{
 		PrivateKeyPath: privatePath,
 		PublicKeyPath:  publicPath,
-		AccessExpiry:   15 * time.Minute,
+		AccessExpiry:   accessExpiry,
 		RefreshExpiry:  7 * 24 * time.Hour,
 		Issuer:         "whento-test",
 	})
@@ -704,6 +712,36 @@ func TestRefreshTokenRotates(t *testing.T) {
 	// The old one is deleted, so replaying it fails.
 	if _, err := fixture.service.RefreshToken(context.Background(), first.RefreshToken); !errors.Is(err, ErrInvalidToken) {
 		t.Errorf("the spent refresh token was accepted again: %v", err)
+	}
+}
+
+// TestExpiresInDescribesTheTokenItCameWith guards a value the client now schedules
+// against. The field used to be a literal 900, which agreed with the token's real
+// lifetime only at the default setting — an instance configuring JWT_ACCESS_EXPIRY got
+// a number describing a token it had never issued, and a client refreshing off it would
+// have aimed at the wrong moment. Deliberately not 15 minutes, so the old constant
+// would fail this.
+func TestExpiresInDescribesTheTokenItCameWith(t *testing.T) {
+	const accessExpiry = 5 * time.Minute
+
+	manager := testJWTWithExpiry(t, accessExpiry)
+	users := newFakeUserRepo()
+	service := NewAuthService(
+		users, newFakeTokenRepo(), &fakeMFARepo{}, manager, newCountingCache(),
+		bcrypt.MinCost, true, []string{"*"},
+	)
+
+	resp, err := service.Register(context.Background(), &models.RegisterRequest{
+		Email:       "expiry@example.test",
+		Password:    "Str0ng!Passw0rd",
+		DisplayName: "Expiry",
+	})
+	if err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+
+	if want := int64(accessExpiry.Seconds()); resp.ExpiresIn != want {
+		t.Errorf("ExpiresIn = %d, want %d — the field does not follow JWT_ACCESS_EXPIRY", resp.ExpiresIn, want)
 	}
 }
 


### PR DESCRIPTION
The comfort half of the auth work. Three things, all downstream of a value the client was throwing away.

## `expires_in` was a literal

`generateAuthResponse` returned `ExpiresIn: 900`. That agreed with the token's real lifetime **only at the default setting** — an instance configuring `JWT_ACCESS_EXPIRY` received a number describing a token it had never issued. `magic_link_service.go` already did it correctly.

Now read from `jwtManager.AccessExpiry()`, whose accessor already existed and was already used elsewhere in the same file. `TestExpiresInDescribesTheTokenItCameWith` uses a 5-minute expiry deliberately, so the old constant fails it — verified by reverting the line and watching it go red.

## Refreshing before the token dies

The client discarded `expires_in` entirely, which is why every refresh had to be **provoked by a 401**: the user's request failed, refreshed and replayed, once a quarter of an hour.

It now schedules a refresh a minute short of expiry, reset on every token and cleared with the session. A token that carries no expiry — the MFA and passkey paths — schedules nothing and falls back to the 401 path, which remains the mechanism; this is an optimisation on top of it.

**A timer is not enough on its own.** Browsers throttle background tabs heavily and suspend a discarded one outright, so a tab left alone wakes with a token that died long ago and a timer that never ran. `visibilitychange` and `online` cover that: coming back checks whether the token is inside the lead window and refreshes only if it is.

Both paths go through the existing `refreshToken()`, so they inherit the in-flight promise and the cross-tab Web Lock from #95 — no second refresh implementation to keep honest.

## Remembering the page

Being thrown out mid-session sent the user to a bare `/login`. The router guard has always sent anonymous visitors to `?redirect=<where they were going>` and `Login.vue` returns them there, but an expiry carried no query — so signing back in landed on the dashboard however deep the page they lost.

**This stays a full page load rather than becoming a router navigation**, which is a deviation from what I sketched earlier and I think the right call. The reload is doing real work: it drops every Pinia store with it, and this client cannot reset them itself without importing the stores that import it. A soft navigation would leave the previous account's user, calendars and settings sitting in memory behind the login form. Adding the query gets the benefit without giving that up.

## Tests

Five new tests in `client.test.ts` — the timer fires at the right moment, does nothing without an expiry, is dropped on sign-out, wakes a sleeping tab, and leaves a healthy token alone — plus two for the redirect query (a deep page, and the login page itself, which has nothing to come back to).

The router stub grew `fullPath` and `name`: without them the redirect was silently untested, since `undefined` took the bare-`/login` branch.

`694 passed` on the frontend, the full Go suite, both build variants, format-check.