### PR TITLE
fix(availability): stop hiding a day nobody can meet on

### DIFF
--- a/internal/availability/models/availability.go
+++ b/internal/availability/models/availability.go
@@ -158,14 +158,14 @@ func (p ParticipantAvailabilitySummary) Window() TimeWindow {
 	return TimeWindow{Start: p.StartTime, End: p.EndTime}
 }
 
-// MaxSimultaneous returns the largest number of the given windows that are open at the
-// same moment. A nil start or end means all day, so a calendar answered entirely in whole
+// MaxSimultaneousFor returns the largest number of the given windows that are open
+// together for at least minMinutes. A nil start or end means all day, so a calendar answered entirely in whole
 // days gives the same number as simply counting the answers.
 //
 // It lives here rather than in the availability service because the notification threshold
 // needs it too, and the dependency runs availability -> notify: the detector cannot reach
 // back into the service without a cycle. Both packages already import this one.
-func MaxSimultaneous(windows []TimeWindow) int {
+func MaxSimultaneousFor(windows []TimeWindow, minMinutes int) int {
 	if len(windows) == 0 {
 		return 0
 	}
@@ -240,28 +240,40 @@ func MaxSimultaneous(windows []TimeWindow) int {
 	}
 	sortInts(boundaries)
 
-	// Calculate the maximum number of participants for each segment
+	// The largest group covering any window long enough to be worth meeting in.
+	//
+	// Every candidate window runs from one boundary to a later one, rather than only
+	// between consecutive ones: a group has to cover the whole of a window at least
+	// minMinutes long, and that window generally spans several elementary segments. With
+	// minMinutes zero the longer candidates can only ever have fewer coverers than the
+	// segments they contain, so the answer is the same one this always gave.
 	maxCount := 0
 
 	for i := 0; i < len(boundaries)-1; i++ {
-		segStart := boundaries[i]
-		segEnd := boundaries[i+1]
+		for j := i + 1; j < len(boundaries); j++ {
+			if boundaries[j]-boundaries[i] < minMinutes {
+				continue
+			}
 
-		// Count participants available for this entire segment
-		count := 0
-		for _, p := range normalized {
-			if p.valid {
-				// Participant is available if their range completely covers the segment
-				if p.startMinutes <= segStart && p.endMinutes >= segEnd {
+			count := 0
+			for _, p := range normalized {
+				// Available if their range completely covers the candidate window.
+				if p.valid && p.startMinutes <= boundaries[i] && p.endMinutes >= boundaries[j] {
 					count++
 				}
 			}
-		}
 
-		if count > maxCount {
-			maxCount = count
+			if count > maxCount {
+				maxCount = count
+			}
 		}
 	}
 
 	return maxCount
+}
+
+// MaxSimultaneous is MaxSimultaneousFor with no minimum: the largest number of windows
+// open at the same moment, however briefly.
+func MaxSimultaneous(windows []TimeWindow) int {
+	return MaxSimultaneousFor(windows, 0)
 }

--- a/internal/availability/repository/availability_repository.go
+++ b/internal/availability/repository/availability_repository.go
@@ -494,10 +494,23 @@ func (r *AvailabilityRepository) GetParticipantCountForDate(
 		return 0, err
 	}
 
+	// How long a meeting has to last is the calendar's policy, not the caller's, so it
+	// is read here rather than threaded through every caller. Without it this counted
+	// any overlap however brief, while the page for the same date counted only overlaps
+	// long enough to hold the event — so a notification could announce a gathering the
+	// interface was already saying could not happen.
+	var minDurationHours int
+	if err := r.pool.QueryRow(ctx,
+		`SELECT COALESCE(min_duration_hours, 0) FROM calendars WHERE id = $1`,
+		calendarID,
+	).Scan(&minDurationHours); err != nil {
+		return 0, fmt.Errorf("failed to read the calendar's minimum duration: %w", err)
+	}
+
 	windows := make([]models.TimeWindow, 0, len(occurrences))
 	for _, occurrence := range occurrences {
 		windows = append(windows, occurrence.Window())
 	}
 
-	return models.MaxSimultaneous(windows), nil
+	return models.MaxSimultaneousFor(windows, minDurationHours*60), nil
 }

--- a/internal/availability/repository/availability_repository_db_test.go
+++ b/internal/availability/repository/availability_repository_db_test.go
@@ -718,6 +718,41 @@ func TestCountMeasuresOverlapNotAnswers(t *testing.T) {
 	}
 }
 
+// TestCountHonoursTheCalendarMinimum keeps the number the notification threshold reads
+// and the number the page shows as one number. They were briefly two: the summary
+// endpoints started counting only overlaps long enough to hold the event while this still
+// counted any overlap, so a notification could announce a gathering the interface was
+// already saying could not happen.
+func TestCountHonoursTheCalendarMinimum(t *testing.T) {
+	pool := dbtest.Pool(t)
+	repo := repository.NewAvailabilityRepository(pool)
+	ctx := dbtest.Context(t)
+
+	f := seed(t, pool)
+	monday := day(0)
+
+	// Half an hour together, on a calendar that wants two.
+	if err := repo.Create(ctx, availability(f.participant.ID, monday, ptr("10:00"), ptr("13:30"))); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if err := repo.Create(ctx, availability(f.other.ID, monday, ptr("13:00"), ptr("18:00"))); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if _, err := pool.Exec(ctx,
+		`UPDATE calendars SET min_duration_hours = 2 WHERE id = $1`, f.calendar.ID); err != nil {
+		t.Fatalf("set the minimum: %v", err)
+	}
+
+	count, err := repo.GetParticipantCountForDate(ctx, f.calendar.ID, monday)
+	if err != nil {
+		t.Fatalf("GetParticipantCountForDate: %v", err)
+	}
+	// Each is free long enough alone; the pair is not.
+	if count != 1 {
+		t.Errorf("count = %d, want 1: half an hour together cannot hold a two-hour event", count)
+	}
+}
+
 // TestCountIsUnchangedForWholeDayAnswers bounds the change above: a calendar answered in
 // whole days — the common case — counts exactly as it always did.
 func TestCountIsUnchangedForWholeDayAnswers(t *testing.T) {

--- a/internal/availability/service/availability_service.go
+++ b/internal/availability/service/availability_service.go
@@ -619,22 +619,15 @@ func (s *AvailabilityService) GetDateSummary(ctx context.Context, token, dateStr
 
 	participantSummaries := summariesFrom(occurrences)
 
-	// Apply min_duration_hours filter if configured
-	if calendarInfo.MinDurationHours > 0 && len(participantSummaries) > 0 {
-		duration := calculateDurationForDate(participantSummaries)
-		if duration < float64(calendarInfo.MinDurationHours) {
-			// Return empty summary if duration is less than minimum
-			return &models.PublicDateAvailabilitySummary{
-				Date:         dateStr,
-				TotalCount:   0,
-				Participants: []models.PublicParticipantAvailabilitySummary{},
-			}, nil
-		}
-	}
-
+	// The minimum duration bounds which overlaps count, not whether the date is worth
+	// answering about. It used to blank the whole summary — count and participants —
+	// whenever the window shared by *everyone* fell short, so a day where two people
+	// were free at different hours reported nobody available at all, with nothing to
+	// say why. The feed never worked that way: it drops a slot that is too short and
+	// keeps the rest.
 	return &models.PublicDateAvailabilitySummary{
 		Date:         dateStr,
-		TotalCount:   calculateMaxSimultaneousParticipants(participantSummaries),
+		TotalCount:   countThatCanMeet(participantSummaries, calendarInfo.MinDurationHours),
 		Participants: filterParticipantSummaries(calendarInfo.LockParticipants, participantID, participantSummaries),
 	}, nil
 }
@@ -733,18 +726,9 @@ func (s *AvailabilityService) GetRangeSummary(ctx context.Context, token, startD
 	// calling .map() on the payload would have thrown.
 	summaries := make([]models.PublicDateAvailabilitySummary, 0, len(dateMap))
 	for date, participants := range dateMap {
-		// Apply min_duration_hours filter if configured
-		if calendarInfo.MinDurationHours > 0 {
-			duration := calculateDurationForDate(participants)
-			if duration < float64(calendarInfo.MinDurationHours) {
-				// Skip this date if duration is less than minimum
-				continue
-			}
-		}
-
 		summaries = append(summaries, models.PublicDateAvailabilitySummary{
 			Date:         date,
-			TotalCount:   calculateMaxSimultaneousParticipants(participants),
+			TotalCount:   countThatCanMeet(participants, calendarInfo.MinDurationHours),
 			Participants: filterParticipantSummaries(calendarInfo.LockParticipants, participantID, participants),
 		})
 	}
@@ -836,62 +820,6 @@ func toAvailabilityResponse(availability *models.Availability, participantName s
 		CreatedAt:                availability.CreatedAt,
 		UpdatedAt:                availability.UpdatedAt,
 	}
-}
-
-// calculateDurationForDate calculates the event duration for a date based on participant availabilities
-// Returns duration in hours
-func calculateDurationForDate(participants []models.ParticipantAvailabilitySummary) float64 {
-	// Check if all participants have no times (all-day event)
-	hasAnyTime := false
-	for _, p := range participants {
-		if p.StartTime != nil || p.EndTime != nil {
-			hasAnyTime = true
-			break
-		}
-	}
-
-	// If all-day event, return 24 hours
-	if !hasAnyTime {
-		return 24.0
-	}
-
-	// Calculate MAX(start_time) and MIN(end_time)
-	var maxStart, minEnd *time.Time
-
-	for _, p := range participants {
-		if p.StartTime != nil && *p.StartTime != "" {
-			t, err := time.Parse("15:04", *p.StartTime)
-			if err == nil {
-				if maxStart == nil || t.After(*maxStart) {
-					maxStart = &t
-				}
-			}
-		}
-
-		if p.EndTime != nil && *p.EndTime != "" {
-			t, err := time.Parse("15:04", *p.EndTime)
-			if err == nil {
-				if minEnd == nil || t.Before(*minEnd) {
-					minEnd = &t
-				}
-			}
-		}
-	}
-
-	// If we couldn't determine both times, treat as all-day
-	if maxStart == nil || minEnd == nil {
-		return 24.0
-	}
-
-	// Calculate duration in hours
-	duration := minEnd.Sub(*maxStart).Hours()
-
-	// Handle negative or zero duration (invalid case)
-	if duration <= 0 {
-		return 0.0
-	}
-
-	return duration
 }
 
 // Recurrence methods
@@ -1549,18 +1477,6 @@ func compareTime(t1, t2 string) int {
 	return 0
 }
 
-// calculateMaxSimultaneousParticipants calculates the maximum number of participants
-// that are available at the same time on a given date.
-// This uses the same logic as the ICS feed generation (time slot segmentation).
-func calculateMaxSimultaneousParticipants(participants []models.ParticipantAvailabilitySummary) int {
-	windows := make([]models.TimeWindow, 0, len(participants))
-	for _, p := range participants {
-		windows = append(windows, p.Window())
-	}
-
-	return models.MaxSimultaneous(windows)
-}
-
 // recurrencesOverlap checks if two recurrences on the same day of week have overlapping date ranges.
 // Returns true if the date ranges overlap.
 // Rules:
@@ -1725,4 +1641,17 @@ func summariesFrom(occurrences []models.Occurrence) []models.ParticipantAvailabi
 	}
 
 	return summaries
+}
+
+// countThatCanMeet is how many participants are free together for long enough to hold
+// the event, which is what both summary endpoints report and what the grid badge shows.
+//
+// minDurationHours of zero means any overlap counts, however brief.
+func countThatCanMeet(participants []models.ParticipantAvailabilitySummary, minDurationHours int) int {
+	windows := make([]models.TimeWindow, 0, len(participants))
+	for _, p := range participants {
+		windows = append(windows, p.Window())
+	}
+
+	return models.MaxSimultaneousFor(windows, minDurationHours*60)
 }

--- a/internal/availability/service/availability_service_test.go
+++ b/internal/availability/service/availability_service_test.go
@@ -175,7 +175,7 @@ func TestCalculateMaxSimultaneousParticipants(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := calculateMaxSimultaneousParticipants(tt.participants)
+			result := countThatCanMeet(tt.participants, 0)
 			if result != tt.expected {
 				t.Errorf("%s: expected %d, got %d", tt.description, tt.expected, result)
 			}

--- a/internal/availability/service/date_summary_test.go
+++ b/internal/availability/service/date_summary_test.go
@@ -268,43 +268,92 @@ func TestGetDateSummaryMasksUntimedOccurrences(t *testing.T) {
 // The old code accumulated into a nil slice, so a date nobody answered came back with
 // `"participants": null` and any client mapping over it threw.
 func TestGetDateSummaryEmptySerialisesAsArray(t *testing.T) {
+	fixture := newSummaryFixture(t, nil)
+
+	got, err := fixture.service.GetDateSummary(context.Background(), "token", "2026-03-05", "")
+	if err != nil {
+		t.Fatalf("GetDateSummary: %v", err)
+	}
+	if got.TotalCount != 0 {
+		t.Errorf("TotalCount = %d, want 0", got.TotalCount)
+	}
+
+	encoded, err := json.Marshal(got)
+	if err != nil {
+		t.Fatalf("marshal response: %v", err)
+	}
+	if !strings.Contains(string(encoded), `"participants":[]`) {
+		t.Errorf("participants = %s, want an empty array rather than null", encoded)
+	}
+}
+
+// TestGetDateSummaryKeepsParticipantsBelowTheMinimum is the reported defect. A day where
+// nobody can meet for long enough used to come back with no participants at all — the
+// count said 0 and the list was empty, so the page showed "0 participant(s)" for a date
+// several people had answered for, with nothing to say why.
+//
+// The minimum bounds which overlaps count, not whether the day is worth describing.
+func TestGetDateSummaryKeepsParticipantsBelowTheMinimum(t *testing.T) {
+	fixture := newSummaryFixture(t, func(c *repository.Calendar) { c.MinDurationHours = 2 })
+	date := mustDate(t, "2026-03-05")
+	fixture.availRepo.occurrences = []models.Occurrence{
+		available(fixture.alice, date, ptr("10:00"), ptr("13:00")),
+		available(fixture.bob, date, ptr("14:00"), ptr("18:00")),
+	}
+
+	got, err := fixture.service.GetDateSummary(context.Background(), "token", "2026-03-05", "")
+	if err != nil {
+		t.Fatalf("GetDateSummary: %v", err)
+	}
+
+	// Neither can meet the other, but each is free long enough on their own.
+	if got.TotalCount != 1 {
+		t.Errorf("TotalCount = %d, want 1", got.TotalCount)
+	}
+	if len(got.Participants) != 2 {
+		t.Fatalf("listed %d participants, want 2: the day is answerable even when the event is not",
+			len(got.Participants))
+	}
+	// With their hours, which is what makes the count legible.
+	for _, p := range got.Participants {
+		if p.StartTime == nil || p.EndTime == nil {
+			t.Errorf("%s came back without hours", p.ParticipantName)
+		}
+	}
+}
+
+// TestGetDateSummaryCountsOnlyOverlapsLongEnough is the other half: an overlap shorter
+// than the event cannot hold it, so it does not count towards the group.
+func TestGetDateSummaryCountsOnlyOverlapsLongEnough(t *testing.T) {
+	date := mustDate(t, "2026-03-05")
+
 	tests := []struct {
-		name string
-		// minDuration over zero exercises the short-overlap early return; zero
-		// exercises the ordinary empty-day path.
-		minDuration int
-		wantCount   int
+		name      string
+		alice     [2]string
+		bob       [2]string
+		wantCount int
 	}{
-		{name: "nobody answered", minDuration: 0, wantCount: 0},
-		{name: "the overlap is below the minimum", minDuration: 12, wantCount: 0},
+		{name: "they overlap for the full minimum", alice: [2]string{"10:00", "15:00"}, bob: [2]string{"13:00", "18:00"}, wantCount: 2},
+		{name: "they overlap, but only briefly", alice: [2]string{"10:00", "13:30"}, bob: [2]string{"13:00", "18:00"}, wantCount: 1},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			fixture := newSummaryFixture(t, func(c *repository.Calendar) {
-				c.MinDurationHours = tt.minDuration
-			})
-			if tt.minDuration > 0 {
-				fixture.availRepo.occurrences = []models.Occurrence{
-					available(fixture.alice, mustDate(t, "2026-03-05"), ptr("09:00"), ptr("10:00")),
-				}
+			fixture := newSummaryFixture(t, func(c *repository.Calendar) { c.MinDurationHours = 2 })
+			fixture.availRepo.occurrences = []models.Occurrence{
+				available(fixture.alice, date, ptr(tt.alice[0]), ptr(tt.alice[1])),
+				available(fixture.bob, date, ptr(tt.bob[0]), ptr(tt.bob[1])),
 			}
 
 			got, err := fixture.service.GetDateSummary(context.Background(), "token", "2026-03-05", "")
 			if err != nil {
 				t.Fatalf("GetDateSummary: %v", err)
 			}
-
 			if got.TotalCount != tt.wantCount {
 				t.Errorf("TotalCount = %d, want %d", got.TotalCount, tt.wantCount)
 			}
-
-			encoded, err := json.Marshal(got)
-			if err != nil {
-				t.Fatalf("marshal response: %v", err)
-			}
-			if !strings.Contains(string(encoded), `"participants":[]`) {
-				t.Errorf("participants = %s, want an empty array rather than null", encoded)
+			if len(got.Participants) != 2 {
+				t.Errorf("listed %d participants, want 2", len(got.Participants))
 			}
 		})
 	}

--- a/internal/availability/service/range_summary_test.go
+++ b/internal/availability/service/range_summary_test.go
@@ -329,6 +329,10 @@ func TestGetRangeSummaryGroupsOccurrencesByDate(t *testing.T) {
 
 // TestGetRangeSummaryMinDuration covers the filter that hides dates too short to be
 // worth meeting on. It runs on the *overlap*, not on any one participant's span.
+// TestGetRangeSummaryMinDuration covers what the minimum now decides: how many people
+// count as able to meet, not whether the date appears at all. A date used to be dropped
+// from the range entirely when the overlap fell short, so the grid showed nothing for a
+// day several people had answered for.
 func TestGetRangeSummaryMinDuration(t *testing.T) {
 	tests := []struct {
 		name        string
@@ -337,31 +341,40 @@ func TestGetRangeSummaryMinDuration(t *testing.T) {
 		aliceEnd    string
 		bobStart    string
 		bobEnd      string
-		wantKept    bool
+		wantCount   int
 	}{
 		{
 			name: "the overlap clears the minimum", minDuration: 2,
 			aliceStart: "09:00", aliceEnd: "17:00",
 			bobStart: "10:00", bobEnd: "14:00",
-			wantKept: true,
+			wantCount: 2,
 		},
 		{
+			// Alice is free for eight hours, so she can hold the event alone; Bob's two
+			// hours with her are not enough for the pair.
 			name: "the overlap is too short", minDuration: 4,
 			aliceStart: "09:00", aliceEnd: "17:00",
 			bobStart: "10:00", bobEnd: "12:00",
-			wantKept: false,
+			wantCount: 1,
 		},
 		{
-			name: "no minimum keeps everything", minDuration: 0,
+			name: "no minimum counts any overlap", minDuration: 0,
 			aliceStart: "09:00", aliceEnd: "17:00",
 			bobStart: "10:00", bobEnd: "10:30",
-			wantKept: true,
+			wantCount: 2,
 		},
 		{
-			name: "an exact match is kept", minDuration: 2,
+			name: "an exact match counts", minDuration: 2,
 			aliceStart: "09:00", aliceEnd: "17:00",
 			bobStart: "10:00", bobEnd: "12:00",
-			wantKept: true,
+			wantCount: 2,
+		},
+		{
+			// The reported defect, at the range grain.
+			name: "nobody overlaps at all", minDuration: 2,
+			aliceStart: "10:00", aliceEnd: "13:00",
+			bobStart: "14:00", bobEnd: "18:00",
+			wantCount: 1,
 		},
 	}
 
@@ -383,39 +396,17 @@ func TestGetRangeSummaryMinDuration(t *testing.T) {
 				t.Fatalf("GetRangeSummary: %v", err)
 			}
 
-			_, kept := byDate(got)["2026-03-05"]
-			if kept != tt.wantKept {
-				t.Errorf("date kept = %v, want %v", kept, tt.wantKept)
+			// The date is always described, whatever the count comes to.
+			if len(got) != 1 {
+				t.Fatalf("got %d dates, want 1: the date is dropped from the grid", len(got))
+			}
+			if got[0].TotalCount != tt.wantCount {
+				t.Errorf("TotalCount = %d, want %d", got[0].TotalCount, tt.wantCount)
+			}
+			if len(got[0].Participants) != 2 {
+				t.Errorf("listed %d participants, want 2", len(got[0].Participants))
 			}
 		})
-	}
-}
-
-// TestGetRangeSummaryCountsSimultaneous guards the difference between "how many people
-// answered" and "how many can actually meet", which is what the threshold gauge shows.
-func TestGetRangeSummaryCountsSimultaneous(t *testing.T) {
-	fixture := newSummaryFixture(t, nil)
-
-	// Two people on the same date who never overlap: two answers, but never two at
-	// once, so the count must be one.
-	fixture.availRepo.occurrences = []models.Occurrence{
-		available(fixture.alice, mustDate(t, "2026-03-05"), ptr("09:00"), ptr("10:00")),
-		available(fixture.bob, mustDate(t, "2026-03-05"), ptr("14:00"), ptr("16:00")),
-	}
-
-	got, err := fixture.service.GetRangeSummary(
-		context.Background(), "token", "2026-03-05", "2026-03-05", "",
-	)
-	if err != nil {
-		t.Fatalf("GetRangeSummary: %v", err)
-	}
-
-	summary := byDate(got)["2026-03-05"]
-	if len(summary.Participants) != 2 {
-		t.Errorf("got %d participants, want 2", len(summary.Participants))
-	}
-	if summary.TotalCount != 1 {
-		t.Errorf("TotalCount = %d, want 1: they never overlap", summary.TotalCount)
 	}
 }
 

--- a/internal/availability/service/time_rules_test.go
+++ b/internal/availability/service/time_rules_test.go
@@ -696,69 +696,6 @@ func TestCreateAvailabilityMapsTheRepositorySentinel(t *testing.T) {
 	}
 }
 
-func TestCalculateDurationForDate(t *testing.T) {
-	tests := []struct {
-		name         string
-		participants []models.ParticipantAvailabilitySummary
-		want         float64
-	}{
-		// No participants means no times, which the "all day" branch reads as a
-		// 24-hour event. Pinned as documentation: GetDateSummary only reaches this
-		// with a non-empty list, so the value is never observed, but a future caller
-		// that does pass an empty list would get 24 rather than 0.
-		{name: "nobody at all is reported as a full day", participants: nil, want: 24},
-		{
-			name: "everyone is available all day",
-			participants: []models.ParticipantAvailabilitySummary{
-				{ParticipantID: uuid.New()},
-				{ParticipantID: uuid.New()},
-			},
-			want: 24,
-		},
-		{
-			// One untimed participant is enough to leave the window undetermined
-			// on that side, which also collapses to a full day.
-			name: "a mix of timed and untimed",
-			participants: []models.ParticipantAvailabilitySummary{
-				{ParticipantID: uuid.New(), StartTime: ptr("09:00")},
-				{ParticipantID: uuid.New()},
-			},
-			want: 24,
-		},
-		{
-			name: "a single timed availability",
-			participants: []models.ParticipantAvailabilitySummary{
-				{ParticipantID: uuid.New(), StartTime: ptr("09:00"), EndTime: ptr("17:00")},
-			},
-			want: 8,
-		},
-		{
-			name: "two participants overlapping for two hours",
-			participants: []models.ParticipantAvailabilitySummary{
-				{ParticipantID: uuid.New(), StartTime: ptr("09:00"), EndTime: ptr("12:00")},
-				{ParticipantID: uuid.New(), StartTime: ptr("10:00"), EndTime: ptr("14:00")},
-			},
-			want: 2,
-		},
-		{
-			name: "two participants who never overlap",
-			participants: []models.ParticipantAvailabilitySummary{
-				{ParticipantID: uuid.New(), StartTime: ptr("09:00"), EndTime: ptr("10:00")},
-				{ParticipantID: uuid.New(), StartTime: ptr("14:00"), EndTime: ptr("16:00")},
-			},
-			want: 0,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if got := calculateDurationForDate(tt.participants); got != tt.want {
-				t.Errorf("calculateDurationForDate = %v, want %v", got, tt.want)
-			}
-		})
-	}
-}
-
 func ptr(s string) *string { return &s }
 
 // TestWeekdayAndDatedWindowsAgree covers a divergence that used to exist.


### PR DESCRIPTION
Reported from production: a date several people had answered for showed **"0 participant(s)"** and a `0/3` badge.

## Not the overlap count from #112

First thing I checked, since #112 changed how counting works. It is not that: the same inputs give the same answer on `ccc9139`, the commit before it.

| `min_duration_hours` | before #112 | after #112 |
|---|---|---|
| 0 | count 1, 2 listed | count 1, 2 listed |
| 2 | **count 0, 0 listed** | **count 0, 0 listed** |

The cause is older and sits one step later in the same function.

## What was happening

`calculateDurationForDate` measured the window shared by **everyone** — `MAX(start)` to `MIN(end)` — which is zero the moment two answers do not overlap. Whenever that fell below `min_duration_hours`:

- the day view returned an empty summary — count **and** participants;
- the range view dropped the date from the grid entirely.

So a day two people had answered for at different hours reported nobody available, with nothing on screen to say why. It also meant that if 3 of 5 people overlapped for hours, the intersection across all 5 was still zero and the date was blanked.

**The feed never worked that way.** `ics_service.go:187` computes slots, drops the ones too short to hold the event, and keeps the rest. That is the right shape — and the third time in this refactor that one concept had two implementations.

## The rule now

The minimum bounds **which overlaps count**, not whether the day is worth describing.

`MaxSimultaneousFor` takes the largest group free together for at least that long. It considers every window between two boundaries rather than only the elementary segments between consecutive ones: a group has to cover a whole window, and that window usually spans several segments. With no minimum the longer candidates can only ever have fewer coverers than the segments they contain, so **calendars without a minimum are unaffected** — same answer as before, by construction.

| Case, minimum 2h | Count | Listed |
|---|---|---|
| 10:00–13:00 and 14:00–18:00 | **1** — neither can meet the other, each is free long enough alone | both, with hours |
| 10:00–15:00 and 13:00–18:00 | 2 | both |
| 10:00–13:30 and 13:00–18:00 (30 min together) | **1** | both |

Listing everyone is what makes the number legible: you see the count *and* why. The alternative — showing only the winning group — turned out to be ambiguous exactly where it matters, since two disjoint people each holding the minimum alone are tied and the code would have to pick one arbitrarily.

## Dead code

`calculateDurationForDate` goes with the question it answered — nothing asks for the window shared by everyone any more — and `calculateMaxSimultaneousParticipants` with it, since `countThatCanMeet` is what both endpoints call. The overlap test moved onto it. `TestCalculateDurationForDate` went with its function.

Two tests that pinned the old behaviour are recentred on the new one and named for what they now prove, plus `TestGetDateSummaryKeepsParticipantsBelowTheMinimum`, which is the reported case.

`make test`, `golangci-lint` (0 issues), both build variants, format-check.