### PR TITLE
fix(api): serve Swagger UI without an inline script

### DIFF
--- a/cmd/router.go
+++ b/cmd/router.go
@@ -8,7 +8,6 @@ import (
 	"net/http"
 
 	"github.com/go-chi/chi/v5"
-	httpSwagger "github.com/swaggo/http-swagger/v2"
 
 	"github.com/whento/pkg/httputil"
 	"github.com/whento/pkg/middleware"
@@ -62,7 +61,9 @@ func newRouter(d *deps, h *handlers, spa http.Handler) chi.Router {
 	registerSEORoutes(r, h)
 
 	// ========== SWAGGER DOCUMENTATION ==========
-	r.Get("/swagger/*", httpSwagger.WrapHandler)
+	// swaggerHandler, not httpSwagger.WrapHandler: the library's index builds the UI from
+	// an inline script the CSP refuses. See cmd/swagger.go.
+	r.Get("/swagger/*", swaggerHandler())
 
 	registerFallbacks(r, spa)
 

--- a/cmd/swagger.go
+++ b/cmd/swagger.go
@@ -1,0 +1,65 @@
+// WhenTo - Collaborative event calendar for self-hosted environments
+// Copyright (C) 2025 WhenTo Contributors
+// SPDX-License-Identifier: BSL-1.1
+
+package main
+
+import (
+	_ "embed"
+	"net/http"
+
+	"github.com/go-chi/chi/v5"
+	httpSwagger "github.com/swaggo/http-swagger/v2"
+)
+
+// The two files this serves in place of what http-swagger would.
+//
+// Kept beside the code that serves them, the way the mail templates sit beside the handlers
+// that render them.
+var (
+	//go:embed swaggerui/index.html
+	swaggerIndex []byte
+
+	//go:embed swaggerui/swagger-initializer.js
+	swaggerInitializer []byte
+)
+
+// swaggerHandler serves the API documentation with no inline script.
+//
+// http-swagger renders an index whose only means of building the interface is an inline
+// <script> calling SwaggerUIBundle. script-src is 'self', so the browser refused it: the
+// bundle loaded, #swagger-ui stayed empty, and /swagger was a blank page in production.
+//
+// Nothing in that library could fix it from the outside. The index is an unexported const
+// parsed inside the handler; its Config carries no nonce and no hash option; and
+// BeforeScript, AfterScript, Plugins and UIConfig all inject into that same inline block,
+// so they make the problem worse. A 'sha256-' allowance was the other candidate and was
+// dropped: the block is a template rendered from config, so the digest breaks on any option
+// change or library bump — a CSP that silently stops matching is worse than one that never
+// did.
+//
+// So the index is ours, modelled on the CSP-clean dist/index.html that swaggo/files already
+// ships and that only the interception above makes unreachable. The initialiser is ours for
+// a duller reason: theirs points at petstore.swagger.io.
+//
+// Everything else — doc.json, the bundles, the stylesheets, the favicons — still comes from
+// the upstream handler untouched.
+func swaggerHandler() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		// The wildcard is the same trailing segment http-swagger switches on, without
+		// re-deriving it from RequestURI. An empty one falls through, so the library keeps
+		// issuing its own redirect to index.html — which lands back here.
+		switch chi.URLParam(r, "*") {
+		case "index.html":
+			w.Header().Set("Content-Type", "text/html; charset=utf-8")
+			_, _ = w.Write(swaggerIndex)
+
+		case "swagger-initializer.js":
+			w.Header().Set("Content-Type", "application/javascript")
+			_, _ = w.Write(swaggerInitializer)
+
+		default:
+			httpSwagger.WrapHandler(w, r)
+		}
+	}
+}

