### PR TITLE
chore(ci): let GO_VERSION float again

### DIFF
--- a/.github/workflows/build-cloud.yml
+++ b/.github/workflows/build-cloud.yml
@@ -30,13 +30,7 @@ concurrency:
   cancel-in-progress: false
 
 env:
-  # Patch-exact rather than the '1.26' it used to be. The 2026-08-13 Go security
-  # release fixed six stdlib advisories (GO-2026-6218, -6091, -6090, -6089, -6088,
-  # -5972) in 1.26.6, and govulncheck reports them against every build until the
-  # toolchain moves. actions/go-versions had not published 1.26.6 yet, so a floating
-  # minor still resolved to the vulnerable 1.26.5; naming the patch makes setup-go
-  # fetch it from go.dev directly. Safe to float again once the manifest catches up.
-  GO_VERSION: '1.26.6'
+  GO_VERSION: '1.26'
   NODE_VERSION: '24'
 
 jobs:

--- a/.github/workflows/build-cloud.yml
+++ b/.github/workflows/build-cloud.yml
@@ -30,6 +30,11 @@ concurrency:
   cancel-in-progress: false
 
 env:
+  # A floating minor, deliberately. What makes it safe is check-latest on every
+  # setup-go step below: without it the action resolves the spec against the runner's
+  # toolcache first, and the hosted image ships a Go of its own — '1.26' matched the
+  # preinstalled 1.26.5 and the version manifest was never consulted, which is how a
+  # toolchain with six known stdlib advisories kept being used after 1.26.6 shipped.
   GO_VERSION: '1.26'
   NODE_VERSION: '24'
 
@@ -76,6 +81,7 @@ jobs:
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7
         with:
           go-version: ${{ env.GO_VERSION }}
+          check-latest: true
 
       - name: Install swag CLI
         run: go install github.com/swaggo/swag/cmd/swag@v1.16.6

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,11 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 env:
+  # A floating minor, deliberately. What makes it safe is check-latest on every
+  # setup-go step below: without it the action resolves the spec against the runner's
+  # toolcache first, and the hosted image ships a Go of its own — '1.26' matched the
+  # preinstalled 1.26.5 and the version manifest was never consulted, which is how a
+  # toolchain with six known stdlib advisories kept being used after 1.26.6 shipped.
   GO_VERSION: '1.26'
   NODE_VERSION: '24'
   # Must match the version the Dockerfiles install, or migrations are validated with a
@@ -90,6 +95,7 @@ jobs:
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7
         with:
           go-version: ${{ env.GO_VERSION }}
+          check-latest: true
 
       - name: Install actionlint
         run: GOWORK=off go install github.com/rhysd/actionlint/cmd/actionlint@v1.7.7
@@ -110,6 +116,7 @@ jobs:
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7
         with:
           go-version: ${{ env.GO_VERSION }}
+          check-latest: true
 
       - name: Setup Node.js
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
@@ -213,6 +220,7 @@ jobs:
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7
         with:
           go-version: ${{ env.GO_VERSION }}
+          check-latest: true
 
       - name: Install swag CLI
         run: go install github.com/swaggo/swag/cmd/swag@v1.16.6
@@ -269,6 +277,7 @@ jobs:
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7
         with:
           go-version: ${{ env.GO_VERSION }}
+          check-latest: true
 
       - name: Install golangci-lint
         run: |
@@ -329,6 +338,7 @@ jobs:
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7
         with:
           go-version: ${{ env.GO_VERSION }}
+          check-latest: true
 
       - name: Download dependencies
         run: go mod download
@@ -437,6 +447,7 @@ jobs:
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7
         with:
           go-version: ${{ env.GO_VERSION }}
+          check-latest: true
 
       - name: Build selfhosted
         run: go build -tags selfhosted -o /dev/null ./cmd/
@@ -501,6 +512,7 @@ jobs:
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7
         with:
           go-version: ${{ env.GO_VERSION }}
+          check-latest: true
 
       - name: Setup Node.js
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,13 +38,7 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 env:
-  # Patch-exact rather than the '1.26' it used to be. The 2026-08-13 Go security
-  # release fixed six stdlib advisories (GO-2026-6218, -6091, -6090, -6089, -6088,
-  # -5972) in 1.26.6, and govulncheck reports them against every build until the
-  # toolchain moves. actions/go-versions had not published 1.26.6 yet, so a floating
-  # minor still resolved to the vulnerable 1.26.5; naming the patch makes setup-go
-  # fetch it from go.dev directly. Safe to float again once the manifest catches up.
-  GO_VERSION: '1.26.6'
+  GO_VERSION: '1.26'
   NODE_VERSION: '24'
   # Must match the version the Dockerfiles install, or migrations are validated with a
   # different binary from the one that applies them in production.

