### PR TITLE
fix(notify): count recurrences when deciding who to notify

### DIFF
--- a/internal/availability/models/availability.go
+++ b/internal/availability/models/availability.go
@@ -24,6 +24,18 @@ type Availability struct {
 	RecurrenceID  *uuid.UUID `json:"recurrence_id,omitempty"`
 }
 
+// AvailableParticipant is one participant who counts as available on a given date,
+// whether they said so directly or a recurrence says it for them.
+//
+// The distinction matters nowhere it is used, which is the point: a recurrence is how
+// someone answers "every Friday" once instead of fifty times, not a lesser kind of
+// answer. Reading it any other way is what kept recurrence-only participants out of
+// their own threshold notifications.
+type AvailableParticipant struct {
+	ID   uuid.UUID
+	Name string
+}
+
 // CreateAvailabilityRequest represents a request to create availability
 type CreateAvailabilityRequest struct {
 	Date      string  `json:"date" validate:"required"`                  // Format: "2006-01-02"

--- a/internal/availability/repository/availability_repository.go
+++ b/internal/availability/repository/availability_repository.go
@@ -343,50 +343,89 @@ func (r *AvailabilityRepository) Delete(ctx context.Context, participantID uuid.
 }
 
 // GetParticipantCountForDate counts unique participants with availability for a specific date
+// GetAvailableParticipantsForDate returns everyone who counts as available on a date,
+// by name, whether they said so directly or a recurrence says it for them.
+//
+// This is the single answer to "who is available on this date". It exists because there
+// were several: the threshold count expanded recurrences in SQL, the notification list
+// read the availabilities table raw, and they disagreed. A participant available only
+// through a recurrence was counted towards the threshold, left out of the participant
+// list in the email, and — worse, and silently — dropped from the recipients of the
+// notification about the very date they had made themselves available for.
+//
+// Two conditions that used to differ between the two queries are settled here. The
+// availabilities half no longer filters on source = 'manual': nothing writes any other
+// value, so the filter selected nothing today while quietly discarding rows written by
+// an older version. And the recurrence half no longer tests start_date IS NULL, because
+// the column is NOT NULL — that branch could never be taken.
+func (r *AvailabilityRepository) GetAvailableParticipantsForDate(
+	ctx context.Context,
+	calendarID uuid.UUID,
+	date time.Time,
+) ([]models.AvailableParticipant, error) {
+	// Written as two EXISTS against participants rather than a UNION of ids followed by
+	// a name lookup: one participant matching both halves is one row either way, and the
+	// name comes back with it.
+	query := `
+		SELECT p.id, p.name
+		FROM participants p
+		WHERE p.calendar_id = $1
+		  AND (
+			EXISTS (
+				SELECT 1 FROM availabilities a
+				WHERE a.participant_id = p.id AND a.date = $2::DATE
+			)
+			OR EXISTS (
+				SELECT 1 FROM recurrences r
+				WHERE r.participant_id = p.id
+				  AND EXTRACT(DOW FROM $2::DATE)::int = r.day_of_week
+				  AND $2::DATE >= r.start_date
+				  AND (r.end_date IS NULL OR $2::DATE <= r.end_date)
+				  AND NOT EXISTS (
+					SELECT 1 FROM recurrence_exceptions re
+					WHERE re.recurrence_id = r.id
+					  AND re.excluded_date = $2::DATE
+				  )
+			)
+		  )
+		ORDER BY p.name ASC`
+
+	rows, err := r.pool.Query(ctx, query, calendarID, date)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get available participants for date: %w", err)
+	}
+	defer rows.Close()
+
+	var participants []models.AvailableParticipant
+	for rows.Next() {
+		var participant models.AvailableParticipant
+		if err := rows.Scan(&participant.ID, &participant.Name); err != nil {
+			return nil, fmt.Errorf("failed to scan available participant: %w", err)
+		}
+		participants = append(participants, participant)
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("error iterating available participants: %w", err)
+	}
+
+	return participants, nil
+}
+
+// GetParticipantCountForDate returns how many participants are available on a date.
+//
+// Derived from the list rather than counted by a query of its own, so the number in
+// "3/3 participants available" and the names printed underneath it cannot disagree.
+// They used to.
 func (r *AvailabilityRepository) GetParticipantCountForDate(
 	ctx context.Context,
 	calendarID uuid.UUID,
 	date time.Time,
 ) (int, error) {
-	// Query counts distinct participants who have availability on this date
-	// This includes both manual availabilities and recurrence-generated ones
-	query := `
-		WITH calendar_participants AS (
-			SELECT id as participant_id
-			FROM participants
-			WHERE calendar_id = $1
-		),
-		date_availabilities AS (
-			-- Manual availabilities for this date
-			SELECT DISTINCT a.participant_id
-			FROM availabilities a
-			JOIN calendar_participants cp ON a.participant_id = cp.participant_id
-			WHERE a.date = $2
-			  AND a.source = 'manual'
-
-			UNION
-
-			-- Recurrence-generated availabilities for this date
-			SELECT DISTINCT r.participant_id
-			FROM recurrences r
-			JOIN calendar_participants cp ON r.participant_id = cp.participant_id
-			WHERE EXTRACT(DOW FROM $2::DATE) = r.day_of_week
-			  AND (r.start_date IS NULL OR $2::DATE >= r.start_date)
-			  AND (r.end_date IS NULL OR $2::DATE <= r.end_date)
-			  -- Exclude if there's an exception for this date
-			  AND NOT EXISTS (
-				SELECT 1 FROM recurrence_exceptions re
-				WHERE re.recurrence_id = r.id
-				  AND re.excluded_date = $2::DATE
-			  )
-		)
-		SELECT COUNT(*) FROM date_availabilities`
-
-	var count int
-	err := r.pool.QueryRow(ctx, query, calendarID, date).Scan(&count)
+	participants, err := r.GetAvailableParticipantsForDate(ctx, calendarID, date)
 	if err != nil {
-		return 0, fmt.Errorf("failed to get participant count for date: %w", err)
+		return 0, err
 	}
 
-	return count, nil
+	return len(participants), nil
 }

