### PR TITLE
fix(ratelimit): give every rule its own bucket

### DIFF
--- a/cmd/ratelimit.go
+++ b/cmd/ratelimit.go
@@ -17,6 +17,10 @@ import (
 // against whom. It is pkg/middleware's RateLimitConfig minus the question of
 // whether rate limiting is switched on at all, which is the routeLimiter's.
 type rateLimitRule struct {
+	// bucket names the budget, and is what keeps one route's traffic from
+	// spending another's. Two rules sharing a name share a counter — which is
+	// occasionally what you want, and must always be deliberate.
+	bucket   string
 	requests int
 	window   time.Duration
 	keyFunc  func(r *http.Request) string
@@ -24,21 +28,27 @@ type rateLimitRule struct {
 
 // perIP buckets by client address. Proxy headers are honoured only for
 // connections coming from a configured trusted proxy; see middleware.IPKeyFunc.
-func perIP(requests int, window time.Duration) rateLimitRule {
-	return rateLimitRule{requests: requests, window: window, keyFunc: middleware.IPKeyFunc}
+//
+// The name is not decoration. Before it existed the key was the address alone,
+// so every perIP route in the application counted into the same bucket and each
+// one compared that shared total against its own limit: loading a calendar page
+// spent four of the five an email address was allowed per quarter hour, and the
+// next attempt to add one got a 429 it had done nothing to earn.
+func perIP(bucket string, requests int, window time.Duration) rateLimitRule {
+	return rateLimitRule{bucket: bucket, requests: requests, window: window, keyFunc: middleware.IPKeyFunc}
 }
 
 // perUser buckets by authenticated user id, and therefore only means anything
 // below middleware.Auth: without it the key is empty and the limiter lets the
 // request through.
-func perUser(requests int, window time.Duration) rateLimitRule {
-	return rateLimitRule{requests: requests, window: window, keyFunc: middleware.UserKeyFunc}
+func perUser(bucket string, requests int, window time.Duration) rateLimitRule {
+	return rateLimitRule{bucket: bucket, requests: requests, window: window, keyFunc: middleware.UserKeyFunc}
 }
 
 // perPathIP buckets by exact request path *and* client address, so two
 // calendars — or two participants of one calendar — never share a budget.
-func perPathIP(requests int, window time.Duration) rateLimitRule {
-	return rateLimitRule{requests: requests, window: window, keyFunc: middleware.CombinedKeyFunc}
+func perPathIP(bucket string, requests int, window time.Duration) rateLimitRule {
+	return rateLimitRule{bucket: bucket, requests: requests, window: window, keyFunc: middleware.CombinedKeyFunc}
 }
 
 // routeLimiter decides once whether rate limiting applies, so that no route has
@@ -75,6 +85,7 @@ func (l *routeLimiter) middlewares(rule rateLimitRule) chi.Middlewares {
 	}
 
 	return chi.Middlewares{l.limiter.Limit(middleware.RateLimitConfig{
+		Bucket:   rule.bucket,
 		Requests: rule.requests,
 		Window:   rule.window,
 		KeyFunc:  rule.keyFunc,

--- a/cmd/ratelimit_test.go
+++ b/cmd/ratelimit_test.go
@@ -46,7 +46,7 @@ func TestRouteLimiterMiddlewares(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			got := newTestLimiter(t, tc.enabled).middlewares(perIP(5, time.Minute))
+			got := newTestLimiter(t, tc.enabled).middlewares(perIP("test", 5, time.Minute))
 			if len(got) != tc.want {
 				t.Fatalf("middlewares() has %d entries, want %d", len(got), tc.want)
 			}
@@ -62,10 +62,10 @@ func TestRouteLimiterMiddlewares(t *testing.T) {
 func TestRouteLimiterOnIsIdentityWhenDisabled(t *testing.T) {
 	r := chi.NewRouter()
 
-	if got := newTestLimiter(t, false).on(r, perIP(5, time.Minute)); got != chi.Router(r) {
+	if got := newTestLimiter(t, false).on(r, perIP("test", 5, time.Minute)); got != chi.Router(r) {
 		t.Error("on() returned a different router with rate limiting disabled")
 	}
-	if got := newTestLimiter(t, true).on(r, perIP(5, time.Minute)); got == chi.Router(r) {
+	if got := newTestLimiter(t, true).on(r, perIP("test", 5, time.Minute)); got == chi.Router(r) {
 		t.Error("on() returned the same router with rate limiting enabled")
 	}
 }
@@ -83,21 +83,21 @@ func TestRouteLimiterHeadersAndRejection(t *testing.T) {
 			name:    "on, enabled",
 			enabled: true,
 			mount: func(l *routeLimiter, r chi.Router, h http.HandlerFunc) {
-				l.on(r, perIP(2, time.Minute)).Get("/x", h)
+				l.on(r, perIP("test", 2, time.Minute)).Get("/x", h)
 			},
 		},
 		{
 			name:    "on, disabled",
 			enabled: false,
 			mount: func(l *routeLimiter, r chi.Router, h http.HandlerFunc) {
-				l.on(r, perIP(2, time.Minute)).Get("/x", h)
+				l.on(r, perIP("test", 2, time.Minute)).Get("/x", h)
 			},
 		},
 		{
 			name:    "use, enabled",
 			enabled: true,
 			mount: func(l *routeLimiter, r chi.Router, h http.HandlerFunc) {
-				l.use(r, perIP(2, time.Minute))
+				l.use(r, perIP("test", 2, time.Minute))
 				r.Get("/x", h)
 			},
 		},
@@ -105,7 +105,7 @@ func TestRouteLimiterHeadersAndRejection(t *testing.T) {
 			name:    "use, disabled",
 			enabled: false,
 			mount: func(l *routeLimiter, r chi.Router, h http.HandlerFunc) {
-				l.use(r, perIP(2, time.Minute))
+				l.use(r, perIP("test", 2, time.Minute))
 				r.Get("/x", h)
 			},
 		},
@@ -167,7 +167,7 @@ func TestRateLimitRuleKeys(t *testing.T) {
 		r := chi.NewRouter()
 		reached := 0
 		l := newTestLimiter(t, true)
-		l.use(r, perIP(2, time.Minute))
+		l.use(r, perIP("test", 2, time.Minute))
 		r.Get("/a", okHandler(&reached))
 		r.Get("/b", okHandler(&reached))
 
@@ -181,7 +181,7 @@ func TestRateLimitRuleKeys(t *testing.T) {
 		r := chi.NewRouter()
 		reached := 0
 		l := newTestLimiter(t, true)
-		l.use(r, perPathIP(2, time.Minute))
+		l.use(r, perPathIP("test", 2, time.Minute))
 		r.Get("/a", okHandler(&reached))
 		r.Get("/b", okHandler(&reached))
 
@@ -193,6 +193,53 @@ func TestRateLimitRuleKeys(t *testing.T) {
 		}
 	})
 
+	// The defect this guards: the bucket key used to be whatever the key function
+	// returned and nothing else, so every perIP rule in the application counted into
+	// one bucket per address — and each compared that shared total against its own
+	// limit. Opening a calendar page (a public read plus three availability reads)
+	// spent four of the five a participant email address was allowed per quarter hour,
+	// and the next attempt to add one was refused having done nothing wrong.
+	//
+	// Both rules carry the same numbers on purpose. The in-memory backend builds its
+	// limiter once per key, from the parameters of whichever request created it, so a
+	// test using different limits would pass even with the bucket name removed — the
+	// looser rule's limiter would simply be the one both routes found. With identical
+	// numbers the name is the only thing that can separate them.
+	t.Run("two rules with different names do not share a budget", func(t *testing.T) {
+		r := chi.NewRouter()
+		reached := 0
+		l := newTestLimiter(t, true)
+		l.on(r, perIP("first", 2, time.Minute)).Get("/a", okHandler(&reached))
+		l.on(r, perIP("second", 2, time.Minute)).Get("/b", okHandler(&reached))
+
+		// Spend /a's budget in full, then ask /b for its own.
+		requestPaths(r, "/a", "/a")
+
+		codes := requestPaths(r, "/b", "/b")
+		for i, code := range codes {
+			if code != http.StatusOK {
+				t.Errorf("request %d to /b = %d, want %d: /a spent a budget that was not its own",
+					i, code, http.StatusOK)
+			}
+		}
+	})
+
+	t.Run("two rules sharing a name share a budget", func(t *testing.T) {
+		// The other half: naming is what decides, so it has to be able to join two
+		// routes deliberately as well as separate them.
+		r := chi.NewRouter()
+		reached := 0
+		l := newTestLimiter(t, true)
+		l.on(r, perIP("shared", 2, time.Minute)).Get("/a", okHandler(&reached))
+		l.on(r, perIP("shared", 2, time.Minute)).Get("/b", okHandler(&reached))
+
+		codes := requestPaths(r, "/a", "/b", "/a")
+		if codes[2] != http.StatusTooManyRequests {
+			t.Errorf("third request across the shared bucket = %d, want %d",
+				codes[2], http.StatusTooManyRequests)
+		}
+	})
+
 	t.Run("perUser is inert without an authenticated user", func(t *testing.T) {
 		// UserKeyFunc reads the user id the Auth middleware puts on the context.
 		// With no Auth above it the key is empty, and pkg/middleware lets an
@@ -201,7 +248,7 @@ func TestRateLimitRuleKeys(t *testing.T) {
 		r := chi.NewRouter()
 		reached := 0
 		l := newTestLimiter(t, true)
-		l.use(r, perUser(1, time.Minute))
+		l.use(r, perUser("test", 1, time.Minute))
 		r.Get("/a", okHandler(&reached))
 
 		codes := requestPaths(r, "/a", "/a", "/a")

--- a/cmd/routes_auth.go
+++ b/cmd/routes_auth.go
@@ -22,27 +22,27 @@ func registerAuthRoutes(r chi.Router, d *deps, h *handlers) {
 	r.Route("/api/v1/auth", func(r chi.Router) {
 		// Public routes with rate limiting
 		r.Group(func(r chi.Router) {
-			l.on(r, perPathIP(5, time.Minute)).Post("/login", h.auth.Login)
-			l.on(r, perPathIP(3, time.Minute)).Post("/register", h.auth.Register)
+			l.on(r, perPathIP("auth-login", 5, time.Minute)).Post("/login", h.auth.Login)
+			l.on(r, perPathIP("auth-register", 3, time.Minute)).Post("/register", h.auth.Register)
 			// Higher than its neighbours because the access token now lives only in
 			// memory: every cold page load spends one refresh, where it used to take
 			// one only after the token expired. At five a minute, reloading a few
 			// times in a row signed the user out. Guessing the value this protects is
 			// not the threat — it is an RSA-signed JWT — so the headroom costs nothing.
-			l.on(r, perPathIP(30, time.Minute)).Post("/refresh", h.auth.Refresh)
+			l.on(r, perPathIP("auth-refresh", 30, time.Minute)).Post("/refresh", h.auth.Refresh)
 			r.Post("/logout", h.auth.Logout)
 
 			// Password reset (public - no auth required)
-			l.on(r, perIP(3, 15*time.Minute)).Post("/forgot-password", h.passwordReset.ForgotPassword)
-			l.on(r, perPathIP(5, 15*time.Minute)).Post("/reset-password", h.passwordReset.ResetPassword)
+			l.on(r, perIP("auth-forgot-password", 3, 15*time.Minute)).Post("/forgot-password", h.passwordReset.ForgotPassword)
+			l.on(r, perPathIP("auth-reset-password", 5, 15*time.Minute)).Post("/reset-password", h.passwordReset.ResetPassword)
 
 			// Magic link authentication (public)
-			l.on(r, perIP(3, 15*time.Minute)).Post("/magic-link/request", h.magicLink.RequestMagicLink)
-			l.on(r, perPathIP(5, 15*time.Minute)).Get("/magic-link/verify/{token}", h.magicLink.VerifyMagicLink)
+			l.on(r, perIP("auth-magic-link-request", 3, 15*time.Minute)).Post("/magic-link/request", h.magicLink.RequestMagicLink)
+			l.on(r, perPathIP("auth-magic-link-verify", 5, 15*time.Minute)).Get("/magic-link/verify/{token}", h.magicLink.VerifyMagicLink)
 			r.Get("/magic-link/available", h.magicLink.CheckAvailable)
 
 			// Email verification (public - no auth required)
-			l.on(r, perPathIP(5, 15*time.Minute)).Get("/verify-email/{token}", h.emailVerification.VerifyEmail)
+			l.on(r, perPathIP("auth-verify-email", 5, 15*time.Minute)).Get("/verify-email/{token}", h.emailVerification.VerifyEmail)
 		})
 
 		// Authenticated routes

--- a/cmd/routes_availability.go
+++ b/cmd/routes_availability.go
@@ -29,7 +29,7 @@ func registerAvailabilityRoutes(r chi.Router, d *deps, h *handlers) {
 		// reconnect loop cannot starve another, and sized for several tabs behind a
 		// shared NAT rather than for API call volume.
 		r.Group(func(r chi.Router) {
-			l.use(r, perPathIP(300, time.Minute))
+			l.use(r, perPathIP("availability-stream", 300, time.Minute))
 
 			r.Get("/calendar/{token}/events", h.events.Stream)
 		})
@@ -56,7 +56,7 @@ func registerAvailabilityRoutes(r chi.Router, d *deps, h *handlers) {
 		// this through the interface. The limiter is here to bound a runaway client,
 		// not to ration normal use.
 		r.Group(func(r chi.Router) {
-			l.use(r, perIP(400, time.Minute))
+			l.use(r, perIP("availability-write", 400, time.Minute))
 
 			// One notice per successful write, for every route below. Placed here
 			// rather than in the nine service methods so a tenth write route cannot

--- a/cmd/routes_calendar.go
+++ b/cmd/routes_calendar.go
@@ -22,25 +22,30 @@ func registerCalendarRoutes(r chi.Router, d *deps, h *handlers) {
 		// Public routes
 		r.Group(func(r chi.Router) {
 			// Public calendar access: 60 requests/minute/IP
-			l.on(r, perIP(60, time.Minute)).Get("/public/{token}", h.calendar.GetPublicCalendar)
+			l.on(r, perIP("calendar-public-read", 60, time.Minute)).Get("/public/{token}", h.calendar.GetPublicCalendar)
 
 			// Anonymous participant registration: 10 requests/minute/IP
-			l.on(r, perIP(10, time.Minute)).Post("/public/{token}/participants", h.participant.AddAnonymousParticipant)
+			l.on(r, perIP("calendar-anonymous-participant", 10, time.Minute)).Post("/public/{token}/participants", h.participant.AddAnonymousParticipant)
 
 			// Public participant email verification: 5 requests/15 minutes/IP
-			l.on(r, perPathIP(5, 15*time.Minute)).Get("/participants/verify-email/{token}", h.participantEmail.VerifyEmail)
+			l.on(r, perPathIP("participant-verify-email", 5, 15*time.Minute)).Get("/participants/verify-email/{token}", h.participantEmail.VerifyEmail)
 
 			// Public participant email management: 5 requests/15 minutes/IP.
 			//
 			// This route was the only one in the group without a limiter, and it is
 			// the one that sends mail to an address the caller picks — unauthenticated,
-			// so an open relay for anyone holding a public calendar link. The budget
-			// matches resend-verification below rather than the looser per-IP defaults,
-			// because both spend the same resource: outbound mail to a third party.
-			l.on(r, perIP(5, 15*time.Minute)).Post("/{token}/participants/{pid}/email", h.participantEmail.AddEmail)
+			// so an open relay for anyone holding a public calendar link. The budget is
+			// deliberately tight rather than following the looser per-IP defaults,
+			// because what it spends is outbound mail to a third party.
+			//
+			// Ten rather than five: a household or an office is one public address, and
+			// several participants filling in their own address one after another is
+			// ordinary use, not abuse. Five was also never really five — until this
+			// bucket was named, opening the calendar page spent four of them on reads.
+			l.on(r, perIP("participant-email-add", 10, 15*time.Minute)).Post("/{token}/participants/{pid}/email", h.participantEmail.AddEmail)
 
 			// Resend verification: 3 requests/15 minutes/IP
-			l.on(r, perIP(3, 15*time.Minute)).Post("/{token}/participants/{pid}/resend-verification", h.participantEmail.ResendVerification)
+			l.on(r, perIP("participant-email-resend", 3, 15*time.Minute)).Post("/{token}/participants/{pid}/resend-verification", h.participantEmail.ResendVerification)
 		})
 
 		// Authenticated routes
@@ -48,7 +53,7 @@ func registerCalendarRoutes(r chi.Router, d *deps, h *handlers) {
 			r.Use(middleware.Auth(d.jwtManager, d.cacheStore))
 
 			// Authenticated routes: 100 requests/minute/user
-			l.use(r, perUser(100, time.Minute))
+			l.use(r, perUser("calendar-authenticated", 100, time.Minute))
 
 			// Calendar CRUD
 			r.Post("/", h.calendar.CreateCalendar)

--- a/cmd/routes_ics.go
+++ b/cmd/routes_ics.go
@@ -22,7 +22,7 @@ func registerICSRoutes(r chi.Router, d *deps, h *handlers) {
 		// Public routes with rate limiting
 		r.Group(func(r chi.Router) {
 			// ICS feed access: 30 requests/minute/IP
-			l.use(r, perIP(30, time.Minute))
+			l.use(r, perIP("ics-feed", 30, time.Minute))
 
 			// ICS feed endpoint (accepts both /feed/{token} and /feed/{token}.ics)
 			r.Get("/feed/{token}", h.ics.GetFeed)
@@ -33,7 +33,7 @@ func registerICSRoutes(r chi.Router, d *deps, h *handlers) {
 		// Authenticated routes for managing unified feed
 		r.Group(func(r chi.Router) {
 			r.Use(middleware.Auth(d.jwtManager, d.cacheStore))
-			l.use(r, perUser(30, time.Minute))
+			l.use(r, perUser("ics-authenticated", 30, time.Minute))
 
 			r.Get("/unified-feed", h.unifiedFeed.GetConfig)
 			r.Post("/unified-feed", h.unifiedFeed.Create)

--- a/cmd/routes_mfa.go
+++ b/cmd/routes_mfa.go
@@ -23,7 +23,7 @@ func registerMFALoginRoutes(r chi.Router, d *deps, h *handlers) {
 
 	r.Group(func(r chi.Router) {
 		// MFA verification: 5 requests/5 minutes/IP
-		l.on(r, perPathIP(5, 5*time.Minute)).Post("/mfa/verify", h.mfa.VerifyLogin)
+		l.on(r, perPathIP("mfa-verify", 5, 5*time.Minute)).Post("/mfa/verify", h.mfa.VerifyLogin)
 	})
 }
 
@@ -36,9 +36,9 @@ func registerMFARoutes(r chi.Router, d *deps, h *handlers) {
 		r.Use(middleware.Auth(d.jwtManager, d.cacheStore))
 
 		// MFA setup/disable: 5 requests/minute/user
-		l.on(r, perUser(5, time.Minute)).Post("/setup/begin", h.mfa.BeginSetup)
-		l.on(r, perUser(5, time.Minute)).Post("/setup/finish", h.mfa.FinishSetup)
-		l.on(r, perUser(3, time.Minute)).Post("/disable", h.mfa.Disable)
+		l.on(r, perUser("mfa-setup-begin", 5, time.Minute)).Post("/setup/begin", h.mfa.BeginSetup)
+		l.on(r, perUser("mfa-setup-finish", 5, time.Minute)).Post("/setup/finish", h.mfa.FinishSetup)
+		l.on(r, perUser("mfa-disable", 3, time.Minute)).Post("/disable", h.mfa.Disable)
 
 		r.Get("/status", h.mfa.GetStatus)
 		r.Post("/backup-codes/regenerate", h.mfa.RegenerateBackupCodes)

--- a/cmd/routes_passkey.go
+++ b/cmd/routes_passkey.go
@@ -23,8 +23,8 @@ func registerPasskeyLoginRoutes(r chi.Router, d *deps, h *handlers) {
 
 	r.Group(func(r chi.Router) {
 		// Passkey login (usernameless/passwordless): 5 requests/minute/IP
-		l.on(r, perPathIP(5, time.Minute)).Post("/passkey/login/begin", h.passkey.BeginDiscoverableAuthentication)
-		l.on(r, perPathIP(5, time.Minute)).Post("/passkey/login/finish", h.passkey.FinishAuthentication)
+		l.on(r, perPathIP("passkey-login-begin", 5, time.Minute)).Post("/passkey/login/begin", h.passkey.BeginDiscoverableAuthentication)
+		l.on(r, perPathIP("passkey-login-finish", 5, time.Minute)).Post("/passkey/login/finish", h.passkey.FinishAuthentication)
 	})
 }
 
@@ -37,8 +37,8 @@ func registerPasskeyRoutes(r chi.Router, d *deps, h *handlers) {
 		r.Use(middleware.Auth(d.jwtManager, d.cacheStore))
 
 		// Passkey operations: 5 requests/minute/user
-		l.on(r, perUser(5, time.Minute)).Post("/register/begin", h.passkey.BeginRegistration)
-		l.on(r, perUser(5, time.Minute)).Post("/register/finish", h.passkey.FinishRegistration)
+		l.on(r, perUser("passkey-register-begin", 5, time.Minute)).Post("/register/begin", h.passkey.BeginRegistration)
+		l.on(r, perUser("passkey-register-finish", 5, time.Minute)).Post("/register/finish", h.passkey.FinishRegistration)
 
 		r.Get("/list", h.passkey.List)
 		r.Patch("/{id}/name", h.passkey.Rename)

--- a/pkg/middleware/ratelimit.go
+++ b/pkg/middleware/ratelimit.go
@@ -103,6 +103,16 @@ func (rl *RateLimiter) Stop() {
 
 // RateLimitConfig holds rate limit configuration
 type RateLimitConfig struct {
+	// Bucket names the budget. It is part of the key, so two routes only share a
+	// counter when they are deliberately given the same name.
+	//
+	// Without it the key was whatever KeyFunc returned and nothing else, which for
+	// an IP-keyed rule meant *one* counter per address for every such route in the
+	// application. Each request compared that shared total against its own limit, so
+	// opening a calendar page — a public read plus three availability reads — spent
+	// four of the five a participant's email address was allowed per quarter hour,
+	// and the second attempt to add one was refused.
+	Bucket   string
 	Requests int                          // Number of requests allowed
 	Window   time.Duration                // Time window
 	KeyFunc  func(r *http.Request) string // Function to extract rate limit key
@@ -124,7 +134,11 @@ func (rl *RateLimiter) Limit(cfg RateLimitConfig) func(http.Handler) http.Handle
 			// request path that in this API carries a calendar token and a
 			// participant UUID. None of it may be written to Redis or held in
 			// the in-memory map, so only its digest ever reaches a backend.
-			allowed, remaining, resetAt, backend, err := rl.check(r.Context(), hashRateLimitKey(key), cfg.Requests, cfg.Window)
+			//
+			// The bucket name goes in before the digest rather than beside it, so
+			// two budgets cannot collide by sharing a key prefix.
+			allowed, remaining, resetAt, backend, err := rl.check(
+				r.Context(), hashRateLimitKey(cfg.Bucket+"|"+key), cfg.Requests, cfg.Window)
 			if err != nil {
 				// Should not happen: memory backend never errors. Allow the
 				// request rather than block on an unexpected internal error.


### PR DESCRIPTION
Reported from production: the **second** attempt to add a participant's email address returns 429.

## What was happening

The bucket key was whatever the key function returned and nothing else — [`ratelimit.go:127`](pkg/middleware/ratelimit.go#L127) hashed `cfg.KeyFunc(r)` with no route and no rule in it. For an IP-keyed rule that is the client address, so **all eight `perIP` routes counted into one bucket per address**, and each request compared that shared total against its own limit.

The reported logs match request for request:

| # | Route | Running total | Limit applied |
|---|---|---|---|
| 1 | `GET /calendars/public/{token}` | 1 | 60 ✅ |
| 2-4 | `GET /availabilities/…` ×3 | 4 | 400 ✅ |
| 5 | **`POST …/participants/{pid}/email`** | 5 | 5 ✅ *(last unit)* |
| 6 | `GET /calendars/public/{token}` | 6 | 60 ✅ |
| 7 | **`POST …/participants/{pid}/email`** | 7 | 5 ❌ **429** |

Opening the calendar page costs four. The first add passed on exactly the last unit of its budget; a reload spent a sixth; the second add was refused having done nothing wrong. On a 15-minute window, one page load was enough to block the endpoint.

`perPathIP` never had the problem — its key is `path + IP`, so each path has its own budget. `perIP` was the one missing scope.

## The fix

Rules carry a name, and the name goes into the key ahead of the digest. Two routes share a counter only when deliberately given the same name. The 26 registrations are named after what they protect (`participant-email-add`, `auth-forgot-password`, `ics-feed`, …).

The route pattern would have been the obvious namespace and does not work: chi only fills it in *during* routing, and the limiter runs before the handler — which is why `Logger` reads it from a deferred call. An explicit name is also more honest, since it makes "these two routes share a budget" a decision someone wrote down.

**The participant email budget goes from 5 to 10** per quarter hour. A household or an office is one public address, and several participants entering their own address in turn is ordinary use — and five was never really five.

## Why nothing caught this

I wrote the regression test, watched it pass with the bug deliberately reintroduced, and had to work out why.

The in-memory backend builds its `rate.Limiter` **once per key**, from the limit and window of whichever request created the entry ([`ratelimit.go:280`](pkg/middleware/ratelimit.go#L280)). Later requests with different parameters reuse it and ignore their own. So a test with a busy 50/min route and a scarce 2/min route passes even when they share a bucket: the busy request creates the limiter, and the scarce route inherits a burst of 50.

Redis does not behave that way — it prunes by the caller's window and compares against the caller's limit — which is why this only ever showed up on an instance with Redis enabled, and why the existing test suite was blind to it.

The test now gives both rules **identical** limits, so the name is the only thing that can separate them. Verified in both directions: it fails with the bucket name removed (`request 0 to /b = 429, want 200`) and passes with it.

That backend quirk is now unreachable — a named bucket has exactly one rule by construction — so it is documented in the test rather than fixed here.

## Verified

`make test` and the `pkg` suite clean, both build variants, format-check.