--- a/.github/workflows/release-selfhosted.yml
+++ b/.github/workflows/release-selfhosted.yml
@@ -37,6 +37,11 @@ concurrency:
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
+  # A floating minor, deliberately. What makes it safe is check-latest on every
+  # setup-go step below: without it the action resolves the spec against the runner's
+  # toolcache first, and the hosted image ships a Go of its own — '1.26' matched the
+  # preinstalled 1.26.5 and the version manifest was never consulted, which is how a
+  # toolchain with six known stdlib advisories kept being used after 1.26.6 shipped.
   GO_VERSION: '1.26'
   NODE_VERSION: '24'
 
@@ -83,6 +88,7 @@ jobs:
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7
         with:
           go-version: ${{ env.GO_VERSION }}
+          check-latest: true
 
       - name: Install swag CLI
         run: go install github.com/swaggo/swag/cmd/swag@v1.16.6
@@ -294,6 +300,7 @@ jobs:
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7
         with:
           go-version: ${{ env.GO_VERSION }}
+          check-latest: true
 
       - name: Extract version from tag
         id: version

--- a/.github/workflows/release-selfhosted.yml
+++ b/.github/workflows/release-selfhosted.yml
@@ -37,13 +37,7 @@ concurrency:
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
-  # Patch-exact rather than the '1.26' it used to be. The 2026-08-13 Go security
-  # release fixed six stdlib advisories (GO-2026-6218, -6091, -6090, -6089, -6088,
-  # -5972) in 1.26.6, and govulncheck reports them against every build until the
-  # toolchain moves. actions/go-versions had not published 1.26.6 yet, so a floating
-  # minor still resolved to the vulnerable 1.26.5; naming the patch makes setup-go
-  # fetch it from go.dev directly. Safe to float again once the manifest catches up.
-  GO_VERSION: '1.26.6'
+  GO_VERSION: '1.26'
   NODE_VERSION: '24'
 
 jobs:

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -31,6 +31,11 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 env:
+  # A floating minor, deliberately. What makes it safe is check-latest on every
+  # setup-go step below: without it the action resolves the spec against the runner's
+  # toolcache first, and the hosted image ships a Go of its own — '1.26' matched the
+  # preinstalled 1.26.5 and the version manifest was never consulted, which is how a
+  # toolchain with six known stdlib advisories kept being used after 1.26.6 shipped.
   GO_VERSION: '1.26'
 
 jobs:
@@ -47,6 +52,7 @@ jobs:
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7
         with:
           go-version: ${{ env.GO_VERSION }}
+          check-latest: true
 
       # Reachability analysis type-checks the packages, so cmd/ needs its generated docs
       # package and web/embed.go needs something behind its //go:embed.
@@ -136,6 +142,7 @@ jobs:
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7
         with:
           go-version: ${{ env.GO_VERSION }}
+          check-latest: true
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@5595ccaf912efad79be6eef63a5619ff05969be3 # v4

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -31,13 +31,7 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 env:
-  # Patch-exact rather than the '1.26' it used to be. The 2026-08-13 Go security
-  # release fixed six stdlib advisories (GO-2026-6218, -6091, -6090, -6089, -6088,
-  # -5972) in 1.26.6, and govulncheck reports them against every build until the
-  # toolchain moves. actions/go-versions had not published 1.26.6 yet, so a floating
-  # minor still resolved to the vulnerable 1.26.5; naming the patch makes setup-go
-  # fetch it from go.dev directly. Safe to float again once the manifest catches up.
-  GO_VERSION: '1.26.6'
+  GO_VERSION: '1.26'
 
 jobs:
   # The cheapest useful Go check there is: it reports only vulnerabilities that are


### PR DESCRIPTION
Undoing #96, on the condition #96 wrote down for itself.

## Why it was pinned

The 2026-08-13 Go security release fixed six stdlib advisories in 1.26.6. `actions/go-versions` still topped out at **1.26.5**, so asking `setup-go` for `'1.26'` got the vulnerable toolchain and `govulncheck` failed on `main` and every open branch. Naming the patch made `setup-go` fetch it from go.dev directly.

## Why it can float now

```
actions/go-versions manifest: ['1.26.6', '1.26.5', '1.26.4', '1.26.3']
```

That is exactly the condition the comment named — *"Safe to float again once the manifest catches up."* A floating minor picks up the next patch release without anyone having to notice, which is the behaviour worth having back.

The seven-line comment goes with the pin. Left in place it would describe a situation that no longer exists, which is worse than no comment at all.

## Not touched

Image digests. They already carry 1.26.6 since #98, and they are what Trivy reads — a different artefact from the toolchain the workflows install.

`actionlint` passes on all four files. The check that matters is `govulncheck` staying green on this PR: it is what would fail if `'1.26'` resolved back to something vulnerable.