### PR TITLE
docs(release): prepare v2.0.0 and record ADR 0006's first trigger

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,9 +40,27 @@ line per release rather than listed individually.
 
 ## [Unreleased]
 
+Nothing yet.
+
+---
+
+## [v2.0.0] — 2026-08-18
+
+_Range: `v1.6.3..v2.0.0`._
+
 The work since `v1.6.3` is largely a technical audit and its remediation: coverage
 went from 29% to a CI-enforced floor, the workflows were hardened and pinned, and
 several defects the new tests surfaced were fixed.
+
+It is a major version for one reason: self-hosting no longer caps calendars, so the
+whole licensing apparatus is gone — `LICENSE_KEY` with it. **Read `### Removed` and
+the upgrade notes in the release body before upgrading**; there is one destructive
+migration and one change that signs every user out once.
+
+A caveat this file exists to record: the licensing removal shipped inside the squash
+commit titled `refactor(frontend): rebuild the calendar views on one shared, tested
+model (#58)`, so `git log v1.6.3..HEAD` does not show it. It is written out below
+because the history cannot be read for it.
 
 ### Added
 
@@ -51,6 +69,16 @@ several defects the new tests surfaced were fixed.
 - Prometheus metrics on a listener of their own, off unless `METRICS_ENABLED` says
   otherwise, labelled by method, chi route pattern and status — never by path,
   token or identity.