--- a/internal/availability/repository/availability_repository_db_test.go
+++ b/internal/availability/repository/availability_repository_db_test.go
@@ -366,6 +366,125 @@ func TestGetByDateIsScopedToTheCalendar(t *testing.T) {
 	}
 }
 
+// TestAvailableParticipantsIncludeRecurrences is the defect this method exists for.
+// Recurrences are expanded when read and never stored, so asking the availabilities
+// table who is available answers "who has a row" — and a participant available every
+// Friday has none. The threshold count expanded them and saw three of three; the
+// notification read the table and saw two. The participant was counted towards the
+// event, left out of the list in the email, and never told about it.
+func TestAvailableParticipantsIncludeRecurrences(t *testing.T) {
+	pool := dbtest.Pool(t)
+	repo := repository.NewAvailabilityRepository(pool)
+	recurrences := repository.NewRecurrenceRepository(pool)
+	ctx := dbtest.Context(t)
+
+	f := seed(t, pool)
+
+	// day(0) is 2027-03-01, a Monday.
+	monday := day(0)
+	if got := monday.Weekday(); got != time.Monday {
+		t.Fatalf("the fixture date is a %s; this test assumes Monday", got)
+	}
+
+	// One participant answers directly, the other stands on a weekly recurrence.
+	if err := repo.Create(ctx, availability(f.participant.ID, monday, nil, nil)); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	weekly := recurrence(f.other.ID, int(time.Monday), nil, nil)
+	if err := recurrences.CreateRecurrence(ctx, weekly); err != nil {
+		t.Fatalf("CreateRecurrence: %v", err)
+	}
+
+	available, err := repo.GetAvailableParticipantsForDate(ctx, f.calendar.ID, monday)
+	if err != nil {
+		t.Fatalf("GetAvailableParticipantsForDate: %v", err)
+	}
+
+	got := map[uuid.UUID]string{}
+	for _, p := range available {
+		got[p.ID] = p.Name
+	}
+	if len(got) != 2 {
+		t.Fatalf("got %d available participants, want 2: %v", len(got), got)
+	}
+	if _, ok := got[f.other.ID]; !ok {
+		t.Error("the participant available through a recurrence is missing")
+	}
+	// The name is what the email prints, so an id alone would not have caught the
+	// half of this defect that was visible.
+	if got[f.other.ID] == "" {
+		t.Error("the recurrence-only participant came back without a name")
+	}
+
+	// The count is derived from this list, so the two cannot disagree — which is the
+	// property that failed in production.
+	count, err := repo.GetParticipantCountForDate(ctx, f.calendar.ID, monday)
+	if err != nil {
+		t.Fatalf("GetParticipantCountForDate: %v", err)
+	}
+	if count != len(available) {
+		t.Errorf("count = %d but the list holds %d: they have diverged again", count, len(available))
+	}
+}
+
+// TestAvailableParticipantsHonourRecurrenceBounds covers the three ways a recurrence
+// does not apply to a date it otherwise matches.
+func TestAvailableParticipantsHonourRecurrenceBounds(t *testing.T) {
+	pool := dbtest.Pool(t)
+	repo := repository.NewAvailabilityRepository(pool)
+	recurrences := repository.NewRecurrenceRepository(pool)
+	ctx := dbtest.Context(t)
+
+	f := seed(t, pool)
+	monday := day(0)
+
+	weekly := recurrence(f.other.ID, int(time.Monday), nil, nil)
+	if err := recurrences.CreateRecurrence(ctx, weekly); err != nil {
+		t.Fatalf("CreateRecurrence: %v", err)
+	}
+
+	available := func(t *testing.T, date time.Time) bool {
+		t.Helper()
+
+		people, err := repo.GetAvailableParticipantsForDate(ctx, f.calendar.ID, date)
+		if err != nil {
+			t.Fatalf("GetAvailableParticipantsForDate: %v", err)
+		}
+		for _, p := range people {
+			if p.ID == f.other.ID {
+				return true
+			}
+		}
+
+		return false
+	}
+
+	if !available(t, monday) {
+		t.Fatal("the recurrence does not apply on its own weekday")
+	}
+	// A Tuesday: the same week, the wrong day.
+	if available(t, day(1)) {
+		t.Error("the recurrence applied on a day it does not fall on")
+	}
+	// Before the recurrence starts. StartDate is 2027-03-01, so day(-7) precedes it.
+	if available(t, day(-7)) {
+		t.Error("the recurrence applied before its start date")
+	}
+
+	// An exception on the matching Monday removes it for that date only.
+	exception := &models.RecurrenceException{RecurrenceID: weekly.ID, ExcludedDate: "2027-03-08"}
+	exception.ID = uuid.New()
+	if err := recurrences.CreateException(ctx, exception); err != nil {
+		t.Fatalf("CreateException: %v", err)
+	}
+	if available(t, day(7)) {
+		t.Error("an excluded date still counted the participant as available")
+	}
+	if !available(t, monday) {
+		t.Error("the exception removed a date it was not for")
+	}
+}
+
 func TestGetParticipantCountForDate(t *testing.T) {
 	pool := dbtest.Pool(t)
 	repo := repository.NewAvailabilityRepository(pool)

--- a/internal/notify/service/notify_service.go
+++ b/internal/notify/service/notify_service.go
@@ -48,8 +48,16 @@ type (
 
 	// AvailabilityStore says who declared themselves available on the date that
 	// moved, which is who gets told about it.
+	//
+	// It asks for the participants rather than the availability rows on purpose. This
+	// used to read the rows and take their participant ids, which silently meant "the
+	// people with a row in the availabilities table" — leaving out everyone whose
+	// availability comes from a recurrence, since those are expanded when read and
+	// never stored.
 	AvailabilityStore interface {
-		GetByDate(ctx context.Context, calendarID uuid.UUID, date time.Time) ([]*availabilityModels.Availability, error)
+		GetAvailableParticipantsForDate(
+			ctx context.Context, calendarID uuid.UUID, date time.Time,
+		) ([]availabilityModels.AvailableParticipant, error)
 	}
 
 	// UserStore resolves the calendar owner, the one recipient who is an account.
@@ -396,37 +404,29 @@ func (s *NotifyService) sendDeduplicatedEmailNotifications(
 		}
 	}
 
-	// Get availabilities for the specific date to find who has availability
-	// This will be used both for participant notification filtering and for building the participant list
-	availabilities, err := s.availabilityRepo.GetByDate(ctx, calendar.ID, transition.Date)
+	// Who is available on this date — the same question, and now the same answer, as
+	// the count that decided the threshold was reached. It settles two things at once:
+	// which participants get told, and which names the email lists.
+	//
+	// Recurrences are expanded when read rather than stored, so asking the
+	// availabilities table directly answered "who has a row", not "who is available".
+	// A participant available every Friday was counted towards the threshold, missing
+	// from the list in the email, and — silently — absent from the recipients of the
+	// notification about their own Friday.
+	availableParticipants, err := s.availabilityRepo.GetAvailableParticipantsForDate(ctx, calendar.ID, transition.Date)
 	if err != nil {
-		s.logger.Error("Failed to get availabilities for date", "calendar_id", calendar.ID, "date", transition.Date, "error", err)
-		availabilities = []*availabilityModels.Availability{} // Empty list on error
+		s.logger.Error("Failed to get available participants for date", "calendar_id", calendar.ID, "date", transition.Date, "error", err)
+		availableParticipants = nil // Empty list on error
 	}
 
-	// Build a map of participant IDs who have availability on this date
-	participantIDsWithAvailability := make(map[uuid.UUID]bool)
-	for _, avail := range availabilities {
-		participantIDsWithAvailability[avail.ParticipantID] = true
+	participantIDsWithAvailability := make(map[uuid.UUID]bool, len(availableParticipants))
+	participantNames := make([]string, 0, len(availableParticipants))
+	for _, p := range availableParticipants {
+		participantIDsWithAvailability[p.ID] = true
+		participantNames = append(participantNames, p.Name)
 	}
 
 	s.logger.Debug("Participants with availability on date", "count", len(participantIDsWithAvailability))
-
-	// Build list of participant names for display in email
-	participantNames := make([]string, 0, len(participantIDsWithAvailability))
-	if len(participantIDsWithAvailability) > 0 {
-		// Get all participants to build the name list
-		allParticipants, err := s.participantRepo.GetByCalendarID(ctx, calendar.ID)
-		if err != nil {
-			s.logger.Error("Failed to get all participants for name list", "calendar_id", calendar.ID, "error", err)
-		} else {
-			for _, p := range allParticipants {
-				if participantIDsWithAvailability[p.ID] {
-					participantNames = append(participantNames, p.Name)
-				}
-			}
-		}
-	}
 
 	// The names themselves go into the email body and stop there. A participant
 	// is often someone who never signed up for anything and gave only a first

--- a/internal/notify/service/notify_service_send_test.go
+++ b/internal/notify/service/notify_service_send_test.go
@@ -56,12 +56,14 @@ func (f *fakeParticipantStore) GetVerifiedParticipantsByCalendar(_ context.Conte
 }
 
 type fakeAvailabilityStore struct {
-	availabilities []*availabilityModels.Availability
-	err            error
+	available []availabilityModels.AvailableParticipant
+	err       error
 }
 
-func (f *fakeAvailabilityStore) GetByDate(_ context.Context, _ uuid.UUID, _ time.Time) ([]*availabilityModels.Availability, error) {
-	return f.availabilities, f.err
+func (f *fakeAvailabilityStore) GetAvailableParticipantsForDate(
+	_ context.Context, _ uuid.UUID, _ time.Time,
+) ([]availabilityModels.AvailableParticipant, error) {
+	return f.available, f.err
 }
 
 type fakeUserStore struct {
@@ -282,8 +284,13 @@ func newNotifyFixture(t *testing.T, config models.NotifyConfig) *notifyFixture {
 	}
 	ownerParticipant.ID = uuid.New()
 
-	available := &availabilityModels.Availability{ParticipantID: participant.ID, Date: date}
-	ownerAvailable := &availabilityModels.Availability{ParticipantID: ownerParticipant.ID, Date: date}
+	// The store answers with participants now, not rows: whether an availability was
+	// typed in or comes from a recurrence is the repository's business, and the
+	// distinction had no place in this service.
+	available := []availabilityModels.AvailableParticipant{
+		{ID: participant.ID, Name: participant.Name},
+		{ID: ownerParticipant.ID, Name: ownerParticipant.Name},
+	}
 
 	return &notifyFixture{
 		calendar:    calendar,
@@ -294,7 +301,7 @@ func newNotifyFixture(t *testing.T, config models.NotifyConfig) *notifyFixture {
 			all:      []calendarModels.Participant{participant, ownerParticipant},
 			verified: []calendarModels.Participant{participant, ownerParticipant},
 		},
-		slots:    &fakeAvailabilityStore{availabilities: []*availabilityModels.Availability{available, ownerAvailable}},
+		slots:    &fakeAvailabilityStore{available: available},
 		users:    &fakeUserStore{user: owner},
 		log:      &fakeNotificationLog{sentRecently: map[string]bool{}},
 		mailer:   &fakeMailer{configured: true},
@@ -443,10 +450,13 @@ func TestCheckThresholdAndNotifyDeduplicatesRecipients(t *testing.T) {
 // TestCheckThresholdAndNotifyEmailRecipientRules covers who is left out.
 func TestCheckThresholdAndNotifyEmailRecipientRules(t *testing.T) {
 	tests := []struct {
-		name       string
-		config     models.NotifyConfig
-		arrange    func(*notifyFixture)
-		wantTo     []string
+		name    string
+		config  models.NotifyConfig
+		arrange func(*notifyFixture)
+		wantTo  []string
+		// wantBody is checked against every message sent, for the cases where who is
+		// listed in the mail matters as much as who receives it.
+		wantBody   []string
 		wantNoMail bool
 	}{
 		{
@@ -479,17 +489,39 @@ func TestCheckThresholdAndNotifyEmailRecipientRules(t *testing.T) {
 			arrange: func(f *notifyFixture) {
 				// Only Ada declared herself available, so the owner participant
 				// is not told even though her address is verified.
-				f.slots.availabilities = []*availabilityModels.Availability{
-					{ParticipantID: f.participant.ID, Date: f.date},
+				f.slots.available = []availabilityModels.AvailableParticipant{
+					{ID: f.participant.ID, Name: f.participant.Name},
 				}
 			},
 			wantTo: []string{"ada@example.test"},
 		},
 		{
+			// The reported defect. Recurrences are expanded when read and never
+			// stored, so a service asking the availabilities table for rows saw
+			// nobody — while the threshold count, which expands them, saw three of
+			// three. The participant was counted towards the event, left out of the
+			// list in the email, and never told about their own Friday.
+			name: "a participant available only through a recurrence is told, and listed",
+			config: models.NotifyConfig{
+				Enabled:            true,
+				NotifyParticipants: true,
+				Channels:           models.ChannelConfig{Email: models.EmailChannelConfig{Enabled: true}},
+			},
+			arrange: func(f *notifyFixture) {
+				// The store answers with the participant either way; what used to
+				// differ is whether a row existed to answer from.
+				f.slots.available = []availabilityModels.AvailableParticipant{
+					{ID: f.participant.ID, Name: f.participant.Name},
+				}
+			},
+			wantTo:   []string{"ada@example.test"},
+			wantBody: []string{"Ada"},
+		},
+		{
 			name:   "nobody is available on the date",
 			config: emailConfig(),
 			arrange: func(f *notifyFixture) {
-				f.slots.availabilities = nil
+				f.slots.available = nil
 			},
 			wantTo: []string{"owner@example.test"},
 		},
@@ -528,8 +560,8 @@ func TestCheckThresholdAndNotifyEmailRecipientRules(t *testing.T) {
 			config: emailConfig(),
 			arrange: func(f *notifyFixture) {
 				f.users.err = errors.New("no such user")
-				f.slots.availabilities = []*availabilityModels.Availability{
-					{ParticipantID: f.participant.ID, Date: f.date},
+				f.slots.available = []availabilityModels.AvailableParticipant{
+					{ID: f.participant.ID, Name: f.participant.Name},
 				}
 				f.people.verified = []calendarModels.Participant{f.participant}
 			},
@@ -584,6 +616,14 @@ func TestCheckThresholdAndNotifyEmailRecipientRules(t *testing.T) {
 				}
 				if !found {
 					t.Errorf("expected %s among the recipients, got %v", want, got)
+				}
+			}
+
+			for _, want := range tt.wantBody {
+				for _, msg := range f.mailer.messages() {
+					if !strings.Contains(msg.Body, want) {
+						t.Errorf("the mail body is missing %q:\n%s", want, msg.Body)
+					}
 				}
 			}
 		})


### PR DESCRIPTION
Reported from production: a participant available through a recurrence is missing from the participant list in a threshold email, while the count above it reads 3/3.

## Why

Recurrences are **expanded when read and never stored**. So asking the `availabilities` table who is available answers "who has a row" — and a participant available every Friday has none.

| | Query | Recurrences? |
|---|---|---|
| **3/3** | `GetParticipantCountForDate` — UNION of the table and the expanded recurrences | ✅ |
| **The list** | `GetByDate` — `SELECT … FROM availabilities WHERE date = $2` | ❌ |

## The missing name was the least of it

That same set drove three decisions:

1. **The participant never received the notification.** [`notify_service.go:452`](internal/notify/service/notify_service.go#L452) skipped anyone not in it, logging *"no availability on this date"* — which was false. They were counted towards the event and then not told about it.
2. **When everyone available was available that way**, `len()` was zero and participant notifications were skipped **entirely**, while the threshold had just been met.
3. The name was missing from the list — the visible symptom, and the mildest of the three.

## The fix

There were **three** implementations of "who is available on this date": SQL for the count, Go for the day view ([`availability_service.go:611`](internal/availability/service/availability_service.go#L611)), and a raw table read here. The first two agree, which is why the modal and the ICS both look right.

This adds one method that answers it once, and **derives the count from its result** — so the number and the names cannot disagree again. It reads as two `EXISTS` against `participants` rather than a UNION of ids plus a name lookup: one participant matching both halves is one row either way, and the name comes back with it.

### Two divergences settled in passing

- The availabilities half no longer filters `source = 'manual'`. Nothing writes any other value ([`availability_service.go:285`](internal/availability/service/availability_service.go#L285) is the only writer), so the filter excluded nothing today while quietly discarding rows written by an older version.
- The recurrence half no longer tests `start_date IS NULL` — the column is `NOT NULL`, so that branch was dead.

### Deliberately left alone

The day view still expands recurrences in Go. It is correct, and folding it in is a change to a read path this defect never touched. Worth doing, on its own.

## Tests

Three, all verified to fail with the recurrence half removed from the query:

- `TestAvailableParticipantsIncludeRecurrences` — a direct answer and a recurrence-only participant both come back, **with names**, and `count == len(list)`.
- `TestAvailableParticipantsHonourRecurrenceBounds` — wrong weekday, before the start date, and an exception each exclude; the exception removes only its own date.
- A case in the notification recipient table asserting the recurrence-only participant is **both** a recipient and named in the body. `wantBody` is new — the old table only ever checked who received mail, never what it said, which is why the list half of this defect had no coverage either.

`make test`: 39 packages, no failures, DB tests included. Both build variants, format-check clean.