### PR TITLE
fix(notify): say when a notification is suppressed rather than sent

### DIFF
--- a/internal/notify/service/notify_service.go
+++ b/internal/notify/service/notify_service.go
@@ -283,7 +283,9 @@ func (s *NotifyService) notifyOwnerExternalChannels(
 				)
 			}
 		} else {
-			s.logger.Debug("Discord notification already sent recently")
+			// Info, not Debug: this is the whole outcome for the channel, and at Debug
+			// a suppressed notice was indistinguishable from one that never ran.
+			s.logger.Info("Discord notification suppressed: already sent for this transition within the hour")
 		}
 	} else {
 		s.logger.Debug("Discord channel disabled or webhook not configured")
@@ -308,7 +310,9 @@ func (s *NotifyService) notifyOwnerExternalChannels(
 				)
 			}
 		} else {
-			s.logger.Debug("Slack notification already sent recently")
+			// Info, not Debug: this is the whole outcome for the channel, and at Debug
+			// a suppressed notice was indistinguishable from one that never ran.
+			s.logger.Info("Slack notification suppressed: already sent for this transition within the hour")
 		}
 	} else {
 		s.logger.Debug("Slack channel disabled or webhook not configured")
@@ -340,7 +344,9 @@ func (s *NotifyService) notifyOwnerExternalChannels(
 				)
 			}
 		} else {
-			s.logger.Debug("Telegram notification already sent recently")
+			// Info, not Debug: this is the whole outcome for the channel, and at Debug
+			// a suppressed notice was indistinguishable from one that never ran.
+			s.logger.Info("Telegram notification suppressed: already sent for this transition within the hour")
 		}
 	} else {
 		s.logger.Debug("Telegram channel disabled or credentials not configured")
@@ -490,6 +496,8 @@ func (s *NotifyService) sendDeduplicatedEmailNotifications(
 		"calendar_id", calendar.ID)
 
 	// 3. Send one email per unique recipient
+	var sentCount, suppressed, failed int
+
 	for email, recipient := range recipients {
 		// One tag per recipient, reused by every line in this iteration, so an
 		// operator can follow a single send through the loop without the address
@@ -508,9 +516,12 @@ func (s *NotifyService) sendDeduplicatedEmailNotifications(
 		}
 
 		if sent {
+			suppressed++
+
 			s.logger.Debug("Email notification already sent recently, skipping",
 				"recipient_ref", recipientRef,
 				"recipient_id_ref", recipientIDRef)
+
 			continue
 		}
 
@@ -535,11 +546,15 @@ func (s *NotifyService) sendDeduplicatedEmailNotifications(
 			"personalised_link", recipient.ParticipantID != nil)
 
 		if err := s.sendEmailNotification(recipient.Email, htmlMessage, recipient.Locale, true); err != nil {
+			failed++
+
 			s.logger.Error("Failed to send email",
 				"recipient_ref", recipientRef,
 				"recipient_id_ref", recipientIDRef,
 				"error", err)
 		} else {
+			sentCount++
+
 			s.logger.Info("Email notification sent successfully",
 				"recipient_ref", recipientRef,
 				"recipient_id_ref", recipientIDRef)
@@ -555,7 +570,18 @@ func (s *NotifyService) sendDeduplicatedEmailNotifications(
 		}
 	}
 
-	s.logger.Debug("sendDeduplicatedEmailNotifications completed")
+	// One line saying what became of the whole batch, at the level an operator watches.
+	//
+	// The two lines above this loop announce a transition and a recipient count, and
+	// every outcome after them used to be Debug — so a batch entirely suppressed by the
+	// anti-spam ledger looked identical to a batch that crashed: the log said
+	// "SENDING NOTIFICATIONS", then nothing at all. Suppression is the expected
+	// behaviour on a second crossing within the hour, and it has to say so.
+	s.logger.Info("Threshold email notifications complete",
+		"calendar_id", calendar.ID,
+		"sent", sentCount,
+		"suppressed_as_already_sent", suppressed,
+		"failed", failed)
 	return nil
 }
 

--- a/internal/notify/service/notify_service_send_test.go
+++ b/internal/notify/service/notify_service_send_test.go
@@ -5,9 +5,11 @@
 package service
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
+	"log/slog"
 	"strings"
 	"sync"
 	"testing"
@@ -869,5 +871,47 @@ func TestSendEmailNotificationPropagatesFailure(t *testing.T) {
 	err := service.sendEmailNotification("a@example.test", "body", "en", false)
 	if err == nil {
 		t.Fatal("expected the SMTP failure to propagate")
+	}
+}
+
+// TestASuppressedBatchSaysSo is about what an operator can see, which is the difference
+// between a working system and one that looks broken.
+//
+// The anti-spam ledger holds a notice for an hour, so a second crossing within it is
+// suppressed by design. Every outcome after the "SENDING NOTIFICATIONS" line was logged
+// at Debug, so at Info the log announced a transition, announced three recipients, and
+// then said nothing at all — indistinguishable from a crash. That cost a real evening of
+// hunting a bug that was not there.
+func TestASuppressedBatchSaysSo(t *testing.T) {
+	var buf bytes.Buffer
+	f := newNotifyFixture(t, emailConfig())
+	f.log.sentRecently = map[string]bool{
+		f.owner.ID.String() + "/email":       true,
+		f.participant.ID.String() + "/email": true,
+	}
+
+	service := NewNotifyService(
+		f.calendars, f.people, f.slots, f.users, f.log,
+		f.mailer, f.external, f.detector,
+		"https://whento.test",
+		slog.New(slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelInfo})),
+	)
+
+	if err := service.CheckThresholdAndNotify(context.Background(), f.calendar.ID, f.date, 1); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(f.mailer.messages()) != 0 {
+		t.Fatalf("sent %d mails despite the ledger", len(f.mailer.messages()))
+	}
+
+	logged := buf.String()
+	if !strings.Contains(logged, "suppressed_as_already_sent") {
+		t.Errorf("nothing at Info says the batch was suppressed:\n%s", logged)
+	}
+	// And it has to say the send count too, or "suppressed" alone reads as a partial
+	// failure rather than the whole story.
+	if !strings.Contains(logged, `"sent":0`) {
+		t.Errorf("the summary does not report how many were sent:\n%s", logged)
 	}
 }