+- Refresh token rotation keeps a 30-second grace window, so two tabs waking at once
+  no longer sign each other out; a token replayed after the window is treated as
+  theft — every session for that user is revoked and the event logged at Warn
+  (#105).
+- The client refreshes its access token a minute before expiry, and on
+  `visibilitychange` and `online`, instead of waiting for a 401 (#106).
+- Being signed out mid-session carries `?redirect=<where you were>`, so signing back
+  in returns to the page you lost (#106).
+- Configuration is validated at startup (`internal/config/validate.go`): an invalid
+  value stops the process instead of silently falling back to a default.
 - A database test harness (`internal/testutil/dbtest`) and browser tests that drive
   the write paths against a real backend (#65, #72).
 - Operator documentation under `docs/`: backup and restore, Postgres/Redis
@@ -59,9 +87,31 @@ several defects the new tests surfaced were fixed.
 
 ### Changed
 
+- `GET /api/ready` reports a `checks` object per dependency and answers 503 while
+  PostgreSQL is unreachable, instead of an unconditional 200.
 - The first day of the week is resolved from the calendar's timezone rather than
   from the viewer's locale (#77).
 - The calendar views were rebuilt on one shared, tested week model (#58).
+- `expires_in` is read from the JWT manager rather than the hardcoded 900, so an
+  instance that sets `JWT_ACCESS_EXPIRY` gets a number describing the token it was
+  issued (#106).
+- "Who is available on this date" is expanded once, in SQL, and every summary,
+  participant list and threshold count derives from that single result (#112).
+- The notification threshold measures overlapping availability, matching what the
+  interface and the ICS feed already meant; `min_duration_hours` bounds which
+  overlaps count rather than whether the day is described at all (#112, #113).
+- A notification batch closes with one log line saying what became of it — sent,
+  suppressed or failed — and per-channel suppression is logged at Info rather than
+  Debug (#114).
+- The participant-email rate limit goes from 5 to 10 requests per quarter hour, and
+  `/auth/refresh` from 5 to 30 per minute per IP (#95, #107).
+- `EmailVerificationHandler` folded into `AuthHandler`, so the binary no longer
+  carries two copies of the verification template and its locale file (#111).
+- A failed migration stops the container instead of starting the application on a
+  half-applied schema (`scripts/docker-entrypoint.sh`).
+- `docker-compose.yml`: a named `whento_keys` volume on `/app/keys`, Redis running
+  as `user: redis` with its password in a `0600` file, `no-new-privileges`,
+  `cap_drop: ALL`, `pids_limit`, and CPU/memory limits on all three services.
 - `cmd/` was split into `wire.go` (dependency injection), `router.go` and one
   `routes_<domain>.go` per business domain; `main.go` now holds only `main()`,
   `run()` and the Swagger annotations.
@@ -76,9 +126,52 @@ several defects the new tests surfaced were fixed.
   `concurrency` groups.
 - Toolchains aligned: Go 1.26 everywhere, Node 24, `goimports` v0.48.0,
   `golangci-lint` v2.12.2 (#51, #52).
+- `GO_VERSION` floats on `1.26` again with `check-latest` on all twelve `setup-go`
+  steps, so a patch release is picked up because it exists rather than because
+  somebody edited four files (#96, #109).
+- The licence and subscription tiers that no longer exist in the code were removed
+  from `LICENSE-COMMERCIAL`, the README and the published Swagger description
+  (#99, #100).
+- Dependency updates (#90–#93, #118–#121).
+
+### Removed
+
+- Self-hosted licensing, in full: the `LICENSE_KEY` variable, the
+  `GET`/`DELETE /api/v1/license`, `/api/v1/license/info`, `/activate` and `/reload`
+  endpoints, the `/admin/license` page, the `cmd/licensegen` generator, and the
+  `licenses` table (`migrations/selfhosted/013`). Self-hosting no longer caps
+  calendars, so there is nothing left to license. The down migration recreates the
+  table but not its contents.
+- The cloud `ecommerce`, `shop`, `subscription`, `vat` and `pricing` domains, the
+  `STRIPE_*` and `LICENSE_PRIVATE_KEY_BASE64` variables, and the frontend views that
+  went with them (`migrations/cloud/013`). No effect on a self-hosted instance.
+- `upgrade_url` from `GET /api/v1/quota/limits`, and `service` from
+  `GET /api/health`.
 
 ### Fixed
 
+- Every rate limit rule gets its own bucket. All eight IP-keyed routes counted into
+  one bucket per address, so opening a calendar page spent four of the five requests
+  a participant's email address was allowed, and the next attempt got an undeserved
+  429 (#107).
+- A participant available only through a recurrence was counted towards the
+  threshold but never notified, and was missing from the participant list in the
+  email; when everyone available was available that way, participant notifications
+  were skipped entirely (#108).
+- A date several people had answered for could report "0 participant(s)": the day's
+  duration was measured as the window shared by *everyone*, which is zero as soon as
+  two answers do not overlap (#113).
+- `/swagger` was a blank page in production — the upstream index builds the UI from
+  an inline script that `script-src 'self'` refuses (#110).
+- The ownership check on a refresh token ran after the delete, so a token belonging
+  to another user was destroyed on its way to being rejected (#105).
+- French subject lines went out as raw UTF-8 and rendered as mojibake in a fair
+  share of mail clients; headers are now RFC 2047 encoded (#98).
+- `Register` generated and stored a refresh token but never set the cookie, so a new
+  account had nothing to restore from (#95).
+- Inter is bundled via `@fontsource-variable/inter` instead of loaded from
+  `fonts.googleapis.com`, so first paint no longer depends on reaching an external
+  host — 18 seconds on a network that cannot (#94).
 - The access token is refreshed at most once at a time, instead of once per
   concurrent 401 (#73).
 - An unmatched `/api` path answers 404 JSON instead of serving the SPA with a
@@ -92,6 +185,22 @@ several defects the new tests surfaced were fixed.
 
 ### Security
 
+- Mail headers are assembled through `net/mail` with an explicit CRLF guard, closing
+  a critical CodeQL `go/email-injection` finding: a newline in a subject or recipient
+  would have ended the header block early and turned the rest into headers of its
+  own, a `Bcc` among them. Recipients must now be bare mailbox addresses
+  (#98, #104).
+- Mail bodies render through `html/template` rather than `text/template`, so
+  contextual escaping is enforced rather than held by convention (#98).
+- The access token is no longer written to localStorage (CodeQL
+  `js/clear-text-storage-of-sensitive-data`), and the `refresh_token` field is
+  dropped from the reset-password JSON response (#95).
+- Signing out broadcasts to the other tabs, which clear and navigate to `/login`;
+  previously only a failed refresh did, so a deliberate sign-out left up to fifteen
+  minutes of readable session in the tab next door (#102).
+- `fonts.googleapis.com` and `fonts.gstatic.com` removed from `style-src` and
+  `font-src`: the CSP now allows no external origin for code, styles or fonts, with
+  a test that fails on either host by name (#94, #103).
 - `govulncheck` (both build tags, both modules), CodeQL, `dependency-review` and
   Trivy image scanning before push; SBOM and signed build provenance on release
   artefacts.
@@ -417,7 +526,8 @@ community templates landed with it.
 
 _Note: this tag is not an ancestor of `main` — see the caveats at the top._
 
-[unreleased]: https://github.com/When-To/whento/compare/v1.6.3...HEAD
+[unreleased]: https://github.com/When-To/whento/compare/v2.0.0...HEAD
+[v2.0.0]: https://github.com/When-To/whento/releases/tag/v2.0.0
 [v1.6.3]: https://github.com/When-To/whento/releases/tag/v1.6.3
 [v1.6.2]: https://github.com/When-To/whento/releases/tag/v1.6.2
 [v1.6.1]: https://github.com/When-To/whento/releases/tag/v1.6.1

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: BSL-1.1
 
 //	@title						WhenTo API
-//	@version					1.6.3
+//	@version					2.0.0
 //	@description				WhenTo is a self-hosted web application for organizing events among friends through collaborative calendars.
 //	@description				Each calendar answers a simple question: **when can we meet?** Participants indicate their availability, and time slots reaching a defined threshold become events accessible via an **iCalendar subscription URL** — automatic synchronization in Google Calendar, Apple Calendar, Outlook, etc.
 //	@description

--- a/docs/adr/0006-manual-releases.md
+++ b/docs/adr/0006-manual-releases.md
@@ -188,3 +188,19 @@ The CI title check adopted here is the precondition for that migration, not an
 alternative to it: `release-please` is only as good as the commit subjects it
 parses. Adopting it later will be a small step *because* of this decision, not in
 spite of it.
+
+### Occurrences of the second trigger
+
+Recorded here so that "twice in a row" is countable rather than remembered. The
+"Bad" section above concedes that nothing enforces the changelog; a trigger nobody
+tallies is not a trigger.
+
+1. **v2.0.0 (2026-08-18).** `## [Unreleased]` had not been touched since the commit
+   that created this file, leaving it 29 commits behind at release time, and it was
+   missing a `### Removed` section entirely — including the removal of self-hosted
+   licensing, `LICENSE_KEY` and four endpoints. The aggravating factor is one this
+   record already names: that removal shipped inside a squash commit titled
+   `refactor(frontend): rebuild the calendar views on one shared, tested model
+   (#58)`, so the drafting command in CONTRIBUTING does not surface it. Enforcing
+   the commit convention was necessary but is not sufficient — a correct subject can
+   still describe only part of its own squash.


### PR DESCRIPTION
## Description

Prepares the release that follows `v1.6.3` — 62 commits, 481 files.

**`CHANGELOG.md`** — closes `## [Unreleased]` as `## [v2.0.0] — 2026-08-18` and brings it up to date. It had not been touched since the commit that created the file, leaving it 29 commits behind (#90 → #121) and missing a `### Removed` section entirely.

**Version: major, not minor.** Three of the four criteria in [CONTRIBUTING §1](.github/CONTRIBUTING.md#release-process) fire, each verified against the code:

| Criterion | Evidence |
| --- | --- |
| Environment variable removed | `LICENSE_KEY` was read at `internal/config/config.go:204` at v1.6.3 and consumed by `cmd/init_selfhosted.go` (selfhosted build). It exists nowhere on `main`. |
| API response changes shape | `GET /api/health` no longer returns `service`; `GET /api/ready` gained a `checks` object and answers **503** when PostgreSQL is unreachable; `GET /api/v1/quota/limits` lost `upgrade_url`. |
| Migration that cannot be rolled back | `migrations/selfhosted/013_drop_licensing.up.sql` runs `DROP TABLE IF EXISTS licenses`. The down migration recreates the schema verbatim but not the activation row. |

No dump-and-restore, though: `postgres:16-alpine` and `redis:7-alpine` are unchanged, so the base-image clause does not apply.

**`cmd/main.go`** — `@version` 1.6.3 → 2.0.0, the drift ADR 0006 predicted as a cost of its own decision.

**`docs/adr/0006-manual-releases.md`** — records the first occurrence of the second `release-please` trigger. The ADR adopts release-please when the changelog is stale at release time *twice in a row*, but nothing counted occurrences, and the record itself concedes nothing enforces the changelog. A trigger nobody tallies cannot fire.

Worth noting for the next release: the removal of self-hosted licensing — the single largest breaking change here — shipped inside the squash commit titled `refactor(frontend): rebuild the calendar views on one shared, tested model (#58)`. The drafting command CONTRIBUTING recommends (`git log --no-merges --format='- %s' v1.6.3..HEAD`) therefore does not surface it, which is why it is written out by hand. A correct Conventional Commit subject can still describe only part of its own squash — a gap the CI title check does not close.

## Type of Change

- [x] Documentation update

No code paths change. `cmd/main.go` is touched only in the Swagger annotation block, and `run()` overrides `SwaggerInfo.Version` from the linker at startup, so the annotation is cosmetic either way.

## Testing

- [x] Manual testing performed

- `make format-check` passes.
- `make swagger` regenerates cleanly and emits `"version": "2.0.0"` (`docs/swagger/` is gitignored, so no diff here).

## Checklist

- [x] My code follows the project's code style
- [x] I have performed a self-review
- [x] New and existing tests pass locally
- [x] I have updated documentation if needed

## After merge

The tag must be created on the **squash-merged commit on `main`**, not on this branch — `v1.6.2` was tagged on a branch that is not an ancestor of `main`, which is why `CHANGELOG.md` carries a caveat about it to this day.

```bash
git checkout main && git pull
git tag -a v2.0.0 -F <release-message.md>   # annotated, never lightweight
git push origin v2.0.0
```

The annotated tag message becomes the release body: `release-selfhosted.yml` reads it with `git cat-file -t` + `git for-each-ref`, prepends it to the installation instructions, and lets `generate_release_notes` append the PR list underneath. A lightweight tag falls back to generated notes with no human summary.