### PR TITLE
fix(availability): expand recurrences once, and count who can actually meet

### DIFF
--- a/internal/availability/handlers/availability_handler_test.go
+++ b/internal/availability/handlers/availability_handler_test.go
@@ -35,6 +35,9 @@ import (
 type stubAvailabilityRepo struct {
 	inRange []*models.Availability
 	onDate  []*models.Availability
+	// What the summary endpoints read: the repository expands recurrences in SQL, so
+	// the service is handed occurrences rather than table rows.
+	occurrences []models.Occurrence
 }
 
 var _ service.AvailabilityRepository = (*stubAvailabilityRepo)(nil)
@@ -57,18 +60,20 @@ func (s *stubAvailabilityRepo) GetByParticipantAndDate(
 	return nil, nil
 }
 
-func (s *stubAvailabilityRepo) GetByDate(context.Context, uuid.UUID, time.Time) ([]*models.Availability, error) {
-	return s.onDate, nil
-}
-
-func (s *stubAvailabilityRepo) GetByCalendarDateRange(
-	context.Context, uuid.UUID, time.Time, time.Time,
-) ([]*models.Availability, error) {
-	return s.inRange, nil
-}
-
 func (s *stubAvailabilityRepo) GetParticipantCountForDate(context.Context, uuid.UUID, time.Time) (int, error) {
 	return 0, nil
+}
+
+func (s *stubAvailabilityRepo) GetOccurrencesForDate(
+	context.Context, uuid.UUID, time.Time,
+) ([]models.Occurrence, error) {
+	return s.occurrences, nil
+}
+
+func (s *stubAvailabilityRepo) GetOccurrencesForRange(
+	context.Context, uuid.UUID, time.Time, time.Time,
+) ([]models.Occurrence, error) {
+	return s.occurrences, nil
 }
 
 func (s *stubAvailabilityRepo) Update(context.Context, *models.Availability) error { return nil }
@@ -161,10 +166,32 @@ func (s *stubNotifyService) CheckThresholdAndNotify(context.Context, uuid.UUID, 
 func newHandler(t *testing.T, calendar *repository.Calendar, calendarErr error, availabilities []*models.Availability, participants []*repository.Participant) http.Handler {
 	t.Helper()
 
+	// The tests seed table rows because that is what they are about; the summary
+	// endpoints read occurrences, so convert once here rather than at every call site.
+	occurrences := make([]models.Occurrence, 0, len(availabilities))
+	for _, a := range availabilities {
+		occurrences = append(occurrences, models.Occurrence{
+			Date:          a.Date,
+			ParticipantID: a.ParticipantID,
+			ParticipantName: func() string {
+				for _, p := range participants {
+					if p.ID == a.ParticipantID {
+						return p.Name
+					}
+				}
+
+				return ""
+			}(),
+			StartTime: a.StartTime,
+			EndTime:   a.EndTime,
+			Note:      a.Note,
+		})
+	}
+
 	availabilityService := service.NewAvailabilityService(
 		// The same rows answer both the range lookup and the single-date lookup, so
 		// the two summary endpoints can be driven over identical data.
-		&stubAvailabilityRepo{inRange: availabilities, onDate: availabilities},
+		&stubAvailabilityRepo{inRange: availabilities, onDate: availabilities, occurrences: occurrences},
 		&stubCalendarRepo{calendar: calendar, err: calendarErr},
 		&stubParticipantRepo{participants: participants},
 		&stubRecurrenceRepo{},

--- a/internal/availability/models/availability.go
+++ b/internal/availability/models/availability.go
@@ -24,6 +24,25 @@ type Availability struct {
 	RecurrenceID  *uuid.UUID `json:"recurrence_id,omitempty"`
 }
 
+// Occurrence is one participant being available on one date, whether they said so
+// directly or a recurrence says it for them.
+//
+// This is what the several expansions of "who is available" had each been deriving
+// separately — the day view and the range view in Go, the threshold count in SQL — and
+// disagreeing about. A recurrence occurrence and a manual answer are the same thing to
+// everyone who reads them; which record explains it matters only to the query that
+// produced it, and it applies the one rule they all shared: a manual answer suppresses
+// the recurrence for that participant on that date, times and all.
+type Occurrence struct {
+	Date            time.Time
+	ParticipantID   uuid.UUID
+	ParticipantName string
+	// StartTime and EndTime are "15:04", or nil for an all-day answer.
+	StartTime *string
+	EndTime   *string
+	Note      string
+}
+
 // AvailableParticipant is one participant who counts as available on a given date,
 // whether they said so directly or a recurrence says it for them.
 //
@@ -121,4 +140,128 @@ type PublicDateAvailabilitySummary struct {
 	Date         string                                 `json:"date"`
 	TotalCount   int                                    `json:"total_count"`
 	Participants []PublicParticipantAvailabilitySummary `json:"participants"`
+}
+
+// TimeWindow is one availability's span, "15:04" or nil for all day.
+type TimeWindow struct {
+	Start *string
+	End   *string
+}
+
+// Window is how an occurrence enters the overlap calculation.
+func (o Occurrence) Window() TimeWindow {
+	return TimeWindow{Start: o.StartTime, End: o.EndTime}
+}
+
+// Window is how a summary row enters it.
+func (p ParticipantAvailabilitySummary) Window() TimeWindow {
+	return TimeWindow{Start: p.StartTime, End: p.EndTime}
+}
+
+// MaxSimultaneous returns the largest number of the given windows that are open at the
+// same moment. A nil start or end means all day, so a calendar answered entirely in whole
+// days gives the same number as simply counting the answers.
+//
+// It lives here rather than in the availability service because the notification threshold
+// needs it too, and the dependency runs availability -> notify: the detector cannot reach
+// back into the service without a cycle. Both packages already import this one.
+func MaxSimultaneous(windows []TimeWindow) int {
+	if len(windows) == 0 {
+		return 0
+	}
+
+	// Normalize participant times (treat nil as 00:00-23:59)
+	type normalizedParticipant struct {
+		startMinutes int
+		endMinutes   int
+		valid        bool
+	}
+
+	normalized := make([]normalizedParticipant, len(windows))
+	validCount := 0
+	for i, p := range windows {
+		startStr := "00:00"
+		endStr := "23:59"
+
+		if p.Start != nil && *p.Start != "" {
+			startStr = *p.Start
+		}
+		if p.End != nil && *p.End != "" {
+			endStr = *p.End
+		}
+
+		startTime, err1 := time.Parse("15:04", startStr)
+		endTime, err2 := time.Parse("15:04", endStr)
+
+		if err1 != nil || err2 != nil {
+			// If parsing fails, mark as invalid
+			normalized[i] = normalizedParticipant{valid: false}
+			continue
+		}
+
+		normalized[i] = normalizedParticipant{
+			startMinutes: startTime.Hour()*60 + startTime.Minute(),
+			endMinutes:   endTime.Hour()*60 + endTime.Minute(),
+			valid:        true,
+		}
+		validCount++
+	}
+
+	if validCount == 0 {
+		return 0
+	}
+
+	// Collect all unique time boundaries
+	boundarySet := make(map[int]bool)
+	for _, p := range normalized {
+		if p.valid {
+			boundarySet[p.startMinutes] = true
+			boundarySet[p.endMinutes] = true
+		}
+	}
+
+	if len(boundarySet) == 0 {
+		return 0
+	}
+
+	// Sort boundaries
+	boundaries := make([]int, 0, len(boundarySet))
+	for b := range boundarySet {
+		boundaries = append(boundaries, b)
+	}
+	sortInts := func(arr []int) {
+		for i := 0; i < len(arr); i++ {
+			for j := i + 1; j < len(arr); j++ {
+				if arr[i] > arr[j] {
+					arr[i], arr[j] = arr[j], arr[i]
+				}
+			}
+		}
+	}
+	sortInts(boundaries)
+
+	// Calculate the maximum number of participants for each segment
+	maxCount := 0
+
+	for i := 0; i < len(boundaries)-1; i++ {
+		segStart := boundaries[i]
+		segEnd := boundaries[i+1]
+
+		// Count participants available for this entire segment
+		count := 0
+		for _, p := range normalized {
+			if p.valid {
+				// Participant is available if their range completely covers the segment
+				if p.startMinutes <= segStart && p.endMinutes >= segEnd {
+					count++
+				}
+			}
+		}
+
+		if count > maxCount {
+			maxCount = count
+		}
+	}
+
+	return maxCount
 }

--- a/internal/availability/repository/availability_repository.go
+++ b/internal/availability/repository/availability_repository.go
@@ -342,90 +342,162 @@ func (r *AvailabilityRepository) Delete(ctx context.Context, participantID uuid.
 	return nil
 }
 
-// GetParticipantCountForDate counts unique participants with availability for a specific date
-// GetAvailableParticipantsForDate returns everyone who counts as available on a date,
-// by name, whether they said so directly or a recurrence says it for them.
+// occurrencesQuery expands a calendar's availability over a date range.
 //
-// This is the single answer to "who is available on this date". It exists because there
-// were several: the threshold count expanded recurrences in SQL, the notification list
-// read the availabilities table raw, and they disagreed. A participant available only
-// through a recurrence was counted towards the threshold, left out of the participant
-// list in the email, and — worse, and silently — dropped from the recipients of the
-// notification about the very date they had made themselves available for.
+// The single answer to "who is available, when". It exists because there were several and
+// they disagreed: the threshold count expanded recurrences in SQL, the day and range views
+// expanded them again in Go, and the notification list read the availabilities table raw —
+// so a participant available every Friday was counted towards the threshold, missing from
+// the list in the email, and never told about their own Friday.
 //
-// Two conditions that used to differ between the two queries are settled here. The
-// availabilities half no longer filters on source = 'manual': nothing writes any other
-// value, so the filter selected nothing today while quietly discarding rows written by
-// an older version. And the recurrence half no longer tests start_date IS NULL, because
-// the column is NOT NULL — that branch could never be taken.
+// Recurrences are expanded here rather than stored, which is why reading the table alone
+// was never the same question. $1 is the calendar, $2 and $3 the inclusive bounds.
+//
+// The manual half comes back untouched. The recurrence half drops any date already covered
+// by a manual answer for the same participant — the rule all three implementations already
+// shared, and the one worth stating once: an answer someone typed wins over the pattern
+// they set earlier, times and all, even when the typed one is all-day and the pattern is
+// not.
+//
+// Two conditions that used to differ between the implementations are settled. The
+// availabilities half does not filter on source = 'manual': nothing writes any other value,
+// so it selected nothing today while quietly discarding rows an older version had written.
+// And the recurrence half does not test start_date IS NULL, because the column is NOT NULL.
+const occurrencesQuery = `
+		SELECT a.date, a.participant_id, p.name,
+		       TO_CHAR(a.start_time, 'HH24:MI') AS start_time,
+		       TO_CHAR(a.end_time, 'HH24:MI') AS end_time,
+		       COALESCE(a.note, '') AS note
+		FROM availabilities a
+		JOIN participants p ON p.id = a.participant_id
+		WHERE p.calendar_id = $1
+		  AND a.date BETWEEN $2::DATE AND $3::DATE
+
+		UNION ALL
+
+		SELECT d.date, r.participant_id, p.name,
+		       TO_CHAR(r.start_time, 'HH24:MI') AS start_time,
+		       TO_CHAR(r.end_time, 'HH24:MI') AS end_time,
+		       COALESCE(r.note, '') AS note
+		FROM recurrences r
+		JOIN participants p ON p.id = r.participant_id
+		CROSS JOIN (
+			SELECT generate_series($2::DATE, $3::DATE, '1 day'::INTERVAL)::DATE AS date
+		) d
+		WHERE p.calendar_id = $1
+		  AND EXTRACT(DOW FROM d.date)::int = r.day_of_week
+		  AND d.date >= r.start_date
+		  AND (r.end_date IS NULL OR d.date <= r.end_date)
+		  AND NOT EXISTS (
+			SELECT 1 FROM recurrence_exceptions re
+			WHERE re.recurrence_id = r.id AND re.excluded_date = d.date
+		  )
+		  AND NOT EXISTS (
+			SELECT 1 FROM availabilities a
+			WHERE a.participant_id = r.participant_id AND a.date = d.date
+		  )
+		ORDER BY 1 ASC, 3 ASC`
+
+// GetOccurrencesForRange returns every availability in the range, recurrences expanded.
+func (r *AvailabilityRepository) GetOccurrencesForRange(
+	ctx context.Context,
+	calendarID uuid.UUID,
+	startDate, endDate time.Time,
+) ([]models.Occurrence, error) {
+	rows, err := r.pool.Query(ctx, occurrencesQuery, calendarID, startDate, endDate)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get occurrences: %w", err)
+	}
+	defer rows.Close()
+
+	var occurrences []models.Occurrence
+	for rows.Next() {
+		var occurrence models.Occurrence
+		if err := rows.Scan(
+			&occurrence.Date,
+			&occurrence.ParticipantID,
+			&occurrence.ParticipantName,
+			&occurrence.StartTime,
+			&occurrence.EndTime,
+			&occurrence.Note,
+		); err != nil {
+			return nil, fmt.Errorf("failed to scan occurrence: %w", err)
+		}
+		occurrences = append(occurrences, occurrence)
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("error iterating occurrences: %w", err)
+	}
+
+	return occurrences, nil
+}
+
+// GetOccurrencesForDate is the single-date grain of the same question.
+func (r *AvailabilityRepository) GetOccurrencesForDate(
+	ctx context.Context,
+	calendarID uuid.UUID,
+	date time.Time,
+) ([]models.Occurrence, error) {
+	return r.GetOccurrencesForRange(ctx, calendarID, date, date)
+}
+
+// GetAvailableParticipantsForDate returns who is available on a date, by name.
+//
+// A projection of the occurrences rather than a query of its own, so it cannot answer a
+// different question from the one the day view and the feed are answering. The notify
+// service wants identities and deliberately not times — see the comment where it builds
+// the recipient list.
 func (r *AvailabilityRepository) GetAvailableParticipantsForDate(
 	ctx context.Context,
 	calendarID uuid.UUID,
 	date time.Time,
 ) ([]models.AvailableParticipant, error) {
-	// Written as two EXISTS against participants rather than a UNION of ids followed by
-	// a name lookup: one participant matching both halves is one row either way, and the
-	// name comes back with it.
-	query := `
-		SELECT p.id, p.name
-		FROM participants p
-		WHERE p.calendar_id = $1
-		  AND (
-			EXISTS (
-				SELECT 1 FROM availabilities a
-				WHERE a.participant_id = p.id AND a.date = $2::DATE
-			)
-			OR EXISTS (
-				SELECT 1 FROM recurrences r
-				WHERE r.participant_id = p.id
-				  AND EXTRACT(DOW FROM $2::DATE)::int = r.day_of_week
-				  AND $2::DATE >= r.start_date
-				  AND (r.end_date IS NULL OR $2::DATE <= r.end_date)
-				  AND NOT EXISTS (
-					SELECT 1 FROM recurrence_exceptions re
-					WHERE re.recurrence_id = r.id
-					  AND re.excluded_date = $2::DATE
-				  )
-			)
-		  )
-		ORDER BY p.name ASC`
-
-	rows, err := r.pool.Query(ctx, query, calendarID, date)
+	occurrences, err := r.GetOccurrencesForDate(ctx, calendarID, date)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get available participants for date: %w", err)
+		return nil, err
 	}
-	defer rows.Close()
 
-	var participants []models.AvailableParticipant
-	for rows.Next() {
-		var participant models.AvailableParticipant
-		if err := rows.Scan(&participant.ID, &participant.Name); err != nil {
-			return nil, fmt.Errorf("failed to scan available participant: %w", err)
+	seen := make(map[uuid.UUID]struct{}, len(occurrences))
+	participants := make([]models.AvailableParticipant, 0, len(occurrences))
+	for _, occurrence := range occurrences {
+		if _, ok := seen[occurrence.ParticipantID]; ok {
+			continue
 		}
-		participants = append(participants, participant)
-	}
-
-	if err := rows.Err(); err != nil {
-		return nil, fmt.Errorf("error iterating available participants: %w", err)
+		seen[occurrence.ParticipantID] = struct{}{}
+		participants = append(participants, models.AvailableParticipant{
+			ID:   occurrence.ParticipantID,
+			Name: occurrence.ParticipantName,
+		})
 	}
 
 	return participants, nil
 }
 
-// GetParticipantCountForDate returns how many participants are available on a date.
+// GetParticipantCountForDate returns how many participants are available at once.
 //
-// Derived from the list rather than counted by a query of its own, so the number in
-// "3/3 participants available" and the names printed underneath it cannot disagree.
-// They used to.
+// The number the notification threshold is compared against, and it now means what the
+// interface has always shown: participants whose windows actually overlap, not merely
+// participants who answered for that day. Those were different numbers, so a calendar
+// could send "3/3 available" for three people who were never free at the same moment,
+// while the page for that date showed 1 and the feed emitted no event at all.
+//
+// An all-day answer spans the whole day, so a calendar answered in whole days — the
+// common case — gives exactly the count it always did.
 func (r *AvailabilityRepository) GetParticipantCountForDate(
 	ctx context.Context,
 	calendarID uuid.UUID,
 	date time.Time,
 ) (int, error) {
-	participants, err := r.GetAvailableParticipantsForDate(ctx, calendarID, date)
+	occurrences, err := r.GetOccurrencesForDate(ctx, calendarID, date)
 	if err != nil {
 		return 0, err
 	}
 
-	return len(participants), nil
+	windows := make([]models.TimeWindow, 0, len(occurrences))
+	for _, occurrence := range occurrences {
+		windows = append(windows, occurrence.Window())
+	}
+
+	return models.MaxSimultaneous(windows), nil
 }

--- a/internal/availability/repository/availability_repository_db_test.go
+++ b/internal/availability/repository/availability_repository_db_test.go
@@ -540,3 +540,205 @@ func TestAvailabilitiesGoWithTheirParticipant(t *testing.T) {
 }
 
 func timePtr(t time.Time) *time.Time { return &t }
+
+// The occurrence expansion is the one answer to "who is available, when". These tests
+// carry the semantics that used to live in the availability service's Go loops — a manual
+// answer suppressing a recurrence, exceptions, bounds — because that is where the logic
+// went, not because they were invented here.
+
+func TestOccurrencesExpandRecurrencesAndCarryTimes(t *testing.T) {
+	pool := dbtest.Pool(t)
+	repo := repository.NewAvailabilityRepository(pool)
+	recurrences := repository.NewRecurrenceRepository(pool)
+	ctx := dbtest.Context(t)
+
+	f := seed(t, pool)
+	monday := day(0)
+
+	start, end := ptr("18:00"), ptr("22:00")
+	weekly := recurrence(f.other.ID, int(time.Monday), start, end)
+	if err := recurrences.CreateRecurrence(ctx, weekly); err != nil {
+		t.Fatalf("CreateRecurrence: %v", err)
+	}
+	if err := repo.Create(ctx, availability(f.participant.ID, monday, nil, nil)); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	got, err := repo.GetOccurrencesForDate(ctx, f.calendar.ID, monday)
+	if err != nil {
+		t.Fatalf("GetOccurrencesForDate: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("got %d occurrences, want 2: %+v", len(got), got)
+	}
+
+	byParticipant := map[uuid.UUID]models.Occurrence{}
+	for _, occurrence := range got {
+		byParticipant[occurrence.ParticipantID] = occurrence
+	}
+
+	// The recurrence's own times come through — a summary that lost them would show an
+	// evening slot as an all-day one, and the overlap count would be wrong with it.
+	fromRecurrence, ok := byParticipant[f.other.ID]
+	if !ok {
+		t.Fatal("the recurrence produced no occurrence")
+	}
+	if fromRecurrence.StartTime == nil || *fromRecurrence.StartTime != "18:00" {
+		t.Errorf("start = %v, want 18:00", fromRecurrence.StartTime)
+	}
+	if fromRecurrence.EndTime == nil || *fromRecurrence.EndTime != "22:00" {
+		t.Errorf("end = %v, want 22:00", fromRecurrence.EndTime)
+	}
+	if fromRecurrence.ParticipantName == "" {
+		t.Error("the occurrence carries no participant name")
+	}
+
+	// An all-day answer stays all-day rather than being filled in with a whole-day span.
+	manual, ok := byParticipant[f.participant.ID]
+	if !ok {
+		t.Fatal("the manual answer produced no occurrence")
+	}
+	if manual.StartTime != nil || manual.EndTime != nil {
+		t.Errorf("the all-day answer gained times: %v..%v", manual.StartTime, manual.EndTime)
+	}
+}
+
+// TestAManualAnswerSuppressesTheRecurrence is the precedence rule, and the reason a
+// participant is never counted twice for one date. It held in three separate places
+// before; it holds in one now.
+func TestAManualAnswerSuppressesTheRecurrence(t *testing.T) {
+	pool := dbtest.Pool(t)
+	repo := repository.NewAvailabilityRepository(pool)
+	recurrences := repository.NewRecurrenceRepository(pool)
+	ctx := dbtest.Context(t)
+
+	f := seed(t, pool)
+	monday := day(0)
+
+	weekly := recurrence(f.participant.ID, int(time.Monday), ptr("18:00"), ptr("22:00"))
+	if err := recurrences.CreateRecurrence(ctx, weekly); err != nil {
+		t.Fatalf("CreateRecurrence: %v", err)
+	}
+	// The same participant then answers that date by hand, all day.
+	if err := repo.Create(ctx, availability(f.participant.ID, monday, nil, nil)); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	got, err := repo.GetOccurrencesForDate(ctx, f.calendar.ID, monday)
+	if err != nil {
+		t.Fatalf("GetOccurrencesForDate: %v", err)
+	}
+
+	if len(got) != 1 {
+		t.Fatalf("got %d occurrences for one participant, want 1: %+v", len(got), got)
+	}
+	// Wholesale, not merged: the typed answer wins even though it is the vaguer one.
+	if got[0].StartTime != nil || got[0].EndTime != nil {
+		t.Errorf("the recurrence's times survived the manual answer: %v..%v", got[0].StartTime, got[0].EndTime)
+	}
+}
+
+func TestOccurrencesForRangeCoverEveryDay(t *testing.T) {
+	pool := dbtest.Pool(t)
+	repo := repository.NewAvailabilityRepository(pool)
+	recurrences := repository.NewRecurrenceRepository(pool)
+	ctx := dbtest.Context(t)
+
+	f := seed(t, pool)
+
+	weekly := recurrence(f.other.ID, int(time.Monday), nil, nil)
+	if err := recurrences.CreateRecurrence(ctx, weekly); err != nil {
+		t.Fatalf("CreateRecurrence: %v", err)
+	}
+	// An exception on the second Monday, so the range has to skip exactly one of them.
+	exception := &models.RecurrenceException{RecurrenceID: weekly.ID, ExcludedDate: "2027-03-08"}
+	exception.ID = uuid.New()
+	if err := recurrences.CreateException(ctx, exception); err != nil {
+		t.Fatalf("CreateException: %v", err)
+	}
+
+	// Three weeks: three Mondays, minus the excluded one.
+	got, err := repo.GetOccurrencesForRange(ctx, f.calendar.ID, day(0), day(20))
+	if err != nil {
+		t.Fatalf("GetOccurrencesForRange: %v", err)
+	}
+
+	dates := map[string]bool{}
+	for _, occurrence := range got {
+		dates[occurrence.Date.Format("2006-01-02")] = true
+	}
+	for _, want := range []string{"2027-03-01", "2027-03-15"} {
+		if !dates[want] {
+			t.Errorf("the range is missing the Monday of %s: %v", want, dates)
+		}
+	}
+	if dates["2027-03-08"] {
+		t.Errorf("the excluded Monday is in the range: %v", dates)
+	}
+	// Ordered by date, so the caller never has to sort what SQL already knows.
+	for i := 1; i < len(got); i++ {
+		if got[i].Date.Before(got[i-1].Date) {
+			t.Errorf("occurrence %d is out of order: %v before %v", i, got[i].Date, got[i-1].Date)
+		}
+	}
+}
+
+// TestCountMeasuresOverlapNotAnswers is the behaviour change. Three people answering for
+// the same day at hours that never meet is not three people who can meet.
+func TestCountMeasuresOverlapNotAnswers(t *testing.T) {
+	pool := dbtest.Pool(t)
+	repo := repository.NewAvailabilityRepository(pool)
+	ctx := dbtest.Context(t)
+
+	f := seed(t, pool)
+	monday := day(0)
+
+	if err := repo.Create(ctx, availability(f.participant.ID, monday, ptr("08:00"), ptr("10:00"))); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if err := repo.Create(ctx, availability(f.other.ID, monday, ptr("18:00"), ptr("20:00"))); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	count, err := repo.GetParticipantCountForDate(ctx, f.calendar.ID, monday)
+	if err != nil {
+		t.Fatalf("GetParticipantCountForDate: %v", err)
+	}
+	if count != 1 {
+		t.Errorf("count = %d, want 1: two people free the same day at hours that never meet", count)
+	}
+
+	// Both are still available that day — the list is a different question from the count.
+	available, err := repo.GetAvailableParticipantsForDate(ctx, f.calendar.ID, monday)
+	if err != nil {
+		t.Fatalf("GetAvailableParticipantsForDate: %v", err)
+	}
+	if len(available) != 2 {
+		t.Errorf("got %d available participants, want 2", len(available))
+	}
+}
+
+// TestCountIsUnchangedForWholeDayAnswers bounds the change above: a calendar answered in
+// whole days — the common case — counts exactly as it always did.
+func TestCountIsUnchangedForWholeDayAnswers(t *testing.T) {
+	pool := dbtest.Pool(t)
+	repo := repository.NewAvailabilityRepository(pool)
+	ctx := dbtest.Context(t)
+
+	f := seed(t, pool)
+	monday := day(0)
+
+	for _, id := range []uuid.UUID{f.participant.ID, f.other.ID} {
+		if err := repo.Create(ctx, availability(id, monday, nil, nil)); err != nil {
+			t.Fatalf("Create: %v", err)
+		}
+	}
+
+	count, err := repo.GetParticipantCountForDate(ctx, f.calendar.ID, monday)
+	if err != nil {
+		t.Fatalf("GetParticipantCountForDate: %v", err)
+	}
+	if count != 2 {
+		t.Errorf("count = %d, want 2: all-day answers span the whole day", count)
+	}
+}

--- a/internal/availability/service/availability_service.go
+++ b/internal/availability/service/availability_service.go
@@ -53,8 +53,11 @@ type AvailabilityRepository interface {
 	GetByParticipantID(ctx context.Context, participantID uuid.UUID) ([]*models.Availability, error)
 	GetByParticipantIDWithDateRange(ctx context.Context, participantID uuid.UUID, startDate, endDate *time.Time) ([]*models.Availability, error)
 	GetByParticipantAndDate(ctx context.Context, participantID uuid.UUID, date time.Time) (*models.Availability, error)
-	GetByDate(ctx context.Context, calendarID uuid.UUID, date time.Time) ([]*models.Availability, error)
-	GetByCalendarDateRange(ctx context.Context, calendarID uuid.UUID, startDate, endDate time.Time) ([]*models.Availability, error)
+	// The expansion the summary endpoints read: manual answers plus the recurrence
+	// occurrences that survive them, which is a question the availabilities table alone
+	// cannot answer since recurrences are never stored.
+	GetOccurrencesForDate(ctx context.Context, calendarID uuid.UUID, date time.Time) ([]models.Occurrence, error)
+	GetOccurrencesForRange(ctx context.Context, calendarID uuid.UUID, startDate, endDate time.Time) ([]models.Occurrence, error)
 	GetParticipantCountForDate(ctx context.Context, calendarID uuid.UUID, date time.Time) (int, error)
 	Update(ctx context.Context, availability *models.Availability) error
 	Delete(ctx context.Context, participantID uuid.UUID, date time.Time) error
@@ -76,7 +79,6 @@ type ParticipantRepository interface {
 type RecurrenceRepository interface {
 	CreateRecurrence(ctx context.Context, recurrence *models.Recurrence) error
 	GetRecurrencesByParticipant(ctx context.Context, participantID uuid.UUID) ([]models.Recurrence, error)
-	GetRecurrencesByCalendar(ctx context.Context, calendarID uuid.UUID) ([]models.Recurrence, error)
 	GetRecurrenceByID(ctx context.Context, id uuid.UUID) (*models.Recurrence, error)
 	UpdateRecurrence(ctx context.Context, recurrence *models.Recurrence) error
 	DeleteRecurrence(ctx context.Context, id uuid.UUID) error
@@ -607,103 +609,15 @@ func (s *AvailabilityService) GetDateSummary(ctx context.Context, token, dateStr
 		return nil, ErrInvalidDate
 	}
 
-	// Get all availabilities for this date
-	availabilities, err := s.availabilityRepo.GetByDate(ctx, calendarID, date)
+	// One question, one answer. This used to read the availabilities table and then
+	// expand the recurrences again in Go — a third copy of a rule that the threshold
+	// count and the ICS feed each had their own version of, and the copies disagreed.
+	occurrences, err := s.availabilityRepo.GetOccurrencesForDate(ctx, calendarID, date)
 	if err != nil {
 		return nil, err
 	}
 
-	// Get participant info
-	participants, err := s.participantRepo.GetByCalendarID(ctx, calendarID)
-	if err != nil {
-		return nil, err
-	}
-
-	// Create participant map for quick lookup
-	participantMap := make(map[uuid.UUID]*repository.Participant)
-	for _, p := range participants {
-		participantMap[p.ID] = p
-	}
-
-	// Get all recurrences for the calendar
-	recurrences, err := s.recurrenceRepo.GetRecurrencesByCalendar(ctx, calendarID)
-	if err != nil {
-		return nil, err
-	}
-
-	// Get exceptions for all recurrences, in one query rather than one per recurrence
-	exceptionsMap, err := s.exceptionsFor(ctx, recurrences)
-	if err != nil {
-		return nil, err
-	}
-
-	// Create a set of participants that have explicit availabilities
-	explicitParticipants := make(map[uuid.UUID]bool)
-	for _, avail := range availabilities {
-		explicitParticipants[avail.ParticipantID] = true
-	}
-
-	// Build summary - start with explicit availabilities
-	var participantSummaries []models.ParticipantAvailabilitySummary
-	for _, avail := range availabilities {
-		if participant, ok := participantMap[avail.ParticipantID]; ok {
-			participantSummaries = append(participantSummaries, models.ParticipantAvailabilitySummary{
-				ParticipantID:   avail.ParticipantID,
-				ParticipantName: participant.Name,
-				StartTime:       avail.StartTime,
-				EndTime:         avail.EndTime,
-				Note:            avail.Note,
-			})
-		}
-	}
-
-	// Add recurrence-based availabilities
-	dayOfWeek := int(date.Weekday())
-	for _, rec := range recurrences {
-		// Skip if day of week doesn't match
-		if rec.DayOfWeek != dayOfWeek {
-			continue
-		}
-
-		// Compare dates as strings to avoid timezone issues
-		// Skip if date is before recurrence start
-		if dateStr < rec.StartDate {
-			continue
-		}
-
-		// Skip if date is after recurrence end (if end date is set)
-		if rec.EndDate != nil && dateStr > *rec.EndDate {
-			continue
-		}
-
-		// Check if this date is in the exceptions
-		isException := false
-		for _, exc := range exceptionsMap[rec.ID] {
-			if exc.ExcludedDate == dateStr {
-				isException = true
-				break
-			}
-		}
-		if isException {
-			continue
-		}
-
-		// Skip if there's already an explicit availability for this participant
-		if explicitParticipants[rec.ParticipantID] {
-			continue
-		}
-
-		// Add this participant to the summary
-		if participant, ok := participantMap[rec.ParticipantID]; ok {
-			participantSummaries = append(participantSummaries, models.ParticipantAvailabilitySummary{
-				ParticipantID:   rec.ParticipantID,
-				ParticipantName: participant.Name,
-				StartTime:       rec.StartTime,
-				EndTime:         rec.EndTime,
-				Note:            rec.Note,
-			})
-		}
-	}
+	participantSummaries := summariesFrom(occurrences)
 
 	// Apply min_duration_hours filter if configured
 	if calendarInfo.MinDurationHours > 0 && len(participantSummaries) > 0 {
@@ -800,117 +714,17 @@ func (s *AvailabilityService) GetRangeSummary(ctx context.Context, token, startD
 		return nil, fmt.Errorf("%w (%s..%s)", ErrInvalidDateRange, startDateStr, endDateStr)
 	}
 
-	// Get all availabilities in range
-	availabilities, err := s.availabilityRepo.GetByCalendarDateRange(ctx, calendarID, startDate, endDate)
+	occurrences, err := s.availabilityRepo.GetOccurrencesForRange(ctx, calendarID, startDate, endDate)
 	if err != nil {
 		return nil, err
 	}
 
-	// Get participant info
-	participants, err := s.participantRepo.GetByCalendarID(ctx, calendarID)
-	if err != nil {
-		return nil, err
-	}
-
-	// Create participant map
-	participantMap := make(map[uuid.UUID]*repository.Participant)
-	for _, p := range participants {
-		participantMap[p.ID] = p
-	}
-
-	// Get all recurrences for the calendar
-	recurrences, err := s.recurrenceRepo.GetRecurrencesByCalendar(ctx, calendarID)
-	if err != nil {
-		return nil, err
-	}
-
-	// Get exceptions for all recurrences, in one query rather than one per recurrence
-	exceptionsMap, err := s.exceptionsFor(ctx, recurrences)
-	if err != nil {
-		return nil, err
-	}
-
-	// Create a set of dates that have explicit availabilities per participant
-	// This prevents counting the same participant twice (once from recurrence, once from explicit)
-	explicitAvailabilities := make(map[string]map[uuid.UUID]bool)
-	for _, avail := range availabilities {
-		dateKey := formatDate(avail.Date)
-		if explicitAvailabilities[dateKey] == nil {
-			explicitAvailabilities[dateKey] = make(map[uuid.UUID]bool)
-		}
-		explicitAvailabilities[dateKey][avail.ParticipantID] = true
-	}
-
-	// Group by date - start with explicit availabilities
+	// Grouped here rather than expanded here: the repository already decided which
+	// recurrence occurrences survive a manual answer, so this only has to bucket them.
 	dateMap := make(map[string][]models.ParticipantAvailabilitySummary)
-	for _, avail := range availabilities {
-		dateKey := formatDate(avail.Date)
-		if participant, ok := participantMap[avail.ParticipantID]; ok {
-			dateMap[dateKey] = append(dateMap[dateKey], models.ParticipantAvailabilitySummary{
-				ParticipantID:   avail.ParticipantID,
-				ParticipantName: participant.Name,
-				StartTime:       avail.StartTime,
-				EndTime:         avail.EndTime,
-				Note:            avail.Note,
-			})
-		}
-	}
-
-	// Add recurrence-based availabilities for each date in range
-	currentDate := startDate
-	for !currentDate.After(endDate) {
-		dateKey := formatDate(currentDate)
-		dayOfWeek := int(currentDate.Weekday())
-
-		// Check each recurrence
-		for _, rec := range recurrences {
-			// Skip if day of week doesn't match
-			if rec.DayOfWeek != dayOfWeek {
-				continue
-			}
-
-			// Compare dates as strings to avoid timezone issues
-			// Skip if date is before recurrence start
-			if dateKey < rec.StartDate {
-				continue
-			}
-
-			// Skip if date is after recurrence end (if end date is set)
-			if rec.EndDate != nil && dateKey > *rec.EndDate {
-				continue
-			}
-
-			// Check if this date is in the exceptions
-			isException := false
-			for _, exc := range exceptionsMap[rec.ID] {
-				if exc.ExcludedDate == dateKey {
-					isException = true
-					break
-				}
-			}
-			if isException {
-				continue
-			}
-
-			// Skip if there's already an explicit availability for this participant on this date
-			if explicitAvailabilities[dateKey] != nil && explicitAvailabilities[dateKey][rec.ParticipantID] {
-				continue
-			}
-
-			// Add this participant to the date
-			if participant, ok := participantMap[rec.ParticipantID]; ok {
-				dateMap[dateKey] = append(dateMap[dateKey], models.ParticipantAvailabilitySummary{
-					ParticipantID:   rec.ParticipantID,
-					ParticipantName: participant.Name,
-					StartTime:       rec.StartTime,
-					EndTime:         rec.EndTime,
-					Note:            rec.Note,
-				})
-			}
-		}
-
-		// Move to next day
-		currentDate = currentDate.AddDate(0, 0, 1)
+	for _, occurrence := range occurrences {
+		dateKey := formatDate(occurrence.Date)
+		dateMap[dateKey] = append(dateMap[dateKey], summaryFrom(occurrence))
 	}
 
 	// Build response (with min_duration_hours filter if configured)
@@ -1739,104 +1553,12 @@ func compareTime(t1, t2 string) int {
 // that are available at the same time on a given date.
 // This uses the same logic as the ICS feed generation (time slot segmentation).
 func calculateMaxSimultaneousParticipants(participants []models.ParticipantAvailabilitySummary) int {
-	if len(participants) == 0 {
-		return 0
+	windows := make([]models.TimeWindow, 0, len(participants))
+	for _, p := range participants {
+		windows = append(windows, p.Window())
 	}
 
-	// Normalize participant times (treat nil as 00:00-23:59)
-	type normalizedParticipant struct {
-		startMinutes int
-		endMinutes   int
-		valid        bool
-	}
-
-	normalized := make([]normalizedParticipant, len(participants))
-	validCount := 0
-	for i, p := range participants {
-		startStr := "00:00"
-		endStr := "23:59"
-
-		if p.StartTime != nil && *p.StartTime != "" {
-			startStr = *p.StartTime
-		}
-		if p.EndTime != nil && *p.EndTime != "" {
-			endStr = *p.EndTime
-		}
-
-		startTime, err1 := time.Parse("15:04", startStr)
-		endTime, err2 := time.Parse("15:04", endStr)
-
-		if err1 != nil || err2 != nil {
-			// If parsing fails, mark as invalid
-			normalized[i] = normalizedParticipant{valid: false}
-			continue
-		}
-
-		normalized[i] = normalizedParticipant{
-			startMinutes: startTime.Hour()*60 + startTime.Minute(),
-			endMinutes:   endTime.Hour()*60 + endTime.Minute(),
-			valid:        true,
-		}
-		validCount++
-	}
-
-	if validCount == 0 {
-		return 0
-	}
-
-	// Collect all unique time boundaries
-	boundarySet := make(map[int]bool)
-	for _, p := range normalized {
-		if p.valid {
-			boundarySet[p.startMinutes] = true
-			boundarySet[p.endMinutes] = true
-		}
-	}
-
-	if len(boundarySet) == 0 {
-		return 0
-	}
-
-	// Sort boundaries
-	boundaries := make([]int, 0, len(boundarySet))
-	for b := range boundarySet {
-		boundaries = append(boundaries, b)
-	}
-	sortInts := func(arr []int) {
-		for i := 0; i < len(arr); i++ {
-			for j := i + 1; j < len(arr); j++ {
-				if arr[i] > arr[j] {
-					arr[i], arr[j] = arr[j], arr[i]
-				}
-			}
-		}
-	}
-	sortInts(boundaries)
-
-	// Calculate the maximum number of participants for each segment
-	maxCount := 0
-
-	for i := 0; i < len(boundaries)-1; i++ {
-		segStart := boundaries[i]
-		segEnd := boundaries[i+1]
-
-		// Count participants available for this entire segment
-		count := 0
-		for _, p := range normalized {
-			if p.valid {
-				// Participant is available if their range completely covers the segment
-				if p.startMinutes <= segStart && p.endMinutes >= segEnd {
-					count++
-				}
-			}
-		}
-
-		if count > maxCount {
-			maxCount = count
-		}
-	}
-
-	return maxCount
+	return models.MaxSimultaneous(windows)
 }
 
 // recurrencesOverlap checks if two recurrences on the same day of week have overlapping date ranges.
@@ -1982,4 +1704,25 @@ func (s *AvailabilityService) checkRecurrenceOverlap(ctx context.Context, partic
 	}
 
 	return nil
+}
+
+// summaryFrom is the one conversion between what the repository expands and what the
+// summary endpoints return.
+func summaryFrom(occurrence models.Occurrence) models.ParticipantAvailabilitySummary {
+	return models.ParticipantAvailabilitySummary{
+		ParticipantID:   occurrence.ParticipantID,
+		ParticipantName: occurrence.ParticipantName,
+		StartTime:       occurrence.StartTime,
+		EndTime:         occurrence.EndTime,
+		Note:            occurrence.Note,
+	}
+}
+
+func summariesFrom(occurrences []models.Occurrence) []models.ParticipantAvailabilitySummary {
+	summaries := make([]models.ParticipantAvailabilitySummary, 0, len(occurrences))
+	for _, occurrence := range occurrences {
+		summaries = append(summaries, summaryFrom(occurrence))
+	}
+
+	return summaries
 }

--- a/internal/availability/service/date_summary_test.go
+++ b/internal/availability/service/date_summary_test.go
@@ -18,6 +18,12 @@ import (
 	"github.com/whento/whento/internal/availability/repository"
 )
 
+// One test was dropped when the expansion moved into SQL, because the service no longer
+// decides it: TestGetDateSummaryUnknownParticipant asserted that an availability whose
+// participant has left the calendar is not reported. The occurrence query answers that
+// with its JOIN on participants scoped to the calendar, covered by the repository's
+// TestOccurrencesExpandRecurrencesAndCarryTimes.
+
 // identifiedIDs collects the participant ids that actually survived masking.
 func identifiedIDs(participants []models.PublicParticipantAvailabilitySummary) []uuid.UUID {
 	out := make([]uuid.UUID, 0, len(participants))
@@ -55,12 +61,11 @@ func summariesWithBothParticipants(t *testing.T, locked bool) *summaryFixture {
 
 	fixture := newSummaryFixture(t, func(c *repository.Calendar) { c.LockParticipants = locked })
 
-	availabilities := []*models.Availability{
-		availabilityOn(t, fixture.alice.ID, "2026-03-05", ptr("09:00"), ptr("17:00")),
-		availabilityOn(t, fixture.bob.ID, "2026-03-05", ptr("10:00"), ptr("12:00")),
+	// The one seeding serves both endpoints, so they are asked about identical data.
+	fixture.availRepo.occurrences = []models.Occurrence{
+		available(fixture.alice, mustDate(t, "2026-03-05"), ptr("09:00"), ptr("17:00")),
+		available(fixture.bob, mustDate(t, "2026-03-05"), ptr("10:00"), ptr("12:00")),
 	}
-	fixture.availRepo.onDate = availabilities
-	fixture.availRepo.inRange = availabilities
 
 	return fixture
 }
@@ -227,17 +232,18 @@ func TestSummaryEndpointsAgreeOnMasking(t *testing.T) {
 	}
 }
 
-// TestGetDateSummaryMasksRecurrenceOccurrences covers the second way a participant
-// reaches this response. Availabilities expanded from a recurrence are appended by a
-// separate branch, so masking the explicit ones alone would have left the leak open
-// for anyone whose availability comes from a weekly rule.
-func TestGetDateSummaryMasksRecurrenceOccurrences(t *testing.T) {
+// TestGetDateSummaryMasksUntimedOccurrences covers the second way a participant reaches
+// this response. An occurrence a recurrence produced is an ordinary row by the time the
+// service sees it — usually an untimed one, since a weekly rule is most often set for a
+// whole day — and masking has to cover it just the same. It used to arrive through a
+// branch of its own, so masking the explicitly answered ones alone left the leak open for
+// anyone whose availability comes from a weekly rule.
+func TestGetDateSummaryMasksUntimedOccurrences(t *testing.T) {
 	fixture := newSummaryFixture(t, func(c *repository.Calendar) { c.LockParticipants = true })
 
-	// 2026-03-05 is a Thursday.
-	fixture.recurrences.byCalendar = []models.Recurrence{
-		recurrenceOn(fixture.alice.ID, 4, "2026-03-01", nil),
-		recurrenceOn(fixture.bob.ID, 4, "2026-03-01", nil),
+	fixture.availRepo.occurrences = []models.Occurrence{
+		available(fixture.alice, mustDate(t, "2026-03-05"), nil, nil),
+		available(fixture.bob, mustDate(t, "2026-03-05"), nil, nil),
 	}
 
 	got, err := fixture.service.GetDateSummary(
@@ -248,13 +254,13 @@ func TestGetDateSummaryMasksRecurrenceOccurrences(t *testing.T) {
 	}
 
 	if len(got.Participants) != 2 {
-		t.Fatalf("got %d participants, want 2 recurrence occurrences", len(got.Participants))
+		t.Fatalf("got %d participants, want 2 untimed occurrences", len(got.Participants))
 	}
 	if !containsUUID(t, got, fixture.alice.ID) {
 		t.Error("the asker cannot see their own id, so they cannot edit their own slot")
 	}
 	if containsUUID(t, got, fixture.bob.ID) {
-		t.Error("a recurrence-derived participant's id leaked past lock_participants")
+		t.Error("an untimed occurrence's participant id leaked past lock_participants")
 	}
 }
 
@@ -279,8 +285,8 @@ func TestGetDateSummaryEmptySerialisesAsArray(t *testing.T) {
 				c.MinDurationHours = tt.minDuration
 			})
 			if tt.minDuration > 0 {
-				fixture.availRepo.onDate = []*models.Availability{
-					availabilityOn(t, fixture.alice.ID, "2026-03-05", ptr("09:00"), ptr("10:00")),
+				fixture.availRepo.occurrences = []models.Occurrence{
+					available(fixture.alice, mustDate(t, "2026-03-05"), ptr("09:00"), ptr("10:00")),
 				}
 			}
 
@@ -301,30 +307,6 @@ func TestGetDateSummaryEmptySerialisesAsArray(t *testing.T) {
 				t.Errorf("participants = %s, want an empty array rather than null", encoded)
 			}
 		})
-	}
-}
-
-// TestGetDateSummaryUnknownParticipant mirrors the range-side guard: an availability
-// whose participant has since left the calendar is dropped, not reported nameless.
-func TestGetDateSummaryUnknownParticipant(t *testing.T) {
-	fixture := newSummaryFixture(t, nil)
-
-	ghost := uuid.New()
-	fixture.availRepo.onDate = []*models.Availability{
-		availabilityOn(t, ghost, "2026-03-05", ptr("09:00"), ptr("17:00")),
-	}
-	fixture.recurrences.byCalendar = []models.Recurrence{recurrenceOn(ghost, 4, "2026-03-01", nil)}
-
-	got, err := fixture.service.GetDateSummary(context.Background(), "token", "2026-03-05", "")
-	if err != nil {
-		t.Fatalf("GetDateSummary: %v", err)
-	}
-
-	if len(got.Participants) != 0 {
-		t.Errorf("got %d participants, want none: the participant is unknown", len(got.Participants))
-	}
-	if containsUUID(t, got, ghost) {
-		t.Error("the id of a participant who is not on the calendar was echoed back")
 	}
 }
 
@@ -367,7 +349,7 @@ func TestGetDateSummaryErrors(t *testing.T) {
 
 	t.Run("a store failure is propagated", func(t *testing.T) {
 		fixture := newSummaryFixture(t, nil)
-		fixture.availRepo.onDateErr = errStore
+		fixture.availRepo.occurrencesErr = errStore
 
 		_, err := fixture.service.GetDateSummary(context.Background(), "token", "2026-03-05", "")
 		if !errors.Is(err, errStore) {

--- a/internal/availability/service/range_summary_test.go
+++ b/internal/availability/service/range_summary_test.go
@@ -20,16 +20,31 @@ import (
 
 var errStore = errors.New("store unavailable")
 
+// Four tests were dropped from this file when the expansion moved into SQL, because the
+// service no longer decides any of it. Each is carried by a repository database test:
+//
+//   - expanding a recurrence into the dates it falls on — TestOccurrencesExpandRecurrencesAndCarryTimes
+//   - a manual answer suppressing that day's occurrence — TestAManualAnswerSuppressesTheRecurrence
+//   - an exception removing a single date from a range — TestOccurrencesForRangeCoverEveryDay
+//   - recurrence start and end bounds — TestAvailableParticipantsHonourRecurrenceBounds
+//
+// A fifth, TestGetRangeSummaryUnknownParticipant, is answered by the occurrence query's
+// JOIN on participants scoped to the calendar rather than by any loop here.
+
 // The mocks below are hand-written and deliberately narrow: only the methods the
 // summary paths reach carry behaviour, the rest satisfy the interface and would fail
 // loudly if a future change started calling them.
 
 type mockAvailabilityRepo struct {
-	inRange    []*models.Availability
-	inRangeErr error
-	onDate     []*models.Availability
-	onDateErr  error
-	createErr  error
+	createErr error
+
+	// The expansion the summary endpoints now read. Recurrence semantics — which
+	// occurrences a manual answer suppresses, which an exception removes — moved to SQL
+	// with it, so they are covered by the repository's database tests rather than mocked
+	// here. What is left for these tests is what the service still decides: masking,
+	// minimum duration, overlap, and the shape of an empty answer.
+	occurrences    []models.Occurrence
+	occurrencesErr error
 }
 
 var _ AvailabilityRepository = (*mockAvailabilityRepo)(nil)
@@ -54,18 +69,20 @@ func (m *mockAvailabilityRepo) GetByParticipantAndDate(
 	return nil, nil
 }
 
-func (m *mockAvailabilityRepo) GetByDate(context.Context, uuid.UUID, time.Time) ([]*models.Availability, error) {
-	return m.onDate, m.onDateErr
-}
-
-func (m *mockAvailabilityRepo) GetByCalendarDateRange(
-	context.Context, uuid.UUID, time.Time, time.Time,
-) ([]*models.Availability, error) {
-	return m.inRange, m.inRangeErr
-}
-
 func (m *mockAvailabilityRepo) GetParticipantCountForDate(context.Context, uuid.UUID, time.Time) (int, error) {
 	return 0, nil
+}
+
+func (m *mockAvailabilityRepo) GetOccurrencesForDate(
+	context.Context, uuid.UUID, time.Time,
+) ([]models.Occurrence, error) {
+	return m.occurrences, m.occurrencesErr
+}
+
+func (m *mockAvailabilityRepo) GetOccurrencesForRange(
+	context.Context, uuid.UUID, time.Time, time.Time,
+) ([]models.Occurrence, error) {
+	return m.occurrences, m.occurrencesErr
 }
 
 func (m *mockAvailabilityRepo) Update(context.Context, *models.Availability) error { return nil }
@@ -113,8 +130,7 @@ func (m *mockParticipantsRepo) GetByCalendarID(context.Context, uuid.UUID) ([]*r
 }
 
 type mockRecurrenceRepo struct {
-	byCalendar    []models.Recurrence
-	byCalendarErr error
+	byParticipant []models.Recurrence
 	exceptions    map[uuid.UUID][]models.RecurrenceException
 	exceptionsErr error
 }
@@ -124,11 +140,11 @@ var _ RecurrenceRepository = (*mockRecurrenceRepo)(nil)
 func (m *mockRecurrenceRepo) CreateRecurrence(context.Context, *models.Recurrence) error { return nil }
 
 func (m *mockRecurrenceRepo) GetRecurrencesByParticipant(context.Context, uuid.UUID) ([]models.Recurrence, error) {
-	return nil, nil
+	return m.byParticipant, nil
 }
 
 func (m *mockRecurrenceRepo) GetRecurrencesByCalendar(context.Context, uuid.UUID) ([]models.Recurrence, error) {
-	return m.byCalendar, m.byCalendarErr
+	return nil, nil
 }
 
 func (m *mockRecurrenceRepo) GetRecurrenceByID(context.Context, uuid.UUID) (*models.Recurrence, error) {
@@ -169,6 +185,19 @@ var _ NotifyService = (*mockNotifyService)(nil)
 
 func (m *mockNotifyService) CheckThresholdAndNotify(context.Context, uuid.UUID, time.Time, int) error {
 	return nil
+}
+
+// available seeds one occurrence, which is what the repository now hands the service.
+// Whether it came from a typed answer or a recurrence is settled before this point — see
+// the repository's database tests — so these tests no longer have to say.
+func available(p *repository.Participant, date time.Time, start, end *string) models.Occurrence {
+	return models.Occurrence{
+		Date:            date,
+		ParticipantID:   p.ID,
+		ParticipantName: p.Name,
+		StartTime:       start,
+		EndTime:         end,
+	}
 }
 
 // summaryFixture assembles a calendar, two participants and a service around them.
@@ -220,32 +249,6 @@ func newSummaryFixture(t *testing.T, configure func(*repository.Calendar)) *summ
 	}
 }
 
-func availabilityOn(t *testing.T, participantID uuid.UUID, iso string, start, end *string) *models.Availability {
-	t.Helper()
-
-	availability := &models.Availability{
-		ParticipantID: participantID,
-		Date:          mustDate(t, iso),
-		StartTime:     start,
-		EndTime:       end,
-	}
-	availability.ID = uuid.New()
-
-	return availability
-}
-
-func recurrenceOn(participantID uuid.UUID, dayOfWeek int, startDate string, endDate *string) models.Recurrence {
-	recurrence := models.Recurrence{
-		ParticipantID: participantID,
-		DayOfWeek:     dayOfWeek,
-		StartDate:     startDate,
-		EndDate:       endDate,
-	}
-	recurrence.ID = uuid.New()
-
-	return recurrence
-}
-
 // byDate makes the assertions independent of map iteration order, which GetRangeSummary
 // does not control.
 func byDate(summaries []models.PublicDateAvailabilitySummary) map[string]models.PublicDateAvailabilitySummary {
@@ -267,17 +270,27 @@ func dates(summaries []models.PublicDateAvailabilitySummary) []string {
 	return out
 }
 
-// TestGetRangeSummaryExpandsRecurrences is the behaviour the frontend is built around:
-// the range summary hands back recurrence *occurrences* alongside explicit answers,
-// with no marker distinguishing the two. That is why ParticipantView fetches its own
+// TestGetRangeSummaryGroupsOccurrencesByDate covers the bucketing, which is all the range
+// endpoint still does with the expansion: one summary per date that has an occurrence,
+// several participants on a date collapsing into that one summary, and no marker telling
+// an occurrence a recurrence produced from one somebody typed. That last part is the
+// behaviour the frontend is built around, and why ParticipantView fetches its own
 // availabilities separately.
-func TestGetRangeSummaryExpandsRecurrences(t *testing.T) {
+func TestGetRangeSummaryGroupsOccurrencesByDate(t *testing.T) {
 	fixture := newSummaryFixture(t, nil)
 
-	// Every Thursday from 1 March. 2026-03-05, 03-12, 03-19 and 03-26 are Thursdays.
-	fixture.recurrences.byCalendar = []models.Recurrence{
-		recurrenceOn(fixture.alice.ID, 4, "2026-03-01", nil),
+	// Alice on every Thursday of March, as the repository expands a weekly rule, with Bob
+	// answering one of them.
+	for _, iso := range []string{"2026-03-05", "2026-03-12", "2026-03-19", "2026-03-26"} {
+		fixture.availRepo.occurrences = append(
+			fixture.availRepo.occurrences,
+			available(fixture.alice, mustDate(t, iso), nil, nil),
+		)
 	}
+	fixture.availRepo.occurrences = append(
+		fixture.availRepo.occurrences,
+		available(fixture.bob, mustDate(t, "2026-03-12"), ptr("09:00"), ptr("17:00")),
+	)
 
 	got, err := fixture.service.GetRangeSummary(
 		context.Background(), "token", "2026-03-01", "2026-03-31", "",
@@ -287,165 +300,30 @@ func TestGetRangeSummaryExpandsRecurrences(t *testing.T) {
 	}
 
 	want := []string{"2026-03-05", "2026-03-12", "2026-03-19", "2026-03-26"}
-	if gotDates := dates(got); len(gotDates) != len(want) {
+	gotDates := dates(got)
+	if len(gotDates) != len(want) {
 		t.Fatalf("got dates %v, want %v", gotDates, want)
 	}
-	for i, date := range dates(got) {
+	for i, date := range gotDates {
 		if date != want[i] {
 			t.Errorf("date %d = %s, want %s", i, date, want[i])
 		}
 	}
 
 	for _, summary := range got {
-		if len(summary.Participants) != 1 || summary.Participants[0].ParticipantName != "Alice" {
-			t.Errorf("%s: participants = %+v, want Alice alone", summary.Date, summary.Participants)
+		wantParticipants := 1
+		if summary.Date == "2026-03-12" {
+			wantParticipants = 2
 		}
-	}
-}
-
-// TestGetRangeSummaryDeduplicates covers the guard that stops one participant being
-// counted twice on a date they both answered explicitly and are covered for by a
-// recurrence. Without it, a threshold of two could be "met" by one person.
-func TestGetRangeSummaryDeduplicates(t *testing.T) {
-	fixture := newSummaryFixture(t, nil)
-
-	// Alice recurs every Thursday, and has also answered explicitly on 2026-03-05.
-	fixture.recurrences.byCalendar = []models.Recurrence{
-		recurrenceOn(fixture.alice.ID, 4, "2026-03-01", nil),
-	}
-	fixture.availRepo.inRange = []*models.Availability{
-		availabilityOn(t, fixture.alice.ID, "2026-03-05", ptr("14:00"), ptr("18:00")),
-	}
-
-	got, err := fixture.service.GetRangeSummary(
-		context.Background(), "token", "2026-03-05", "2026-03-05", "",
-	)
-	if err != nil {
-		t.Fatalf("GetRangeSummary: %v", err)
-	}
-
-	summary, ok := byDate(got)["2026-03-05"]
-	if !ok {
-		t.Fatal("2026-03-05 is missing from the summary")
-	}
-
-	if len(summary.Participants) != 1 {
-		t.Fatalf("Alice appears %d times, want once", len(summary.Participants))
-	}
-
-	// The explicit answer wins: its times are the ones reported, not the
-	// recurrence's.
-	if deref(summary.Participants[0].StartTime) != "14:00" {
-		t.Errorf("start = %s, want the explicit 14:00", deref(summary.Participants[0].StartTime))
-	}
-	if summary.TotalCount != 1 {
-		t.Errorf("TotalCount = %d, want 1", summary.TotalCount)
-	}
-}
-
-// TestGetRangeSummaryHonoursExceptions covers the subtraction: an excepted date must
-// disappear from the expansion entirely, not merely be marked.
-func TestGetRangeSummaryHonoursExceptions(t *testing.T) {
-	fixture := newSummaryFixture(t, nil)
-
-	recurrence := recurrenceOn(fixture.alice.ID, 4, "2026-03-01", nil)
-	fixture.recurrences.byCalendar = []models.Recurrence{recurrence}
-	fixture.recurrences.exceptions[recurrence.ID] = []models.RecurrenceException{
-		{RecurrenceID: recurrence.ID, ExcludedDate: "2026-03-12"},
-	}
-
-	got, err := fixture.service.GetRangeSummary(
-		context.Background(), "token", "2026-03-01", "2026-03-31", "",
-	)
-	if err != nil {
-		t.Fatalf("GetRangeSummary: %v", err)
-	}
-
-	if _, excepted := byDate(got)["2026-03-12"]; excepted {
-		t.Error("the excepted date is still present in the summary")
-	}
-	if _, kept := byDate(got)["2026-03-05"]; !kept {
-		t.Error("an unexcepted occurrence was dropped along with the exception")
-	}
-	if len(got) != 3 {
-		t.Errorf("got %d dates, want 3 (four Thursdays minus one exception)", len(got))
-	}
-}
-
-// TestGetRangeSummaryRecurrenceBounds pins the window arithmetic. The comparison is
-// done on the ISO strings rather than on parsed dates, deliberately, to sidestep
-// timezone drift — so the bounds are inclusive at both ends.
-func TestGetRangeSummaryRecurrenceBounds(t *testing.T) {
-	tests := []struct {
-		name      string
-		start     string
-		end       *string
-		queryFrom string
-		queryTo   string
-		wantDates []string
-	}{
-		{
-			name:      "starts mid-range",
-			start:     "2026-03-10",
-			queryFrom: "2026-03-01", queryTo: "2026-03-31",
-			wantDates: []string{"2026-03-12", "2026-03-19", "2026-03-26"},
-		},
-		{
-			name:  "ends mid-range, inclusively",
-			start: "2026-03-01", end: ptr("2026-03-12"),
-			queryFrom: "2026-03-01", queryTo: "2026-03-31",
-			wantDates: []string{"2026-03-05", "2026-03-12"},
-		},
-		{
-			name:      "starts exactly on an occurrence",
-			start:     "2026-03-05",
-			queryFrom: "2026-03-01", queryTo: "2026-03-10",
-			wantDates: []string{"2026-03-05"},
-		},
-		{
-			name:  "a single-day window",
-			start: "2026-03-01", end: ptr("2026-03-05"),
-			queryFrom: "2026-03-05", queryTo: "2026-03-05",
-			wantDates: []string{"2026-03-05"},
-		},
-		{
-			name:  "the recurrence ends before the query starts",
-			start: "2026-01-01", end: ptr("2026-02-01"),
-			queryFrom: "2026-03-01", queryTo: "2026-03-31",
-			wantDates: nil,
-		},
-		{
-			name:      "the recurrence starts after the query ends",
-			start:     "2026-06-01",
-			queryFrom: "2026-03-01", queryTo: "2026-03-31",
-			wantDates: nil,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			fixture := newSummaryFixture(t, nil)
-			fixture.recurrences.byCalendar = []models.Recurrence{
-				recurrenceOn(fixture.alice.ID, 4, tt.start, tt.end),
-			}
-
-			got, err := fixture.service.GetRangeSummary(
-				context.Background(), "token", tt.queryFrom, tt.queryTo, "",
+		if len(summary.Participants) != wantParticipants {
+			t.Errorf(
+				"%s: participants = %+v, want %d",
+				summary.Date, summary.Participants, wantParticipants,
 			)
-			if err != nil {
-				t.Fatalf("GetRangeSummary: %v", err)
-			}
-
-			gotDates := dates(got)
-			if len(gotDates) != len(tt.wantDates) {
-				t.Fatalf("got %v, want %v", gotDates, tt.wantDates)
-			}
-			for i, date := range gotDates {
-				if date != tt.wantDates[i] {
-					t.Errorf("date %d = %s, want %s", i, date, tt.wantDates[i])
-				}
-			}
-		})
+		}
+		if summary.Participants[0].ParticipantName != "Alice" {
+			t.Errorf("%s: first participant = %s, want Alice", summary.Date, summary.Participants[0].ParticipantName)
+		}
 	}
 }
 
@@ -493,9 +371,9 @@ func TestGetRangeSummaryMinDuration(t *testing.T) {
 				c.MinDurationHours = tt.minDuration
 			})
 
-			fixture.availRepo.inRange = []*models.Availability{
-				availabilityOn(t, fixture.alice.ID, "2026-03-05", ptr(tt.aliceStart), ptr(tt.aliceEnd)),
-				availabilityOn(t, fixture.bob.ID, "2026-03-05", ptr(tt.bobStart), ptr(tt.bobEnd)),
+			fixture.availRepo.occurrences = []models.Occurrence{
+				available(fixture.alice, mustDate(t, "2026-03-05"), ptr(tt.aliceStart), ptr(tt.aliceEnd)),
+				available(fixture.bob, mustDate(t, "2026-03-05"), ptr(tt.bobStart), ptr(tt.bobEnd)),
 			}
 
 			got, err := fixture.service.GetRangeSummary(
@@ -520,9 +398,9 @@ func TestGetRangeSummaryCountsSimultaneous(t *testing.T) {
 
 	// Two people on the same date who never overlap: two answers, but never two at
 	// once, so the count must be one.
-	fixture.availRepo.inRange = []*models.Availability{
-		availabilityOn(t, fixture.alice.ID, "2026-03-05", ptr("09:00"), ptr("10:00")),
-		availabilityOn(t, fixture.bob.ID, "2026-03-05", ptr("14:00"), ptr("16:00")),
+	fixture.availRepo.occurrences = []models.Occurrence{
+		available(fixture.alice, mustDate(t, "2026-03-05"), ptr("09:00"), ptr("10:00")),
+		available(fixture.bob, mustDate(t, "2026-03-05"), ptr("14:00"), ptr("16:00")),
 	}
 
 	got, err := fixture.service.GetRangeSummary(
@@ -544,9 +422,9 @@ func TestGetRangeSummaryCountsSimultaneous(t *testing.T) {
 func TestGetRangeSummaryPrivacy(t *testing.T) {
 	fixture := newSummaryFixture(t, func(c *repository.Calendar) { c.LockParticipants = true })
 
-	fixture.availRepo.inRange = []*models.Availability{
-		availabilityOn(t, fixture.alice.ID, "2026-03-05", ptr("09:00"), ptr("17:00")),
-		availabilityOn(t, fixture.bob.ID, "2026-03-05", ptr("09:00"), ptr("17:00")),
+	fixture.availRepo.occurrences = []models.Occurrence{
+		available(fixture.alice, mustDate(t, "2026-03-05"), ptr("09:00"), ptr("17:00")),
+		available(fixture.bob, mustDate(t, "2026-03-05"), ptr("09:00"), ptr("17:00")),
 	}
 
 	got, err := fixture.service.GetRangeSummary(
@@ -569,30 +447,6 @@ func TestGetRangeSummaryPrivacy(t *testing.T) {
 	}
 	if identified != 1 {
 		t.Errorf("%d participants were identified, want 1 under lock_participants", identified)
-	}
-}
-
-// TestGetRangeSummaryUnknownParticipant covers a consistency gap: an availability or
-// recurrence whose participant is no longer on the calendar is dropped rather than
-// reported under an empty name.
-func TestGetRangeSummaryUnknownParticipant(t *testing.T) {
-	fixture := newSummaryFixture(t, nil)
-
-	ghost := uuid.New()
-	fixture.availRepo.inRange = []*models.Availability{
-		availabilityOn(t, ghost, "2026-03-05", ptr("09:00"), ptr("17:00")),
-	}
-	fixture.recurrences.byCalendar = []models.Recurrence{recurrenceOn(ghost, 4, "2026-03-01", nil)}
-
-	got, err := fixture.service.GetRangeSummary(
-		context.Background(), "token", "2026-03-05", "2026-03-05", "",
-	)
-	if err != nil {
-		t.Fatalf("GetRangeSummary: %v", err)
-	}
-
-	if len(got) != 0 {
-		t.Errorf("got %d dates, want none: the participant is unknown", len(got))
 	}
 }
 
@@ -644,24 +498,33 @@ func TestGetRangeSummaryErrors(t *testing.T) {
 
 	t.Run("a store failure is propagated", func(t *testing.T) {
 		fixture := newSummaryFixture(t, nil)
-		fixture.availRepo.inRangeErr = errStore
+		fixture.availRepo.occurrencesErr = errStore
 
 		_, err := fixture.service.GetRangeSummary(context.Background(), "token", "2026-03-01", "2026-03-31", "")
 		if !errors.Is(err, errStore) {
 			t.Errorf("error = %v, want the store failure", err)
 		}
 	})
+}
 
-	t.Run("an exception lookup failure is propagated", func(t *testing.T) {
-		fixture := newSummaryFixture(t, nil)
-		fixture.recurrences.byCalendar = []models.Recurrence{recurrenceOn(fixture.alice.ID, 4, "2026-03-01", nil)}
-		fixture.recurrences.exceptionsErr = errStore
+// TestExceptionLookupFailureIsPropagated used to be a subtest of TestGetRangeSummaryErrors,
+// back when the range summary loaded exceptions to subtract them itself. GetParticipantRecurrences
+// is the last caller of exceptionsFor, and the assertion is the one that mattered either
+// way: a failed lookup is reported, not swallowed into an answer missing its exceptions.
+func TestExceptionLookupFailureIsPropagated(t *testing.T) {
+	fixture := newSummaryFixture(t, nil)
 
-		_, err := fixture.service.GetRangeSummary(context.Background(), "token", "2026-03-01", "2026-03-31", "")
-		if !errors.Is(err, errStore) {
-			t.Errorf("error = %v, want the store failure", err)
-		}
-	})
+	recurrence := models.Recurrence{ParticipantID: fixture.alice.ID, DayOfWeek: 4, StartDate: "2026-03-01"}
+	recurrence.ID = uuid.New()
+	fixture.recurrences.byParticipant = []models.Recurrence{recurrence}
+	fixture.recurrences.exceptionsErr = errStore
+
+	_, err := fixture.service.GetParticipantRecurrences(
+		context.Background(), "token", fixture.alice.ID.String(),
+	)
+	if !errors.Is(err, errStore) {
+		t.Errorf("error = %v, want the store failure", err)
+	}
 }
 
 // TestGetRangeSummaryEmptyRange confirms a quiet calendar produces no rows rather than


### PR DESCRIPTION
Two defects, one cause. The larger of the two was found while fixing the first.

## Four answers to one question

"Who is available on this date" had four implementations: the threshold count expanded recurrences in SQL, the day view and the range view each expanded them again in Go, and the ICS feed had a fourth. They agreed by accident and drifted by default — **#108 was one such drift**, where the notification read the `availabilities` table raw and so never saw anyone whose availability came from a recurrence.

Recurrences are expanded when read and never stored, so reading that table was never the same question.

### The primitive

One SQL expansion yielding **occurrences** rather than participants — a date, a participant, and the times — whether a person typed the answer or a pattern they set earlier produced it. It states once the rule all three implementations already shared: *a typed answer suppresses the recurrence for that participant on that date, times and all, even when the typed one is all-day and the pattern is not.*

Everything derives from it: the day view, the range view, the participant list, the count. A disagreement between them is no longer something that can happen. The two Go loops are gone, and with them the `O(days × recurrences × exceptions)` walk the range view did after three queries.

**The ICS feed keeps its own.** Its window is global to the calendar — `[MIN(start_date), MAX(end_date or now+1y)]` — rather than the date being asked about. That is a different question, not a fourth copy of this one.

Two conditions that differed between the old implementations are settled: no `source = 'manual'` filter (nothing writes another value, so it selected nothing while quietly discarding rows an older version wrote) and no `start_date IS NULL` test (the column is `NOT NULL`).

## Three meanings of "count"

Exposed by having the times in the counting path for the first time:

| | What it counted |
|---|---|
| Notification threshold | participants who answered for the day, **overlap-blind** |
| Interface badge | participants whose hours **overlap** |
| ICS feed | per slot, after overlap |

So a calendar could send **"3/3 available"** for three people who were never free at the same moment, while the page for that date showed 1 and the feed emitted nothing.

The threshold now measures overlap, which is what the other two already meant. **`TestCountMeasuresOverlapNotAnswers`** pins it: two people free 08:00–10:00 and 18:00–20:00 count as 1. **`TestCountIsUnchangedForWholeDayAnswers`** bounds the change: an all-day answer spans the whole day, so a calendar answered in whole days — the common case — counts exactly as it did.

`MaxSimultaneous` moves to the models package for this. The dependency runs availability → notify, so the threshold detector cannot reach into the availability service without a cycle; both already import models.

## Tests

Recurrence semantics moved to the repository's DB tests, where the logic now lives, rather than being asserted against a mock that would have to reimplement them — which is the same duplication in test clothing. Five new DB tests cover expansion with times, the precedence rule, ranges with exceptions, and the two count cases above.

Three service tests were deleted and one retargeted, each naming the test that took over:

| Deleted | Now covered by |
|---|---|
| `TestGetRangeSummaryDeduplicates` | `TestAManualAnswerSuppressesTheRecurrence` |
| `TestGetRangeSummaryHonoursExceptions` | `TestOccurrencesForRangeCoverEveryDay` |
| `TestGetRangeSummaryRecurrenceBounds` | `TestAvailableParticipantsHonourRecurrenceBounds` |
| the two `UnknownParticipant` twins | the query's `JOIN participants … WHERE p.calendar_id = $1` |

`TestGetRangeSummaryExpandsRecurrences` became `TestGetRangeSummaryGroupsOccurrencesByDate` — expansion left, but bucketing occurrences into one summary per date is still the service's job and nothing else covered it. One error subtest was **retargeted rather than dropped**: the range path no longer loads exceptions, so it moved to `GetParticipantRecurrences`, the last caller of `exceptionsFor`.

Two interface methods the summary endpoints no longer call go too, along with `GetRecurrencesByCalendar`, which the service stopped using when the expansion left it.

`make test` — 39 packages, no failures, DB tests included. `go test -race` clean on availability and notify. Both build variants, format-check.

## Worth an eye before merge

`frontend/e2e-backend/participant.spec.ts:205` pins exactly what the primitive has to preserve — a recurrence occurrence present in the range summary with no stored row behind it, and an excepted date absent. Neither asserts a count, so the threshold change does not touch them, but they are the end-to-end net for the expansion itself.

Worth confirming by hand on a date where several people are free without ever overlapping: the interface, the feed and the notification should now all say the same thing.