--- a/cmd/swagger_test.go
+++ b/cmd/swagger_test.go
@@ -1,0 +1,106 @@
+// WhenTo - Collaborative event calendar for self-hosted environments
+// Copyright (C) 2025 WhenTo Contributors
+// SPDX-License-Identifier: BSL-1.1
+
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// /swagger was a blank page in production: the library's index builds the interface from an
+// inline <script>, and script-src is 'self'. The tests below are what keeps it from becoming
+// one again — a browser refusing a script is silent server-side, so nothing else would.
+
+// scriptOpenTag finds every <script …> opening tag. A tag without a src attribute carries
+// its code in the document, which is exactly what script-src 'self' refuses.
+var scriptOpenTag = regexp.MustCompile(`(?is)<script(\s[^>]*)?>`)
+
+// htmlComment is stripped before the match. The index explains in a comment what it exists
+// to avoid, and naming the tag there is not the same as carrying one — a browser parses no
+// script out of a comment either.
+var htmlComment = regexp.MustCompile(`(?s)<!--.*?-->`)
+
+// jsBlockComment is stripped for the same reason. Only /* … */ and not // …, which would
+// eat the second half of any https:// in the code the test is actually looking at.
+var jsBlockComment = regexp.MustCompile(`(?s)/\*.*?\*/`)
+
+func TestSwaggerIndexCarriesNoInlineScript(t *testing.T) {
+	r := testRouter(t, false)
+
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/swagger/index.html", nil))
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("GET /swagger/index.html = %d, want 200", rec.Code)
+	}
+
+	body := rec.Body.String()
+	for _, tag := range scriptOpenTag.FindAllString(htmlComment.ReplaceAllString(body, ""), -1) {
+		if !strings.Contains(tag, "src=") {
+			t.Errorf("the index carries an inline script, which script-src 'self' refuses: %s", tag)
+		}
+	}
+	// The three files it must pull instead, all same-origin.
+	for _, want := range []string{
+		`src="./swagger-ui-bundle.js"`,
+		`src="./swagger-ui-standalone-preset.js"`,
+		`src="./swagger-initializer.js"`,
+		`id="swagger-ui"`,
+	} {
+		if !strings.Contains(body, want) {
+			t.Errorf("the index is missing %q:\n%s", want, body)
+		}
+	}
+}
+
+func TestSwaggerInitializerPointsAtThisBinary(t *testing.T) {
+	r := testRouter(t, false)
+
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/swagger/swagger-initializer.js", nil))
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("GET /swagger/swagger-initializer.js = %d, want 200", rec.Code)
+	}
+
+	body := rec.Body.String()
+	code := jsBlockComment.ReplaceAllString(body, "")
+	if !strings.Contains(code, "./doc.json") {
+		t.Errorf("the initialiser does not load this binary's spec:\n%s", body)
+	}
+	// The upstream file is reachable through the same handler and hardcodes the public demo
+	// in its code, not merely in a comment — serving it would render somebody else's API.
+	if strings.Contains(code, "petstore.swagger.io") {
+		t.Errorf("the upstream demo initialiser is being served:\n%s", body)
+	}
+	if got := rec.Header().Get("Content-Type"); !strings.Contains(got, "javascript") {
+		t.Errorf("Content-Type = %q, want a JavaScript type", got)
+	}
+}
+
+// TestSwaggerStillDelegatesTheSpec guards the half that is not ours: only two paths are
+// intercepted, and everything else has to reach the library untouched.
+func TestSwaggerStillDelegatesTheSpec(t *testing.T) {
+	r := testRouter(t, false)
+
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/swagger/doc.json", nil))
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("GET /swagger/doc.json = %d, want 200", rec.Code)
+	}
+
+	var spec map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &spec); err != nil {
+		t.Fatalf("the spec is not JSON: %v", err)
+	}
+	if _, ok := spec["paths"]; !ok {
+		t.Error("the spec carries no paths, so it is not the API description")
+	}
+}

--- a/cmd/swaggerui/index.html
+++ b/cmd/swaggerui/index.html
@@ -1,0 +1,31 @@
+<!doctype html>
+<!--
+  Served in place of the one github.com/swaggo/http-swagger renders.
+
+  That one builds the interface from an inline <script>, which the Content-Security-Policy
+  refuses: script-src is 'self', so the bundle loaded and #swagger-ui stayed empty. The
+  template is an unexported const parsed inside the handler, and its Config offers neither a
+  nonce nor a hash, so there was nothing to configure — only to replace.
+
+  This is the shape github.com/swaggo/files already ships in dist/index.html, which is
+  CSP-clean and unreachable only because the handler intercepts index.html to render its own.
+  Every asset below is a relative file served by that same handler; nothing here is inline.
+-->
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>WhenTo API</title>
+    <link rel="stylesheet" type="text/css" href="./swagger-ui.css" />
+    <link rel="stylesheet" type="text/css" href="./index.css" />
+    <link rel="icon" type="image/png" href="./favicon-32x32.png" sizes="32x32" />
+    <link rel="icon" type="image/png" href="./favicon-16x16.png" sizes="16x16" />
+  </head>
+
+  <body>
+    <div id="swagger-ui"></div>
+    <script src="./swagger-ui-bundle.js" charset="UTF-8"></script>
+    <script src="./swagger-ui-standalone-preset.js" charset="UTF-8"></script>
+    <script src="./swagger-initializer.js" charset="UTF-8"></script>
+  </body>
+</html>