### PR DESCRIPTION
Reported as "the notification was not sent". It was not — and the system was right. What was wrong is that nothing said so.

## What actually happened

The anti-spam ledger holds a notice for **one hour** per `(calendar, date, transition, recipient, channel)`. A second crossing inside that window is suppressed by design, which is what a calendar flickering over its threshold needs.

The reported log reads:

```
THRESHOLD REACHED TRANSITION DETECTED  previous=2 new=3 threshold=3
Threshold transition detected - SENDING NOTIFICATIONS
Email recipients collected (deduplicated)  total_unique_recipients=3
                    ← nothing
```

Every outcome after that point was `Debug`. At `Info` — the level an operator watches — a batch entirely suppressed by the ledger was **indistinguishable from one that crashed on the way out**.

Working out which it was meant reading the source and eliminating a panic by noting that the goroutine's `recover` would have logged one. That is too much work for a question the log should answer, and it cost a real evening of hunting a bug that was not there.

## The change

The email path closes with **one line** carrying what became of the batch:

```
Threshold email notifications complete  sent=0 suppressed_as_already_sent=3 failed=0
```

One line rather than one per recipient, so it does not grow with the recipient list — the per-recipient detail stays at Debug where it belongs. The three owner channels each send at most one notice, so their suppression is simply raised to `Info`, where it already sat alone.

## What does not change

**When to suppress.** An hour is a reasonable guard, and the fix for a notification you want again sooner is to say so, not to send it twice. Both the window and the ledger are untouched.

## Test

`TestASuppressedBatchSaysSo` seeds a ledger that suppresses everyone, captures the logger at `Info`, and asserts the summary reports both the suppression and `"sent":0` — suppression alone would read as a partial failure rather than the whole story. Verified to fail with the summary line dropped back to `Debug`.

`make test`, `golangci-lint` (0 issues), both build variants, format-check.