### PR TITLE
refactor(auth): fold the verification handler into AuthHandler

### DIFF
--- a/cmd/routes_auth.go
+++ b/cmd/routes_auth.go
@@ -42,7 +42,7 @@ func registerAuthRoutes(r chi.Router, d *deps, h *handlers) {
 			r.Get("/magic-link/available", h.magicLink.CheckAvailable)
 
 			// Email verification (public - no auth required)
-			l.on(r, perPathIP("auth-verify-email", 5, 15*time.Minute)).Get("/verify-email/{token}", h.emailVerification.VerifyEmail)
+			l.on(r, perPathIP("auth-verify-email", 5, 15*time.Minute)).Get("/verify-email/{token}", h.auth.VerifyEmail)
 		})
 
 		// Authenticated routes
@@ -54,7 +54,7 @@ func registerAuthRoutes(r chi.Router, d *deps, h *handlers) {
 			r.Patch("/me/password", h.auth.ChangePassword)
 
 			// Email verification (authenticated - requires login)
-			r.Post("/send-verification", h.emailVerification.SendVerificationEmail)
+			r.Post("/send-verification", h.auth.SendVerificationEmail)
 
 			// Admin routes
 			r.Group(func(r chi.Router) {

--- a/cmd/wire.go
+++ b/cmd/wire.go
@@ -85,12 +85,11 @@ type deps struct {
 // other's thirty-odd local variables.
 type handlers struct {
 	// Auth
-	health            *authHandlers.HealthHandler
-	auth              *authHandlers.AuthHandler
-	emailVerification *authHandlers.EmailVerificationHandler
-	passwordReset     *authHandlers.PasswordResetHandler
-	magicLink         *authHandlers.MagicLinkHandler
-	adminMFA          *authHandlers.AdminMFAHandler
+	health        *authHandlers.HealthHandler
+	auth          *authHandlers.AuthHandler
+	passwordReset *authHandlers.PasswordResetHandler
+	magicLink     *authHandlers.MagicLinkHandler
+	adminMFA      *authHandlers.AdminMFAHandler
 
 	// Passkey and MFA
 	passkey *passkeyHandlers.PasskeyHandler
@@ -225,12 +224,11 @@ func buildHandlers(d *deps) (*handlers, error) {
 	)
 
 	return &handlers{
-		health:            authHandlers.NewHealthHandler(d.pool, d.cacheProbe),
-		auth:              authHandler,
-		emailVerification: authHandlers.NewEmailVerificationHandler(authSvc, userRepo, d.mailer, d.cfg, d.log),
-		passwordReset:     authHandlers.NewPasswordResetHandler(passwordResetSvc),
-		magicLink:         authHandlers.NewMagicLinkHandler(magicLinkSvc, d.mailer, d.log),
-		adminMFA:          authHandlers.NewAdminMFAHandler(mfaSvc, d.log),
+		health:        authHandlers.NewHealthHandler(d.pool, d.cacheProbe),
+		auth:          authHandler,
+		passwordReset: authHandlers.NewPasswordResetHandler(passwordResetSvc),
+		magicLink:     authHandlers.NewMagicLinkHandler(magicLinkSvc, d.mailer, d.log),
+		adminMFA:      authHandlers.NewAdminMFAHandler(mfaSvc, d.log),
 
 		passkey: passkeyHandler,
 		mfa:     mfaHandler,

--- a/cmd/wire_test.go
+++ b/cmd/wire_test.go
@@ -62,7 +62,6 @@ func TestBuildHandlers(t *testing.T) {
 		}{
 			{name: "health", got: h.health},
 			{name: "auth", got: h.auth},
-			{name: "emailVerification", got: h.emailVerification},
 			{name: "passwordReset", got: h.passwordReset},
 			{name: "magicLink", got: h.magicLink},
 			{name: "adminMFA", got: h.adminMFA},

--- a/internal/auth/handlers/auth_handler.go
+++ b/internal/auth/handlers/auth_handler.go
@@ -5,14 +5,12 @@
 package handlers
 
 import (
-	"bytes"
 	"context"
 	"crypto/rand"
 	_ "embed"
 	"encoding/hex"
 	"encoding/json"
 	"errors"
-	"fmt"
 	"html/template"
 	"log/slog"
 	"net/http"
@@ -203,8 +201,15 @@ func (h *AuthHandler) Register(w http.ResponseWriter, r *http.Request) {
 			if err := h.userRepo.SetVerificationToken(r.Context(), resp.User.ID, token, expiresAt); err != nil {
 				h.logger.Error("Failed to save verification token", "error", err)
 			} else {
-				// Send verification email (async, don't block registration)
-				go h.sendVerificationEmail(resp.User.Email, resp.User.DisplayName, resp.User.Locale, token)
+				// Send verification email (async, don't block registration).
+				// The closure exists to swallow the error deliberately rather than by
+				// having nowhere to put it: the response has already been decided, and
+				// sendVerificationEmail has logged the failure with a recipient
+				// fingerprint by the time this runs.
+				user := resp.User
+				go func() {
+					_ = h.sendVerificationEmail(user.Email, user.DisplayName, user.Locale, token)
+				}()
 			}
 		}
 	}
@@ -218,62 +223,6 @@ func (h *AuthHandler) Register(w http.ResponseWriter, r *http.Request) {
 	}
 
 	httputil.JSON(w, http.StatusCreated, resp)
-}
-
-// sendVerificationEmail sends the verification email (helper for Register)
-func (h *AuthHandler) sendVerificationEmail(to, displayName, locale, token string) {
-	if !h.emailService.IsConfigured() {
-		h.logger.Warn("Email service not configured, cannot send verification email")
-		return
-	}
-
-	verificationURL := fmt.Sprintf("%s/verify-email/%s", h.cfg.AppURL, token)
-
-	// Get translations for locale (fallback to english)
-	trans, ok := h.verificationTranslations[locale]
-	if !ok {
-		trans = h.verificationTranslations["en"]
-	}
-
-	// Prepare template data
-	expiryDuration := h.cfg.Email.VerificationExpiry.String()
-	data := map[string]any{
-		"Subject":        trans["subject"],
-		"Greeting":       email.ReplaceVar(trans["greeting"], "DisplayName", displayName),
-		"Intro":          trans["intro"],
-		"CTAInstruction": trans["cta_instruction"],
-		"CTAButton":      trans["cta_button"],
-		"OrCopy":         trans["or_copy"],
-		"ExpiryNotice":   email.ReplaceVar(trans["expiry_notice"], "ExpiryDuration", expiryDuration),
-		"SecurityNotice": trans["security_notice"],
-		// The one locale string holding deliberate markup: the signature ends with a
-		// <br> between the sign-off and the team name. Everything else in this map is a
-		// plain string, so html/template escapes it — which is exactly what has to
-		// happen to a display name.
-		"Signature":       template.HTML(trans["signature"]),
-		"VerificationURL": verificationURL,
-	}
-
-	// Execute template
-	var htmlBody bytes.Buffer
-	if err := h.verificationTemplate.Execute(&htmlBody, data); err != nil {
-		h.logger.Error("Failed to execute verification template", "error", err)
-		return
-	}
-
-	// Send email
-	err := h.emailService.Send(email.Email{
-		To:      []string{to},
-		Subject: trans["subject"],
-		Body:    htmlBody.String(),
-		HTML:    true,
-	})
-
-	if err != nil {
-		h.logger.Error("Failed to send verification email", "error", err, "recipient_ref", logger.Fingerprint(to))
-	} else {
-		h.logger.Info("Verification email sent", "recipient_ref", logger.Fingerprint(to), "locale", locale)
-	}
 }
 
 // Login handles user login

--- a/internal/auth/handlers/email_body_test.go
+++ b/internal/auth/handlers/email_body_test.go
@@ -7,6 +7,7 @@ package handlers_test
 import (
 	"io"
 	"log/slog"
+	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
@@ -26,7 +27,7 @@ import (
 // SendVerificationEmail is the seam: it is the one auth path that sends synchronously.
 // Registration and magic links hand the same builders to a detached goroutine.
 
-func verificationRig(t *testing.T, user *models.User) (*handlers.EmailVerificationHandler, *fakeEmailSender) {
+func verificationRig(t *testing.T, user *models.User) (*handlers.AuthHandler, *fakeEmailSender) {
 	t.Helper()
 
 	store := &fakeUserStore{user: user}
@@ -40,7 +41,10 @@ func verificationRig(t *testing.T, user *models.User) (*handlers.EmailVerificati
 	}
 	discard := slog.New(slog.NewTextHandler(io.Discard, nil))
 
-	return handlers.NewEmailVerificationHandler(nil, store, mail, cfg, discard), mail
+	// nil for the service and the two repositories: SendVerificationEmail reaches none
+	// of them. That was true of the handler this replaced too — its authService field
+	// was declared, assigned and never read.
+	return handlers.NewAuthHandler(nil, store, mail, cfg, discard, nil, nil), mail
 }
 
 func resend(t *testing.T, user *models.User) string {
@@ -121,5 +125,29 @@ func TestVerificationMailEscapesTheDisplayName(t *testing.T) {
 	// direction: the reader sees "&lt;script&gt;" instead of "<script>".
 	if strings.Contains(body, "&amp;lt;") {
 		t.Errorf("the display name is double-escaped:\n%s", body)
+	}
+}
+
+// TestVerificationMailSaysSoWhenSMTPIsOff pins the one behaviour this merge changed.
+// The endpoint answered 200 "Verification email sent successfully" on an instance with no
+// SMTP, having sent nothing. The status is right — verifying an address is optional, and
+// failing the request would be the wrong shape — but the message was not.
+func TestVerificationMailSaysSoWhenSMTPIsOff(t *testing.T) {
+	user := &models.User{Email: "ada@example.test", DisplayName: "Ada", Locale: "en"}
+
+	handler, mail := verificationRig(t, user)
+	mail.configured = false
+
+	rec := httptest.NewRecorder()
+	handler.SendVerificationEmail(rec, asUser(post("/api/v1/auth/send-verification", `{}`), user.ID))
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200: an unconfigured instance must not fail the request", rec.Code)
+	}
+	if len(mail.sent) != 0 {
+		t.Fatalf("sent %d mails with SMTP off", len(mail.sent))
+	}
+	if strings.Contains(rec.Body.String(), "sent successfully") {
+		t.Errorf("the response claims a mail was sent: %s", rec.Body.String())
 	}
 }

--- a/internal/auth/handlers/email_verification.go
+++ b/internal/auth/handlers/email_verification.go
@@ -9,10 +9,8 @@ import (
 	"crypto/rand"
 	_ "embed"
 	"encoding/hex"
-	"encoding/json"
 	"fmt"
 	"html/template"
-	"log/slog"
 	"net/http"
 	"time"
 
@@ -21,62 +19,13 @@ import (
 
 	"github.com/whento/pkg/email"
 	"github.com/whento/pkg/httputil"
+	"github.com/whento/pkg/logger"
 
 	// Aliased: the constructor below takes a *slog.Logger named `logger`, which
 	// would otherwise shadow the package.
 	pkglog "github.com/whento/pkg/logger"
 	"github.com/whento/pkg/middleware"
-	"github.com/whento/whento/internal/auth/service"
-	"github.com/whento/whento/internal/config"
 )
-
-//go:embed templates/email_verification.html
-var emailVerificationTemplateEV string
-
-//go:embed templates/locales/email_verification.json
-var emailVerificationTranslationsEV string
-
-// EmailVerificationHandler handles email verification HTTP requests
-type EmailVerificationHandler struct {
-	authService              *service.AuthService
-	userRepo                 UserStore
-	emailService             EmailSender
-	cfg                      *config.Config
-	logger                   *slog.Logger
-	verificationTemplate     *template.Template
-	verificationTranslations map[string]map[string]string
-}
-
-// NewEmailVerificationHandler creates a new email verification handler
-func NewEmailVerificationHandler(
-	authService *service.AuthService,
-	userRepo UserStore,
-	emailService EmailSender,
-	cfg *config.Config,
-	logger *slog.Logger,
-) *EmailVerificationHandler {
-	// Parse email verification template
-	verificationTmpl, err := template.New("email_verification").Parse(emailVerificationTemplateEV)
-	if err != nil {
-		logger.Error("Failed to parse email verification template", "error", err)
-	}
-
-	// Load email verification translations
-	var verificationTrans map[string]map[string]string
-	if err := json.Unmarshal([]byte(emailVerificationTranslationsEV), &verificationTrans); err != nil {
-		logger.Error("Failed to load email verification translations", "error", err)
-	}
-
-	return &EmailVerificationHandler{
-		authService:              authService,
-		userRepo:                 userRepo,
-		emailService:             emailService,
-		cfg:                      cfg,
-		logger:                   logger,
-		verificationTemplate:     verificationTmpl,
-		verificationTranslations: verificationTrans,
-	}
-}
 
 // SendVerificationEmail sends a verification email to the authenticated user
 //
@@ -90,7 +39,7 @@ func NewEmailVerificationHandler(
 //	@Failure		404	{object}	httputil.ErrorResponse	"User not found"
 //	@Failure		500	{object}	httputil.ErrorResponse	"Failed to generate or send verification email"
 //	@Router			/api/v1/auth/send-verification [post]
-func (h *EmailVerificationHandler) SendVerificationEmail(w http.ResponseWriter, r *http.Request) {
+func (h *AuthHandler) SendVerificationEmail(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	userIDStr := middleware.GetUserID(ctx)
 	if userIDStr == "" {
@@ -139,8 +88,18 @@ func (h *EmailVerificationHandler) SendVerificationEmail(w http.ResponseWriter, 
 
 	// Send verification email
 	if err := h.sendVerificationEmail(user.Email, user.DisplayName, user.Locale, token); err != nil {
-		h.logger.Error("Failed to send verification email", "error", err)
 		httputil.Error(w, http.StatusInternalServerError, httputil.ErrCodeInternal, "Failed to send verification email")
+		return
+	}
+
+	// An instance with no SMTP configured answers 200 rather than 500 — verifying an
+	// address is optional, and failing the request would be the wrong shape. But it had
+	// been claiming to have sent something, which was untrue.
+	if !h.emailService.IsConfigured() {
+		httputil.JSON(w, http.StatusOK, map[string]string{
+			"message": "Email sending is not configured on this instance",
+		})
+
 		return
 	}
 
@@ -160,7 +119,7 @@ func (h *EmailVerificationHandler) SendVerificationEmail(w http.ResponseWriter, 
 //	@Failure		400		{object}	httputil.ErrorResponse	"Invalid or expired verification token"
 //	@Failure		500		{object}	httputil.ErrorResponse	"Failed to verify email"
 //	@Router			/api/v1/auth/verify-email/{token} [get]
-func (h *EmailVerificationHandler) VerifyEmail(w http.ResponseWriter, r *http.Request) {
+func (h *AuthHandler) VerifyEmail(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	token := chi.URLParam(r, "token")
 
@@ -202,7 +161,7 @@ func (h *EmailVerificationHandler) VerifyEmail(w http.ResponseWriter, r *http.Re
 }
 
 // sendVerificationEmail sends the actual verification email
-func (h *EmailVerificationHandler) sendVerificationEmail(to, displayName, locale, token string) error {
+func (h *AuthHandler) sendVerificationEmail(to, displayName, locale, token string) error {
 	if !h.emailService.IsConfigured() {
 		h.logger.Warn("Email service not configured, skipping verification email")
 		return nil
@@ -249,6 +208,12 @@ func (h *EmailVerificationHandler) sendVerificationEmail(to, displayName, locale
 		Body:    htmlBody.String(),
 		HTML:    true,
 	}); err != nil {
+		// Logged here as well as returned. Registration sends in a goroutine, so this
+		// fingerprint is the only thing that attributes a delivery failure to a
+		// recipient — the caller there has no response to put it in.
+		h.logger.Error("Failed to send verification email",
+			"error", err, "recipient_ref", logger.Fingerprint(to))
+
 		return err
 	}
 

--- a/internal/auth/handlers/email_verification.go
+++ b/internal/auth/handlers/email_verification.go
@@ -20,10 +20,6 @@ import (
 	"github.com/whento/pkg/email"
 	"github.com/whento/pkg/httputil"
 	"github.com/whento/pkg/logger"
-
-	// Aliased: the constructor below takes a *slog.Logger named `logger`, which
-	// would otherwise shadow the package.
-	pkglog "github.com/whento/pkg/logger"
 	"github.com/whento/pkg/middleware"
 )
 
@@ -217,6 +213,6 @@ func (h *AuthHandler) sendVerificationEmail(to, displayName, locale, token strin
 		return err
 	}
 
-	h.logger.Info("Verification email sent", "recipient_ref", pkglog.Fingerprint(to), "locale", locale)
+	h.logger.Info("Verification email sent", "recipient_ref", logger.Fingerprint(to), "locale", locale)
 	return nil
 }


### PR DESCRIPTION
Flagged during #98 as "a PR to itself". It turned out smaller than expected.

## The overlap

`EmailVerificationHandler` was a **strict subset** of `AuthHandler` — the same seven fields, same names, same types, same order — and its constructor was `NewAuthHandler`'s first five parameters. Both `//go:embed`ed `templates/email_verification.html` and its locale file, so the binary carried two copies and parsed each twice at startup. The `EV` suffix on the second pair existed only to dodge the collision inside one package.

**Its `authService` field was dead**: declared, assigned in the constructor, never read. The `nil` that `email_body_test.go` passed was not tolerated by luck — no reachable path could dereference it, and `wire.go` was passing `authSvc` to satisfy a parameter nothing used.

So the merge adds **no** dependency to `AuthHandler` and leaves `NewAuthHandler`'s signature alone. That is why the ~30 auth tests going through `newRig` needed no change at all.

## The two `sendVerificationEmail`

Identical line for line, including a four-line comment. They differed only in error handling — and **each had lost something the other kept**:

| | void version (`AuthHandler`) | error version (`EmailVerificationHandler`) |
|---|---|---|
| reports failure | ✗ — called as a bare `go` | ✓ |
| logs `recipient_ref` on a failed send | ✓ | ✗ — caller logged without it |

The survivor does both. Registration still sends asynchronously, so the fingerprint is still the only thing that attributes a delivery failure to a recipient on that path — the response has already been decided by the time it runs. The closure in `Register` swallows the returned error deliberately rather than by having nowhere to put it, which the comment says.

## One behaviour changes

With no SMTP configured, `POST /auth/send-verification` answered **200 "Verification email sent successfully"** having sent nothing.

The status stays 200 — verifying an address is optional, and failing the request would be the wrong shape for an instance that simply has no mail set up. But the message now says what actually happened. `TestVerificationMailSaysSoWhenSMTPIsOff` pins it.

## Blast radius

`routes_auth.go` (two handler references, keeping the rate limiter on one and the `middleware.Auth` group on the other), `wire.go` (field + construction), `wire_test.go` (its nil-check row), and `email_body_test.go`'s rig retargeted onto `AuthHandler`.

`make test` clean, both build variants, `make swagger` regenerates without a diff to the annotations.