### PR TITLE
fix(frontend): point the footer's documentation and contributing links at real files

### DIFF
--- a/frontend/src/components/Footer.vue
+++ b/frontend/src/components/Footer.vue
@@ -41,7 +41,7 @@
             </li>
             <li>
               <a
-                href="https://github.com/When-To/whento/issues"
+                href="https://github.com/When-To/whento/tree/main/docs"
                 target="_blank"
                 rel="noopener noreferrer"
                 class="text-gray-600 hover:text-primary-600 dark:text-gray-400 dark:hover:text-primary-400"
@@ -90,7 +90,7 @@
             </li>
             <li>
               <a
-                href="https://github.com/When-To/whento/blob/main/CONTRIBUTING.md"
+                href="https://github.com/When-To/whento/blob/main/.github/CONTRIBUTING.md"
                 target="_blank"
                 rel="noopener noreferrer"
                 class="text-gray-600 hover:text-primary-600 dark:text-gray-400 dark:hover:text-primary-400"
@@ -139,10 +139,8 @@
 
 <script setup lang="ts">
 import { useI18n } from 'vue-i18n';
+import { useBuildType } from '@/composables/useBuildType';
 
 const { t } = useI18n();
-
-// Get build type from environment
-const buildType = import.meta.env.VITE_BUILD_TYPE || 'cloud';
-const isCloud = buildType === 'cloud';
+const { isCloud } = useBuildType();
 </script>


### PR DESCRIPTION
Two of the six links in the footer did not go where their label said.

- **Contributing** pointed at `blob/main/CONTRIBUTING.md`. There is no
  `CONTRIBUTING.md` at the root — the file is `.github/CONTRIBUTING.md`, so the
  link returned a 404. Every other reference in the repo (README, CHANGELOG,
  `docs/`, ADR 0006, `ISSUE_TEMPLATE/config.yml`) already used the `.github/`
  path; the footer was the last one left behind.
- **Documentation** pointed at `/issues` — byte for byte the same URL as
  "Report a bug" one list below it — rather than at `docs/`, where the
  documentation lives. It now points at `tree/main/docs`, so GitHub shows the
  file listing with `docs/README.md` rendered underneath.

Nothing in CI would have caught either one: there is no link checker in
`.github/workflows/`.

While in the file: `Footer.vue` was the last component reading
`import.meta.env.VITE_BUILD_TYPE` by hand instead of going through
`useBuildType()`, which `CLAUDE.md` asks for and which `App.vue` and `Home.vue`
already use. `isCloud` becomes a `ComputedRef`, auto-unwrapped in the template,
so neither usage site changes.

## Verification

`/check` — formatting, `vue-tsc`, eslint, Vitest (694 tests), both build
variants compiling, and the Go suite — all pass. The six link targets were
checked against the working tree.