### PR TITLE
fix(build): restore the migrate-builder stage truncated in two Dockerfiles

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -111,7 +111,12 @@ ARG TARGETARCH
 ARG MIGRATE_VERSION=v4.19.1
 
 RUN go mod init migratebuild && \
-    go get "github.com/golang-migrate/migrate/v4/cmd/migrate
+    go get "github.com/golang-migrate/migrate/v4/cmd/migrate@${MIGRATE_VERSION}" && \
+    CGO_ENABLED=0 GOOS=linux GOARCH="${TARGETARCH}" go build \
+    -tags postgres \
+    -ldflags "-s -w -X main.Version=${MIGRATE_VERSION}" \
+    -o /usr/local/bin/migrate \
+    github.com/golang-migrate/migrate/v4/cmd/migrate
 
 # Runtime stage
 FROM alpine:3.24@sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198a6eec434943f8b

--- a/build/cloud/Dockerfile
+++ b/build/cloud/Dockerfile
@@ -84,7 +84,12 @@ ARG TARGETARCH
 ARG MIGRATE_VERSION=v4.19.1
 
 RUN go mod init migratebuild && \
-    go get "github.com/golang-migrate/migrate/v4/cmd/migrate
+    go get "github.com/golang-migrate/migrate/v4/cmd/migrate@${MIGRATE_VERSION}" && \
+    CGO_ENABLED=0 GOOS=linux GOARCH="${TARGETARCH}" go build \
+    -tags postgres \
+    -ldflags "-s -w -X main.Version=${MIGRATE_VERSION}" \
+    -o /usr/local/bin/migrate \
+    github.com/golang-migrate/migrate/v4/cmd/migrate
 
 # Runtime stage
 FROM alpine:3.24@sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198a6eec434943f8b

--- a/cmd/dockerfiles_test.go
+++ b/cmd/dockerfiles_test.go
@@ -123,6 +123,40 @@ func TestDockerfilesAgreeOnTheirPins(t *testing.T) {
 		}
 	})
 
+	// The pins above are values; this is the code that uses them. Comparing only
+	// the ARGs let a truncated `go get` line ship in two of the three files: the
+	// versions still agreed, so every check passed, and the release image failed
+	// to build with "unterminated quoted string". The stage is meant to be
+	// identical everywhere, so compare it as text.
+	//
+	// Scoped to the migrate-builder stage rather than everything below the build
+	// stage, because the runtime stages genuinely differ: each copies the
+	// migrations its own variant built.
+	t.Run("the migrate-builder stage is identical", func(t *testing.T) {
+		const (
+			start = "# Build the migrate CLI."
+			end   = "# Runtime stage"
+		)
+
+		var first, firstFile string
+		for _, name := range dockerfiles {
+			section, ok := sectionBetween(sources[name], start, end)
+			if !ok {
+				t.Errorf("%s: no migrate-builder stage between %q and %q", name, start, end)
+
+				continue
+			}
+			if firstFile == "" {
+				first, firstFile = section, name
+
+				continue
+			}
+			if section != first {
+				t.Errorf("%s and %s do not build the migrate CLI the same way", name, firstFile)
+			}
+		}
+	})
+
 	// The comment above those ARGs says to keep them in step with the CI
 	// workflow and the devcontainer, because the CLI that validates the
 	// migrations has to be the one that applies them. That is checkable.
@@ -178,6 +212,21 @@ func argValue(source, name string) (string, bool) {
 	}
 
 	return "", false
+}
+
+// sectionBetween returns the text from start up to end, excluding end. Both
+// markers must appear, and end must follow start.
+func sectionBetween(source, start, end string) (string, bool) {
+	from := strings.Index(source, start)
+	if from < 0 {
+		return "", false
+	}
+	to := strings.Index(source[from:], end)
+	if to < 0 {
+		return "", false
+	}
+
+	return source[from : from+to], true
 }
 
 // goInstallVersion returns the version a `go install module@version` line pins,


### PR DESCRIPTION
## Description

The cloud image failed to build for `v2.0.0` ([run 32291824821](https://github.com/When-To/whento/actions/runs/32291824821)):

```
/bin/sh: syntax error: unterminated quoted string
```

My mistake in #123, and worth stating precisely. The new `migrate-builder` stage was written once into `build/selfhosted/Dockerfile` and copied into the other two by a script whose end marker matched the **first** occurrence of `github.com/golang-migrate/migrate/v4/cmd/migrate` — which is inside the `go get` line, not the `go build` line that closes the `RUN`. Both copies were cut mid-argument:

```dockerfile
RUN go mod init migratebuild && \
    go get "github.com/golang-migrate/migrate/v4/cmd/migrate     # ← everything after this was gone
```

`build/selfhosted/Dockerfile` was written by hand and is intact, which is why the self-hosted release built and only the cloud one broke.

## Why nothing caught it

`TestDockerfilesAgreeOnTheirPins` compares the `ARG` values and the base image digests. Those still agreed — the truncation removed only the version interpolation from a `RUN` body, which no check looked at. `go build` does not parse Dockerfiles, and CI's dev image job builds the root Dockerfile but did not run on that pull request.

So this adds the check that would have failed: the `migrate-builder` stage compared as text across the three files. Verified by reintroducing the exact truncation and watching it fail:

```
--- FAIL: TestDockerfilesAgreeOnTheirPins/the_migrate-builder_stage_is_identical
    build/cloud/Dockerfile and Dockerfile do not build the migrate CLI the same way
```

Scoped to that stage rather than to everything below the build stage, because the runtime stages differ on purpose: each copies the migrations its own variant built.

## Type of Change

- [x] Bug fix (non-breaking change fixing an issue)

## Testing

- [x] Manual testing performed
- [x] Tested with self-hosted build (`go build -tags selfhosted`)

- The three `migrate-builder` stages are now byte-identical (checked by hash, and by the new sub-test)
- `go test -tags selfhosted ./cmd/` passes; the new sub-test fails when the truncation is reintroduced and passes when it is not
- No unterminated quotes remain in any of the three files

Docker is unavailable in this environment, so the image build itself is left to CI.

## Checklist

- [x] My code follows the project's code style
- [x] I have performed a self-review
- [x] New and existing tests pass locally
- [x] I have updated documentation if needed