### PR TITLE
fix(ci): bump golang across the three Dockerfiles and group docker updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -96,6 +96,13 @@ updates:
     commit-message:
       prefix: 'chore(deps)'
     labels: ['dependencies', 'docker']
+    # One pull request across all four directories, not one per directory. The
+    # three Dockerfiles pin the same images and cmd/dockerfiles_test.go fails
+    # when they disagree, so an ungrouped bump lands in one file and reds the
+    # build until the other two are updated by hand.
+    groups:
+      docker:
+        patterns: ['*']
     ignore:
       # Node 26 is Current, not LTS. Stay on 24.
       - dependency-name: node

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@
 # re-published upstream and silently change the runtime, which makes a build
 # non-reproducible. The tag stays in front of the digest so the version is still
 # readable, and Dependabot (package-ecosystem: docker) keeps both in step.
-# Digests resolved 2026-08-12 from registry-1.docker.io; they are the multi-arch
+# Digests resolved 2026-08-18 from registry-1.docker.io; they are the multi-arch
 # index digests, so multi-platform builds keep working.
 
 # Frontend build stage
@@ -39,7 +39,7 @@ COPY frontend/ ./
 RUN npm run build
 
 # Go build stage
-FROM golang:1.26-alpine3.24@sha256:70b46548e42db77e0966aaf3619fd068734dc6c77584d526b91126504fd95816 AS builder
+FROM golang:1.26-alpine3.24@sha256:3889b425f035be855a72fb4755265311293b6d414521f0a519d819df32222d83 AS builder
 
 WORKDIR /build
 

--- a/build/cloud/Dockerfile
+++ b/build/cloud/Dockerfile
@@ -16,11 +16,11 @@
 # re-published upstream and silently change the runtime, which makes a build
 # non-reproducible. The tag stays in front of the digest so the version is still
 # readable, and Dependabot (package-ecosystem: docker) keeps both in step.
-# Digests resolved 2026-08-12 from registry-1.docker.io; they are the multi-arch
+# Digests resolved 2026-08-18 from registry-1.docker.io; they are the multi-arch
 # index digests, so multi-platform builds keep working.
 
 # Build stage
-FROM golang:1.26-alpine3.24@sha256:70b46548e42db77e0966aaf3619fd068734dc6c77584d526b91126504fd95816 AS builder
+FROM golang:1.26-alpine3.24@sha256:3889b425f035be855a72fb4755265311293b6d414521f0a519d819df32222d83 AS builder
 
 WORKDIR /build
 

--- a/build/selfhosted/Dockerfile
+++ b/build/selfhosted/Dockerfile
@@ -16,11 +16,11 @@
 # re-published upstream and silently change the runtime, which makes a build
 # non-reproducible. The tag stays in front of the digest so the version is still
 # readable, and Dependabot (package-ecosystem: docker) keeps both in step.
-# Digests resolved 2026-08-12 from registry-1.docker.io; they are the multi-arch
+# Digests resolved 2026-08-18 from registry-1.docker.io; they are the multi-arch
 # index digests, so multi-platform builds keep working.
 
 # Build stage
-FROM golang:1.26-alpine3.24@sha256:70b46548e42db77e0966aaf3619fd068734dc6c77584d526b91126504fd95816 AS builder
+FROM golang:1.26-alpine3.24@sha256:3889b425f035be855a72fb4755265311293b6d414521f0a519d819df32222d83 AS builder
 
 WORKDIR /build
 


### PR DESCRIPTION
Replaces #115, #116 and #117.

## Why

Dependabot's `docker` entry lists four directories but declared no group, so it treated each as an independent manifest and opened one pull request per directory for the same `golang:1.26-alpine3.24` digest bump.

The three Dockerfiles pin the same images on purpose — Docker has no include mechanism, and `cmd/dockerfiles_test.go` fails the build when the copies drift apart. A bump that reaches only one of them therefore reds `Test Backend`, which is why all three pull requests failed the same check and why none of them could ever go green on its own:

```
--- FAIL: TestDockerfilesAgreeOnTheirPins/the_same_image_tag_resolves_to_the_same_digest_everywhere
    build/selfhosted/Dockerfile pins golang:1.26-alpine3.24 to sha256:70b4654…, but Dockerfile pins it to sha256:3889b42…
    build/cloud/Dockerfile      pins golang:1.26-alpine3.24 to sha256:70b4654…, but Dockerfile pins it to sha256:3889b42…
```

## What

- `chore(deps)` — carry `golang` to `3889b42` in all three Dockerfiles at once, and restamp the `Digests resolved` date the three copies share.
- `fix(ci)` — add a `groups:` block to the `docker` ecosystem so future image bumps arrive as a single pull request spanning every directory, instead of one per file.

`/.devcontainer` joins the same group. Its base image (`mcr.microsoft.com/devcontainers/go`) is a different one and is not covered by the test, so it simply travels in the same pull request.

## Verification

Run locally on this branch:

- `TestDockerfilesAgreeOnTheirPins` — all six sub-tests pass
- `go build` for both `selfhosted` and `cloud` — OK
- `make test` — no failures
- `make format-check`, frontend type-check, lint and the 694 Vitest tests — OK