--- a/cmd/swaggerui/swagger-initializer.js
+++ b/cmd/swaggerui/swagger-initializer.js
@@ -1,0 +1,20 @@
+/*
+ * Served in place of the one github.com/swaggo/files ships.
+ *
+ * Theirs exists and is reachable, but points at petstore.swagger.io — it is the upstream
+ * demo initialiser, not a configurable one. This is the same file with the URL pointed at
+ * the spec this binary actually serves, which the handler renders at ./doc.json from the
+ * // @... annotations in cmd/main.go.
+ *
+ * Being a file rather than an inline block is the entire point: script-src 'self' allows it.
+ */
+window.onload = function () {
+  window.ui = SwaggerUIBundle({
+    url: './doc.json',
+    dom_id: '#swagger-ui',
+    deepLinking: true,
+    presets: [SwaggerUIBundle.presets.apis, SwaggerUIStandalonePreset],
+    plugins: [SwaggerUIBundle.plugins.DownloadUrl],
+    layout: 'StandaloneLayout',
+  });
+};


### PR DESCRIPTION
`/swagger` has been a blank page in production. Flagged while doing #103; this is the fix.

## What was happening

The library's index builds the interface from an **inline `<script>`** calling `SwaggerUIBundle`, and `script-src` is `'self'`. The browser refused it: the bundle loaded, `<div id="swagger-ui">` stayed empty.

Server-side nothing looks wrong — 200, correct Content-Type, right number of bytes. A refused script is silent unless somebody opens the console, which is why it went unnoticed.

## Why not configure it

Nothing in `http-swagger` reaches that block from outside:

- the index is an **unexported const**, parsed inside the handler — no `Template` field;
- its `Config` carries **neither a nonce nor a hash** option;
- `BeforeScript`, `AfterScript`, `Plugins` and `UIConfig` all inject **into that same inline block**, so they make the problem worse.

A `'sha256-…'` allowance was the other candidate and was dropped: the block is a Go template rendered from `Config`, so the digest breaks on any option change or library bump. A CSP that silently stops matching is worse than one that never did.

## What this does

`swaggo/files` already ships a `dist/index.html` that is **CSP-clean** — no inline script, no inline style, every asset a relative file. It is unreachable only because the handler intercepts `index.html` to render its own template.

So `cmd/swagger.go` intercepts two paths and delegates the rest:

| Path | Served by |
|---|---|
| `/swagger/index.html` | ours, modelled on the clean `dist/index.html` |
| `/swagger/swagger-initializer.js` | ours, pointed at `./doc.json` |
| `doc.json`, bundles, stylesheets, favicons | `httpSwagger.WrapHandler`, untouched |

The initialiser has to be ours for a duller reason than the index: theirs is reachable through the same handler but hardcodes `https://petstore.swagger.io/v2/swagger.json` — it is the upstream demo, not a configurable file.

An empty trailing segment falls through, so the library keeps issuing its own redirect to `index.html`, which lands back here. The route keeps its `r.Get("/swagger/*", …)` shape, so `routes_test.go`'s route table is unchanged.

## What it does not do

**The global CSP is untouched** and `'unsafe-inline'` stays in `style-src`. That one is not about Swagger: the SPA binds `:style` in nine places (`QuotaUsage.vue:118`, `ParticipantDetailsPopup.vue:14`, `TimeSelect.vue:488`…) and Vue renders those as inline style attributes. `TestSecurityHeaders` needs no change.

## Tests

Three in `cmd/`, all verified to fail with the interception disabled:

- the index carries **no** `<script>` without a `src`, and pulls the three expected files;
- the initialiser loads `./doc.json` and **not** `petstore.swagger.io`;
- `/swagger/doc.json` still returns the parsed spec, i.e. delegation is intact.

Both assertions needed a second pass. My first regex matched `<script src=…></script>` because it accepted any non-space after `>` — including the `<` of the closing tag. And both files explain in a comment what they exist to avoid, naming `<script>` and `petstore.swagger.io` literally, so the tests strip comments before matching: a browser parses no script out of a comment either, and the upstream initialiser hardcodes that host in its **code**, so the check keeps its teeth.

## Still to confirm by eye

Open `/swagger/` in a browser and check the console reports **no** CSP violation. `swagger-ui-bundle.js` contains one `new Function("return this")` — the standard webpack `globalThis` polyfill. If it is reached it would need `'unsafe-eval'`, which we do not want; in practice Swagger UI runs without it, but that is the thing a test cannot tell us.